### PR TITLE
Add topmost and activation tests

### DIFF
--- a/Examples/GetWindow.ps1
+++ b/Examples/GetWindow.ps1
@@ -2,4 +2,6 @@
 
 Get-DesktopWindow | Format-Table *
 
-Set-DesktopWindow -Name '*Zadanie - Notepad' -Height 800 -Width 1200 -Left 100
+Set-DesktopWindow -Name '*Notepad' -Height 800 -Width 1200 -Left 100 -Activate
+
+Set-DesktopWindow -Name '*Notepad' -TopMost

--- a/Examples/WindowActions.ps1
+++ b/Examples/WindowActions.ps1
@@ -1,0 +1,4 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Make the first Notepad window top-most and bring it to the foreground
+Set-DesktopWindow -Name '*Notepad*' -TopMost -Activate

--- a/README.MD
+++ b/README.MD
@@ -178,3 +178,18 @@ Get-DesktopWindow | Format-Table *
 Set-DesktopWindow -Name '*Zadanie - Notepad' -Height 800 -Width 1200 -Left 100
 Set-DesktopWindow -Name '*Zadanie - Notepad' -State Maximize
 ```
+
+### Example in PowerShell - Activating and Setting Window Top-Most
+
+```powershell
+Set-DesktopWindow -Name '*Notepad*' -TopMost -Activate
+```
+
+#### Example in C# - Activating and Setting Window Top-Most
+
+```csharp
+var manager = new WindowManager();
+var window = manager.GetWindows().First();
+manager.SetWindowTopMost(window, true);
+manager.ActivateWindow(window);
+```

--- a/Sources/DesktopManager.Example/Program.cs
+++ b/Sources/DesktopManager.Example/Program.cs
@@ -71,6 +71,9 @@
 
             // Set wallpaper for the first monitor
             monitor.SetWallpaper(1, @"C:\Users\przemyslaw.klys\Downloads\CleanupMonster2.jpg");
+
+            // Demonstrate window management features
+            WindowExamples.Run();
         }
     }
 }

--- a/Sources/DesktopManager.Example/WindowExamples.cs
+++ b/Sources/DesktopManager.Example/WindowExamples.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Example {
+    /// <summary>
+    /// Demonstrates WindowManager features such as setting a window top-most and activating it.
+    /// </summary>
+    internal static class WindowExamples {
+        public static void Run() {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                Console.WriteLine("Window management examples require Windows.");
+                return;
+            }
+
+            var manager = new WindowManager();
+            var window = manager.GetWindows().FirstOrDefault();
+            if (window == null) {
+                Console.WriteLine("No windows found to manipulate.");
+                return;
+            }
+
+            // Make the window top-most
+            manager.SetWindowTopMost(window, true);
+            Console.WriteLine($"Set '{window.Title}' as top-most.");
+
+            // Bring the window to the foreground
+            manager.ActivateWindow(window);
+            Console.WriteLine($"Activated '{window.Title}'.");
+
+            // Reset top-most state
+            manager.SetWindowTopMost(window, false);
+        }
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
@@ -56,6 +56,18 @@ namespace DesktopManager.PowerShell {
         public WindowState? State { get; set; }
 
         /// <summary>
+        /// <para type="description">Set the window as top-most.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter TopMost { get; set; }
+
+        /// <summary>
+        /// <para type="description">Activate the window.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Activate { get; set; }
+
+        /// <summary>
         /// Begin processing
         /// </summary>
         protected override void BeginProcessing() {
@@ -85,6 +97,12 @@ namespace DesktopManager.PowerShell {
                                     break;
                             }
                         }
+                        if (TopMost.IsPresent) {
+                            manager.SetWindowTopMost(window, true);
+                        }
+                        if (Activate.IsPresent) {
+                            manager.ActivateWindow(window);
+                        }
                     } catch (Exception ex) {
                         WriteWarning($"Failed to modify window '{window.Title}': {ex.Message}");
                     }
@@ -103,6 +121,12 @@ namespace DesktopManager.PowerShell {
             }
             if (Width >= 0 || Height >= 0) {
                 parts.Add($"Resize to {Width}x{Height}");
+            }
+            if (TopMost.IsPresent) {
+                parts.Add("TopMost");
+            }
+            if (Activate.IsPresent) {
+                parts.Add("Activate");
             }
 
             return string.Join(" and ", parts);

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -23,15 +23,15 @@ public class WindowTopMostActivationTests
         }
 
         var window = windows.First();
-        var originalStyle = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        var originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
         bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
         manager.SetWindowTopMost(window, !wasTop);
-        var toggled = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        var toggled = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
         Assert.AreEqual(!wasTop, (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
 
         manager.SetWindowTopMost(window, wasTop);
-        var reverted = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        var reverted = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
         Assert.AreEqual(wasTop, (reverted & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
     }
 

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowTopMostActivationTests
+{
+    [TestMethod]
+    public void SetWindowTopMost_TogglesState()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0)
+        {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var originalStyle = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
+
+        manager.SetWindowTopMost(window, !wasTop);
+        var toggled = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        Assert.AreEqual(!wasTop, (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
+
+        manager.SetWindowTopMost(window, wasTop);
+        var reverted = MonitorNativeMethods.GetWindowLong(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        Assert.AreEqual(wasTop, (reverted & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
+    }
+
+    [TestMethod]
+    public void ActivateWindow_BringsToFront()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0)
+        {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        manager.ActivateWindow(window);
+        var foreground = MonitorNativeMethods.GetForegroundWindow();
+
+        Assert.AreEqual(window.Handle, foreground);
+    }
+}

--- a/Sources/DesktopManager/MonitorNativeMethods.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.cs
@@ -131,6 +131,21 @@ public static class MonitorNativeMethods {
     public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, int uFlags);
 
     /// <summary>
+    /// Brings the specified window to the foreground.
+    /// </summary>
+    /// <param name="hWnd">The window handle.</param>
+    /// <returns>True if successful.</returns>
+    [DllImport("user32.dll")]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    /// <summary>
+    /// Gets the handle of the foreground window.
+    /// </summary>
+    /// <returns>The foreground window handle.</returns>
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    /// <summary>
     /// Sends a message to a window.
     /// </summary>
     /// <param name="hWnd">The window handle.</param>
@@ -154,10 +169,22 @@ public static class MonitorNativeMethods {
     /// Indexes for GetWindowLong
     /// </summary>
     public const int GWL_STYLE = -16;
+    public const int GWL_EXSTYLE = -20;
 
     /// <summary>
     /// Window style values
     /// </summary>
     public const int WS_MINIMIZE = 0x20000000;
     public const int WS_MAXIMIZE = 0x01000000;
+
+    /// <summary>
+    /// Extended window style values
+    /// </summary>
+    public const int WS_EX_TOPMOST = 0x00000008;
+
+    /// <summary>
+    /// Window insert after handles.
+    /// </summary>
+    public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+    public static readonly IntPtr HWND_NOTOPMOST = new IntPtr(-2);
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -222,6 +222,31 @@ namespace DesktopManager {
                 0);
         }
 
+        /// <summary>
+        /// Sets whether a window is topmost.
+        /// </summary>
+        /// <param name="windowInfo">The window information.</param>
+        /// <param name="topMost">True to make the window topmost; false to reset.</param>
+        public void SetWindowTopMost(WindowInfo windowInfo, bool topMost) {
+            const int SWP_NOMOVE = 0x0002;
+            const int SWP_NOSIZE = 0x0001;
+
+            var insertAfter = topMost ? MonitorNativeMethods.HWND_TOPMOST : MonitorNativeMethods.HWND_NOTOPMOST;
+            if (!MonitorNativeMethods.SetWindowPos(windowInfo.Handle, insertAfter, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE)) {
+                throw new InvalidOperationException("Failed to set window topmost state");
+            }
+        }
+
+        /// <summary>
+        /// Activates a window.
+        /// </summary>
+        /// <param name="windowInfo">The window information.</param>
+        public void ActivateWindow(WindowInfo windowInfo) {
+            if (!MonitorNativeMethods.SetForegroundWindow(windowInfo.Handle)) {
+                throw new InvalidOperationException("Failed to activate window");
+            }
+        }
+
         private bool MatchesWildcard(string text, string pattern) {
             if (pattern == "*") {
                 return true;


### PR DESCRIPTION
## Summary
- extend native methods with foreground and style helpers
- implement tests for SetWindowTopMost and ActivateWindow

## Testing
- `dotnet test Sources/DesktopManager.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851d163048c832eabe39b91fe44ca7d