### PR TITLE
Add monitor orientation & resolution cmdlet

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopResolution')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PowerShell.Tests/SetDesktopResolution.Tests.ps1
+++ b/PowerShell.Tests/SetDesktopResolution.Tests.ps1
@@ -1,0 +1,14 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../DesktopManager.psd1" -Force
+}
+
+describe 'Set-DesktopResolution' {
+    it 'supports WhatIf mode' {
+        { Set-DesktopResolution -Width 800 -Height 600 -WhatIf } | Should -Not -Throw
+    }
+
+    it 'accepts orientation parameter' {
+        { Set-DesktopResolution -Width 800 -Height 600 -Orientation Default -WhatIf } | Should -Not -Throw
+    }
+}
+

--- a/Sources/DesktopManager.Example/Program.cs
+++ b/Sources/DesktopManager.Example/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace DesktopManager.Example {
+namespace DesktopManager.Example {
     /// <summary>
     /// The main class for the DesktopManager example application.
     /// </summary>
@@ -71,6 +71,9 @@
 
             // Set wallpaper for the first monitor
             monitor.SetWallpaper(1, @"C:\Users\przemyslaw.klys\Downloads\CleanupMonster2.jpg");
+
+            ResolutionOrientationDemo.Run();
         }
     }
 }
+

