### PR TITLE
Fix SetWindowPos flags

### DIFF
--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -4,20 +4,16 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
-public class WindowPositionTests
-{
+public class WindowPositionTests {
     [TestMethod]
-    public void GetAndSetWindowPosition_RoundTrips()
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
+    public void GetAndSetWindowPosition_RoundTrips() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         var manager = new WindowManager();
         var windows = manager.GetWindows();
-        if (windows.Count == 0)
-        {
+        if (windows.Count == 0) {
             Assert.Inconclusive("No windows found to test");
         }
 
@@ -29,5 +25,31 @@ public class WindowPositionTests
 
         Assert.AreEqual(original.Left, updated.Left);
         Assert.AreEqual(original.Top, updated.Top);
+    }
+
+    [TestMethod]
+    public void MoveWindow_DoesNotChangeZOrder() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windowsBefore = manager.GetWindows();
+        if (windowsBefore.Count < 1) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windowsBefore.First();
+        int indexBefore = windowsBefore.FindIndex(w => w.Handle == window.Handle);
+
+        var original = manager.GetWindowPosition(window);
+        manager.SetWindowPosition(window, original.Left + 1, original.Top + 1);
+
+        var windowsAfterMove = manager.GetWindows();
+        int indexAfterMove = windowsAfterMove.FindIndex(w => w.Handle == window.Handle);
+
+        manager.SetWindowPosition(window, original.Left, original.Top);
+
+        Assert.AreEqual(indexBefore, indexAfterMove);
     }
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -125,16 +125,7 @@ namespace DesktopManager {
         /// <param name="left">The left position.</param>
         /// <param name="top">The top position.</param>
         public void SetWindowPosition(WindowInfo windowInfo, int left, int top) {
-            if (!MonitorNativeMethods.SetWindowPos(
-                windowInfo.Handle,
-                IntPtr.Zero,
-                left,
-                top,
-                -1,
-                -1,
-                1)) {
-                throw new InvalidOperationException("Failed to set window position");
-            }
+            SetWindowPosition(windowInfo, left, top, -1, -1);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure SetWindowPosition uses SWP_NOZORDER and SWP_NOSIZE
- add regression test verifying window z-order

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Debug -f net8.0 --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851901aa038832ebaa851c89909ff2c