### PR TITLE
Add automatic timeout for monitor event watcher

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow')
+    CmdletsToExport        = @('Register-DesktopMonitorEvent', 'Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Examples/RegisterDesktopMonitorEvent.ps1
+++ b/Examples/RegisterDesktopMonitorEvent.ps1
@@ -1,0 +1,5 @@
+Import-Module .\DesktopManager.psd1 -Force
+
+# Monitor display changes for 30 seconds and automatically unregister
+Register-DesktopMonitorEvent -Duration 30 -Action { Write-Host "Display settings changed" }
+

--- a/README.MD
+++ b/README.MD
@@ -178,3 +178,19 @@ Get-DesktopWindow | Format-Table *
 Set-DesktopWindow -Name '*Zadanie - Notepad' -Height 800 -Width 1200 -Left 100
 Set-DesktopWindow -Name '*Zadanie - Notepad' -State Maximize
 ```
+
+#### Example in PowerShell - Monitoring Display Changes
+
+Use `Register-DesktopMonitorEvent` to react when monitors are plugged in or the display configuration changes.
+
+```powershell
+Register-DesktopMonitorEvent -Duration 30 -Action { Write-Host 'Display settings changed' }
+```
+
+#### Example in C# - Monitoring Display Changes
+
+Applications can subscribe to the `MonitorWatcher.DisplaySettingsChanged` event.
+
+```csharp
+MonitorWatcherExample.Run(TimeSpan.FromSeconds(30));
+```

--- a/Sources/DesktopManager.Example/MonitorWatcherExample.cs
+++ b/Sources/DesktopManager.Example/MonitorWatcherExample.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace DesktopManager.Example;
+
+internal static class MonitorWatcherExample {
+    public static async Task RunAsync(TimeSpan duration) {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Console.WriteLine("MonitorWatcher works only on Windows.");
+            return;
+        }
+
+        using var watcher = new MonitorWatcher();
+        watcher.DisplaySettingsChanged += (_, _) =>
+            Helpers.AddLine("MonitorWatcher", "Display settings changed");
+        Console.WriteLine($"Monitoring display changes for {duration.TotalSeconds} seconds...");
+        await Task.Delay(duration);
+    }
+}
+

--- a/Sources/DesktopManager.Example/Program.cs
+++ b/Sources/DesktopManager.Example/Program.cs
@@ -71,6 +71,9 @@
 
             // Set wallpaper for the first monitor
             monitor.SetWallpaper(1, @"C:\Users\przemyslaw.klys\Downloads\CleanupMonster2.jpg");
+
+            // Run monitor watcher example for 30 seconds
+            MonitorWatcherExample.RunAsync(TimeSpan.FromSeconds(30)).Wait();
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopMonitorEvent.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopMonitorEvent.cs
@@ -1,0 +1,39 @@
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+using System;
+using System.Management.Automation;
+using System.Timers;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Registers for desktop monitor change events.</summary>
+[Cmdlet(VerbsLifecycle.Register, "DesktopMonitorEvent")]
+public sealed class CmdletRegisterDesktopMonitorEvent : PSCmdlet {
+    /// <summary>The script block to run when the event is raised.</summary>
+    [Parameter(Mandatory = false)]
+    public ScriptBlock Action { get; set; }
+
+    /// <summary>The duration to monitor before automatically unregistering.</summary>
+    [Parameter(Mandatory = false)]
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>Begin processing.</summary>
+    protected override void BeginProcessing() {
+        var watcher = new MonitorWatcher();
+        var subscriber = Events.SubscribeEvent(watcher, nameof(MonitorWatcher.DisplaySettingsChanged), "MonitorWatcher", null, Action, true, false);
+        WriteObject(subscriber);
+
+        if (Duration > TimeSpan.Zero) {
+            var timer = new Timer(Duration.TotalMilliseconds) { AutoReset = false };
+            timer.Elapsed += (_, _) => {
+                Events.UnsubscribeEvent(subscriber);
+                watcher.Dispose();
+                timer.Dispose();
+            };
+            timer.Start();
+        }
+    }
+}
+
+
+
+#endif

--- a/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorWatcherTests {
+    [TestMethod]
+    public void MonitorWatcher_CanBeCreated() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var watcher = new MonitorWatcher();
+        Assert.IsNotNull(watcher);
+    }
+}

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -55,4 +55,8 @@
         <Using Include="System" />
         <Using Include="System.Collections.Generic" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
+    </ItemGroup>
 </Project>

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -1,0 +1,41 @@
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Monitors display change notifications using <c>WM_DISPLAYCHANGE</c>.
+/// </summary>
+public sealed class MonitorWatcher : IDisposable {
+    /// <summary>
+    /// Raised when display settings change.
+    /// </summary>
+    public event EventHandler DisplaySettingsChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MonitorWatcher"/> class.
+    /// </summary>
+    /// <exception cref="PlatformNotSupportedException">Thrown when not running on Windows.</exception>
+    public MonitorWatcher() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            throw new PlatformNotSupportedException("MonitorWatcher is supported only on Windows.");
+        }
+
+        SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
+    }
+
+    private void OnDisplaySettingsChanged(object sender, EventArgs e) {
+        DisplaySettingsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Unsubscribes from system events.
+    /// </summary>
+    public void Dispose() {
+        SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+        GC.SuppressFinalize(this);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- automate unregistration in `Register-DesktopMonitorEvent`
- update example script to use the new `-Duration` parameter
- delay asynchronously in C# example instead of blocking thread

## Testing
- `dotnet test Sources/DesktopManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6851d15f89d8832ea70eccbc7013c83f