### PR TITLE
Fix case-insensitive matching for windows

### DIFF
--- a/Sources/DesktopManager.Tests/WindowTitleMatchingTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTitleMatchingTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowTitleMatchingTests
+{
+    [TestMethod]
+    public void GetWindows_TitleMatchingIsCaseInsensitive()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0)
+        {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        string titleUpper = window.Title.ToUpperInvariant();
+        string titleLower = window.Title.ToLowerInvariant();
+
+        Assert.IsTrue(manager.GetWindows(titleUpper).Any(w => w.Handle == window.Handle));
+        Assert.IsTrue(manager.GetWindows(titleLower).Any(w => w.Handle == window.Handle));
+    }
+}

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -233,7 +233,7 @@ namespace DesktopManager {
                 }
             }
 
-            return text.Contains(pattern);
+            return text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- compare titles ignoring case in `MatchesWildcard`
- add tests for case-insensitive window title matching

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685199693f9c832e97e584d74a504c43