--- a/Sources/DesktopManager.Example/ResolutionOrientationDemo.cs
+++ b/Sources/DesktopManager.Example/ResolutionOrientationDemo.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+
+namespace DesktopManager.Example;
+
+internal static class ResolutionOrientationDemo {
+    public static void Run() {
+        Monitors monitors = new Monitors();
+        var first = monitors.GetMonitorsConnected().FirstOrDefault();
+        if (first == null) {
+            return;
+        }
+
+        var position = first.GetMonitorPosition();
+        int width = position.Right - position.Left;
+        int height = position.Bottom - position.Top;
+
+        monitors.SetMonitorResolution(first.DeviceId, width, height);
+        monitors.SetMonitorOrientation(first.DeviceId, DisplayOrientation.Default);
+    }
+}
+

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopResolution.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopResolution.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Sets the resolution of a desktop monitor.</summary>
+/// <para type="synopsis">Sets the resolution of a desktop monitor.</para>
+/// <para type="description">Allows changing the resolution and orientation of a monitor identified by index or device ID.</para>
+[Cmdlet(VerbsCommon.Set, "DesktopResolution", DefaultParameterSetName = "Index", SupportsShouldProcess = true)]
+public sealed class CmdletSetDesktopResolution : PSCmdlet {
+    /// <summary>
+    /// <para type="description">The index of the monitor.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, Position = 0, ParameterSetName = "Index")]
+    public int? Index;
+
+    /// <summary>
+    /// <para type="description">The device ID of the monitor.</para>
+    /// </summary>
+    [Alias("MonitorID")]
+    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "DeviceID")]
+    public string DeviceId;
+
+    /// <summary>
+    /// <para type="description">The device name of the monitor.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, Position = 2, ParameterSetName = "DeviceName")]
+    public string DeviceName;
+
+    /// <summary>
+    /// <para type="description">Set resolution for the primary monitor only.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, Position = 3, ParameterSetName = "PrimaryOnly")]
+    public SwitchParameter? PrimaryOnly;
+
+    /// <summary>
+    /// <para type="description">Resolution width.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 4)]
+    public int Width;
+
+    /// <summary>
+    /// <para type="description">Resolution height.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 5)]
+    public int Height;
+
+    /// <summary>
+    /// <para type="description">Optional display orientation.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, Position = 6)]
+    public DisplayOrientation? Orientation;
+
+    private ActionPreference ErrorAction;
+
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing() {
+        ErrorAction = CmdletHelper.GetErrorAction(this);
+        Monitors monitors = new Monitors();
+
+        bool? primaryOnly = MyInvocation.BoundParameters.ContainsKey(nameof(PrimaryOnly)) ? (bool?)PrimaryOnly : null;
+        int? index = MyInvocation.BoundParameters.ContainsKey(nameof(Index)) ? (int?)Index : null;
+        string deviceId = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceId)) ? DeviceId : null;
+        string deviceName = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceName)) ? DeviceName : null;
+
+        var getMonitors = monitors.GetMonitors(connectedOnly: null, primaryOnly: primaryOnly, index: index, deviceId: deviceId, deviceName: deviceName);
+        foreach (var monitor in getMonitors) {
+            var action = $"Set resolution to {Width}x{Height}" + (Orientation != null ? $" orientation {Orientation}" : string.Empty);
+            if (ShouldProcess($"Monitor {monitor.DeviceName}", action)) {
+                try {
+                    monitors.SetMonitorResolution(monitor.DeviceId, Width, Height);
+                    if (Orientation != null) {
+                        monitors.SetMonitorOrientation(monitor.DeviceId, Orientation.Value);
+                    }
+                } catch (Exception ex) {
+                    if (ErrorAction == ActionPreference.Stop) { throw; }
+                    WriteWarning($"Failed to set resolution for {monitor.DeviceName}: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorResolutionOrientationTests {
+    [TestMethod]
+    public void SetResolutionAndOrientation_DoesNotThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var monitors = new Monitors().GetMonitorsConnected();
+        if (monitors.Count == 0) {
+            Assert.Inconclusive("No monitors found to test");
+        }
+
+        var monitor = monitors.First();
+        var position = monitor.GetMonitorPosition();
+        int width = position.Right - position.Left;
+        int height = position.Bottom - position.Top;
+
+        var manager = new Monitors();
+        manager.SetMonitorResolution(monitor.DeviceId, width, height);
+        manager.SetMonitorOrientation(monitor.DeviceId, DisplayOrientation.Default);
+    }
+}
+

--- a/Sources/DesktopManager/Enums.cs
+++ b/Sources/DesktopManager/Enums.cs
@@ -112,3 +112,25 @@ public enum DisplayChangeConfirmation : int {
     /// </summary>
     BadDualView = -6
 }
+
+/// <summary>
+/// Specifies the orientation of the display.
+/// </summary>
+public enum DisplayOrientation {
+    /// <summary>
+    /// Default landscape orientation.
+    /// </summary>
+    Default = 0,
+    /// <summary>
+    /// Rotated 90 degrees.
+    /// </summary>
+    Degrees90 = 1,
+    /// <summary>
+    /// Rotated 180 degrees.
+    /// </summary>
+    Degrees180 = 2,
+    /// <summary>
+    /// Rotated 270 degrees.
+    /// </summary>
+    Degrees270 = 3
+}

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -164,6 +164,46 @@ public class Monitors {
     }
 
     /// <summary>
+    /// Sets the resolution of a monitor by its device ID.
+    /// </summary>
+    /// <param name="deviceId">The device ID of the monitor.</param>
+    /// <param name="width">The desired width.</param>
+    /// <param name="height">The desired height.</param>
+    public void SetMonitorResolution(string deviceId, int width, int height) {
+        _monitorService.SetMonitorResolution(deviceId, width, height);
+    }
+
+    /// <summary>
+    /// Sets the resolution of a monitor by its index.
+    /// </summary>
+    /// <param name="index">The index of the monitor.</param>
+    /// <param name="width">The desired width.</param>
+    /// <param name="height">The desired height.</param>
+    public void SetMonitorResolution(int index, int width, int height) {
+        var deviceId = _monitorService.GetMonitorDevicePathAt((uint)index);
+        _monitorService.SetMonitorResolution(deviceId, width, height);
+    }
+
+    /// <summary>
+    /// Sets the orientation of a monitor by its device ID.
+    /// </summary>
+    /// <param name="deviceId">The device ID of the monitor.</param>
+    /// <param name="orientation">The orientation to apply.</param>
+    public void SetMonitorOrientation(string deviceId, DisplayOrientation orientation) {
+        _monitorService.SetMonitorOrientation(deviceId, orientation);
+    }
+
+    /// <summary>
+    /// Sets the orientation of a monitor by its index.
+    /// </summary>
+    /// <param name="index">The index of the monitor.</param>
+    /// <param name="orientation">The orientation to apply.</param>
+    public void SetMonitorOrientation(int index, DisplayOrientation orientation) {
+        var deviceId = _monitorService.GetMonitorDevicePathAt((uint)index);
+        _monitorService.SetMonitorOrientation(deviceId, orientation);
+    }
+
+    /// <summary>
     /// Gets a list of all display devices.
     /// </summary>
     /// <returns>A list of all display devices.</returns>


### PR DESCRIPTION
## Summary
- add `DisplayOrientation` enum
- support setting monitor resolution and orientation
- expose helper methods in `Monitors`
- implement `Set-DesktopResolution` cmdlet
- export the new cmdlet in the module manifest
- add C# and PowerShell tests for the new cmdlet
- demonstrate resolution/orientation API in example app

## Testing
- `dotnet build Sources/DesktopManager.sln --configuration Debug`
- `dotnet test Sources/DesktopManager.sln --no-build --verbosity minimal`
- `pwsh -NoProfile -Command "Invoke-Pester -Path PowerShell.Tests -CI"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d185f658832eac846232d6fce21f