### PR TITLE
Fix EnumWindows lParam type

### DIFF
--- a/Sources/DesktopManager/MonitorNativeMethods.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.cs
@@ -68,9 +68,9 @@ public static class MonitorNativeMethods {
     /// <param name="lpEnumFunc">The callback function to invoke for each window.</param>
     /// <param name="lParam">Application-defined value to pass to the callback function.</param>
     /// <returns>True if the enumeration completes, false if it was cancelled.</returns>
-    public delegate bool EnumWindowsProc(IntPtr hWnd, int lParam);
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
     [DllImport("user32.dll")]
-    public static extern bool EnumWindows(EnumWindowsProc enumFunc, int lParam);
+    public static extern bool EnumWindows(EnumWindowsProc enumFunc, IntPtr lParam);
 
     /// <summary>
     /// Gets the window text length.

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -32,7 +32,7 @@ namespace DesktopManager {
                         handles.Add(handle);
                     }
                     return true;
-                }, 0);
+                }, IntPtr.Zero);
 
             var windows = new List<WindowInfo>();
             foreach (var handle in handles) {


### PR DESCRIPTION
## Summary
- use `IntPtr` for `EnumWindowsProc` lParam parameter
- use `IntPtr` for `EnumWindows` P/Invoke signature
- pass `IntPtr.Zero` when enumerating windows

## Testing
- `dotnet test Sources/DesktopManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68519029bb90832e8d70373f50f7d8e4