### PR TITLE
Fix Set-DesktopWallpaper parameter sets

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
@@ -32,13 +32,13 @@ public sealed class CmdletSetDesktopWallpaper : PSCmdlet {
     /// <para type="description">The device ID of the monitor to set the wallpaper for.</para>
     /// </summary>
     [Alias("MonitorID")]
-    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Index")]
+    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "DeviceId")]
     public string DeviceId;
 
     /// <summary>
     /// <para type="description">The device name of the monitor to set the wallpaper for.</para>
     /// </summary>
-    [Parameter(Mandatory = false, Position = 2, ParameterSetName = "Index")]
+    [Parameter(Mandatory = false, Position = 2, ParameterSetName = "DeviceName")]
     public string DeviceName;
 
     /// <summary>
@@ -104,6 +104,11 @@ public sealed class CmdletSetDesktopWallpaper : PSCmdlet {
         int? index = MyInvocation.BoundParameters.ContainsKey(nameof(Index)) ? (int?)Index : null;
         string deviceId = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceId)) ? DeviceId : null;
         string deviceName = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceName)) ? DeviceName : null;
+
+        if (index != null && (deviceId != null || deviceName != null)) {
+            var ex = new ArgumentException("-Index cannot be combined with -DeviceId or -DeviceName.");
+            ThrowTerminatingError(new ErrorRecord(ex, "ParameterConflict", ErrorCategory.InvalidArgument, null));
+        }
 
         Monitors monitors = new Monitors();
         if (All) {

--- a/Tests/SetDesktopWallpaper.Tests.ps1
+++ b/Tests/SetDesktopWallpaper.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'Set-DesktopWallpaper parameter validation' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/..\DesktopManager.psd1" -Force
+    }
+
+    It 'Throws when using Index with DeviceId' {
+        { Set-DesktopWallpaper -Index 1 -DeviceId 'Dummy' -WallpaperPath '/' } |
+            Should -Throw -ErrorId 'AmbiguousParameterSet,DesktopManager.PowerShell.CmdletSetDesktopWallpaper'
+    }
+
+    It 'Throws when using Index with DeviceName' {
+        { Set-DesktopWallpaper -Index 1 -DeviceName 'Dummy' -WallpaperPath '/' } |
+            Should -Throw -ErrorId 'AmbiguousParameterSet,DesktopManager.PowerShell.CmdletSetDesktopWallpaper'
+    }
+}
+


### PR DESCRIPTION
## Summary
- split `DeviceId` and `DeviceName` into dedicated parameter sets
- forbid using `-Index` with either identifier
- add tests verifying the new parameter set enforcement

## Testing
- `dotnet build Sources/DesktopManager.sln -c Debug`
- `pwsh -NoLogo -NoProfile -File DesktopManager.Tests.ps1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685199733294832ead81ff0ff2ac4784