### PR TITLE
Fix GetWindowLongPtr compatibility

### DIFF
--- a/Sources/DesktopManager/MonitorNativeMethods.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.cs
@@ -147,8 +147,23 @@ public static class MonitorNativeMethods {
     /// <param name="hWnd">A handle to the window.</param>
     /// <param name="nIndex">The zero-based offset to the value to be retrieved.</param>
     /// <returns>The requested value.</returns>
-    [DllImport("user32.dll")]
-    public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLong", SetLastError = true)]
+    private static extern IntPtr GetWindowLong32(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr", SetLastError = true)]
+    private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+    /// <summary>
+    /// Retrieves information about the specified window. Handles both x86 and x64 processes.
+    /// </summary>
+    /// <param name="hWnd">A handle to the window.</param>
+    /// <param name="nIndex">The zero-based offset to the value to be retrieved.</param>
+    /// <returns>The requested value as a pointer.</returns>
+    public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex) {
+        return IntPtr.Size == 8
+            ? GetWindowLongPtr64(hWnd, nIndex)
+            : GetWindowLong32(hWnd, nIndex);
+    }
 
     /// <summary>
     /// Indexes for GetWindowLong

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -61,7 +61,8 @@ namespace DesktopManager {
                             windowInfo.Bottom = rect.Bottom;
 
                             // Get window state
-                            int style = MonitorNativeMethods.GetWindowLong(handle, MonitorNativeMethods.GWL_STYLE);
+                            IntPtr stylePtr = MonitorNativeMethods.GetWindowLongPtr(handle, MonitorNativeMethods.GWL_STYLE);
+                            int style = stylePtr.ToInt32();
                             if ((style & MonitorNativeMethods.WS_MINIMIZE) != 0) {
                                 windowInfo.State = WindowState.Minimize;
                             } else if ((style & MonitorNativeMethods.WS_MAXIMIZE) != 0) {


### PR DESCRIPTION
## Summary
- use `GetWindowLongPtr` with platform wrapper
- update window state retrieval to handle `IntPtr`

## Testing
- `pwsh -NoLogo -NoProfile -Command './DesktopManager.Tests.ps1'` *(fails: Get-DesktopMonitor not found)*

------
https://chatgpt.com/codex/tasks/task_e_685199566af4832e85f1fef985113a98