### PR TITLE
Add unit tests for monitors and window positioning

### DIFF
--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 

--- a/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorEnumerationTests
+{
+    [TestMethod]
+    public void GetMonitorsConnected_ReturnsAtLeastOne()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var monitors = new Monitors().GetMonitorsConnected();
+        Assert.IsNotNull(monitors);
+        Assert.IsTrue(monitors.Count > 0, "No monitors were returned");
+    }
+}

--- a/Sources/DesktopManager.Tests/UnitTest1.cs
+++ b/Sources/DesktopManager.Tests/UnitTest1.cs
@@ -1,9 +1,0 @@
-namespace DesktopManager.Tests;
-
-[TestClass]
-public class UnitTest1 {
-    [TestMethod]
-    public void TestMethod1() {
-
-    }
-}

--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowPositionTests
+{
+    [TestMethod]
+    public void GetAndSetWindowPosition_RoundTrips()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0)
+        {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var original = manager.GetWindowPosition(window);
+
+        manager.SetWindowPosition(window, original.Left, original.Top);
+        var updated = manager.GetWindowPosition(window);
+
+        Assert.AreEqual(original.Left, updated.Left);
+        Assert.AreEqual(original.Top, updated.Top);
+    }
+}


### PR DESCRIPTION
## Summary
- add MSTest unit tests for monitor enumeration
- test window positioning with round-trip check
- reference DesktopManager project from test project
- remove placeholder UnitTest1.cs

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_68517bd91738832e8ad666d1768a4f65