### PR TITLE
Fix COM wallpaper error after RDP

### DIFF
--- a/Sources/DesktopManager/MonitorService.cs
+++ b/Sources/DesktopManager/MonitorService.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace DesktopManager;
 
 /// <summary>
@@ -13,6 +15,12 @@ public class MonitorService {
     /// <param name="desktopManager">The desktop manager interface.</param>
     public MonitorService(IDesktopManager desktopManager) {
         _desktopManager = desktopManager;
+
+        try {
+            _desktopManager.Enable();
+        } catch (COMException) {
+            // Ignored - COM may fail in unsupported scenarios
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- call `IDesktopManager.Enable()` when constructing `MonitorService`

## Testing
- `dotnet test Sources/DesktopManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6851936fc128832eae22fc373107a2ef