### PR TITLE
Add monitor-based window movement

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Management.Automation;
 
 namespace DesktopManager.PowerShell {
@@ -50,6 +51,12 @@ namespace DesktopManager.PowerShell {
         public int Height { get; set; } = -1;
 
         /// <summary>
+        /// <para type="description">Target monitor index to move the window to.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public int? MonitorIndex { get; set; }
+
+        /// <summary>
         /// <para type="description">The desired window state (Normal, Minimize, Maximize, or Close).</para>
         /// </summary>
         [Parameter(Mandatory = false)]
@@ -62,10 +69,24 @@ namespace DesktopManager.PowerShell {
             var manager = new WindowManager();
             var windows = manager.GetWindows(Name);
 
+            Monitor targetMonitor = null;
+            if (MonitorIndex.HasValue) {
+                targetMonitor = new Monitors().GetMonitors(index: MonitorIndex.Value).FirstOrDefault();
+                if (targetMonitor == null) {
+                    WriteWarning($"Monitor with index {MonitorIndex.Value} not found");
+                }
+            }
+
             foreach (var window in windows) {
                 var action = GetActionDescription();
+                if (MonitorIndex.HasValue) {
+                    action = $"Move to monitor {MonitorIndex.Value}" + (string.IsNullOrEmpty(action) ? string.Empty : $" and {action}");
+                }
                 if (ShouldProcess($"Window '{window.Title}'", action)) {
                     try {
+                        if (targetMonitor != null) {
+                            manager.MoveWindowToMonitor(window, targetMonitor);
+                        }
                         if (Left >= 0 || Top >= 0 || Width >= 0 || Height >= 0) {
                             manager.SetWindowPosition(window, Left, Top, Width, Height);
                         }
@@ -97,6 +118,9 @@ namespace DesktopManager.PowerShell {
 
             if (State.HasValue) {
                 parts.Add(State.Value.ToString());
+            }
+            if (MonitorIndex.HasValue) {
+                parts.Add($"Move to monitor {MonitorIndex.Value}");
             }
             if (Left >= 0 || Top >= 0) {
                 parts.Add($"Move to ({Left}, {Top})");

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -172,6 +173,40 @@ namespace DesktopManager {
                 flags)) {
                 throw new InvalidOperationException("Failed to set window position");
             }
+        }
+
+        /// <summary>
+        /// Moves the specified window to the target monitor while preserving its relative position.
+        /// </summary>
+        /// <param name="windowInfo">The window to move.</param>
+        /// <param name="targetMonitor">The monitor to move the window to.</param>
+        public void MoveWindowToMonitor(WindowInfo windowInfo, Monitor targetMonitor) {
+            if (targetMonitor == null) {
+                throw new ArgumentNullException(nameof(targetMonitor));
+            }
+
+            RECT windowRect = new RECT();
+            if (!MonitorNativeMethods.GetWindowRect(windowInfo.Handle, out windowRect)) {
+                throw new InvalidOperationException("Failed to get window position");
+            }
+
+            var targetBounds = targetMonitor.GetMonitorBounds();
+
+            var currentMonitor = _monitors.GetMonitors(index: windowInfo.MonitorIndex).FirstOrDefault();
+            RECT currentBounds;
+            if (currentMonitor != null) {
+                currentBounds = currentMonitor.GetMonitorBounds();
+            } else {
+                currentBounds = new RECT { Left = windowRect.Left, Top = windowRect.Top };
+            }
+
+            int offsetX = windowRect.Left - currentBounds.Left;
+            int offsetY = windowRect.Top - currentBounds.Top;
+
+            int newLeft = targetBounds.Left + offsetX;
+            int newTop = targetBounds.Top + offsetY;
+
+            SetWindowPosition(windowInfo, newLeft, newTop);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- allow moving windows between monitors in `WindowManager`
- expose MonitorIndex on `Set-DesktopWindow`

## Testing
- `dotnet test Sources/DesktopManager.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851d1704724832ebd00f06d64eccf6c