### PR TITLE
Fix CA1416 warnings

### DIFF
--- a/Sources/DesktopManager.Example/Helpers.cs
+++ b/Sources/DesktopManager.Example/Helpers.cs
@@ -111,7 +111,7 @@ internal class Helpers {
                 nestedTable.AddColumn("Value");
 
                 foreach (DictionaryEntry entry in dictionaryValue) {
-                    var escapedKey = Markup.Escape(entry.Key.ToString());
+                    var escapedKey = Markup.Escape(entry.Key?.ToString() ?? string.Empty);
                     var escapedValue = Markup.Escape(entry.Value?.ToString() ?? "null");
                     nestedTable.AddRow(escapedKey, escapedValue);
                 }

--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopScreenshot.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopScreenshot.cs
@@ -2,6 +2,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Management.Automation;
+using System.Runtime.Versioning;
 
 namespace DesktopManager.PowerShell;
 
@@ -9,6 +10,7 @@ namespace DesktopManager.PowerShell;
 /// <para type="synopsis">Captures a screenshot of the desktop.</para>
 /// <para type="description">Captures the current desktop image. When a path is provided the image is saved as PNG; otherwise a Bitmap object is returned. The screenshot can target a specific monitor or any region.</para>
 [Cmdlet(VerbsLifecycle.Invoke, "DesktopScreenshot")]
+[SupportedOSPlatform("windows")]
 public sealed class CmdletInvokeDesktopScreenshot : PSCmdlet {
     /// <summary>
     /// <para type="description">Optional path to save the screenshot as a PNG file.</para>

--- a/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopMonitorEvent.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopMonitorEvent.cs
@@ -2,11 +2,13 @@
 using System;
 using System.Management.Automation;
 using System.Timers;
+using System.Runtime.Versioning;
 
 namespace DesktopManager.PowerShell;
 
 /// <summary>Registers for desktop monitor change events.</summary>
 [Cmdlet(VerbsLifecycle.Register, "DesktopMonitorEvent")]
+[SupportedOSPlatform("windows")]
 public sealed class CmdletRegisterDesktopMonitorEvent : PSCmdlet {
     /// <summary>The script block to run when the event is raised.</summary>
     [Parameter(Mandatory = false)]

--- a/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
+++ b/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
@@ -12,10 +12,14 @@
         <LangVersion>latest</LangVersion>
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
-        <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
+      <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <Compile Include="..\Shared\SupportedOSPlatformAttribute.cs" />
+  </ItemGroup>
 
     <PropertyGroup>
         <!-- Make sure the output DLL's from library are included in the output -->

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +15,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\SupportedOSPlatformAttribute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
@@ -1,12 +1,18 @@
+using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
 
 namespace DesktopManager.Tests;
 
 [TestClass]
+[SupportedOSPlatform("windows")]
 public class MonitorWatcherTests {
     [TestMethod]
     public void MonitorWatcher_CanBeCreated() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
             Assert.Inconclusive("Test requires Windows");
         }
 

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -23,15 +23,15 @@ public class WindowTopMostActivationTests
         }
 
         var window = windows.First();
-        var originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        long originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
         manager.SetWindowTopMost(window, !wasTop);
-        var toggled = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        long toggled = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         Assert.AreEqual(!wasTop, (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
 
         manager.SetWindowTopMost(window, wasTop);
-        var reverted = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE);
+        long reverted = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         Assert.AreEqual(wasTop, (reverted & MonitorNativeMethods.WS_EX_TOPMOST) != 0);
     }
 

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -39,9 +39,13 @@
         <Content Include="..\..\Assets\Icons\DesktopManager.ico" />
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <Compile Include="..\Shared\SupportedOSPlatformAttribute.cs" />
+  </ItemGroup>
 
     <ItemGroup>
         <None Include="..\..\Assets\Icons\DesktopManager.png">

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -1,6 +1,7 @@
 #if !NETSTANDARD2_0 && !NETSTANDARD2_1
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 
 namespace DesktopManager;
@@ -8,6 +9,7 @@ namespace DesktopManager;
 /// <summary>
 /// Monitors display change notifications using <c>WM_DISPLAYCHANGE</c>.
 /// </summary>
+[SupportedOSPlatform("windows")]
 public sealed class MonitorWatcher : IDisposable {
     /// <summary>
     /// Raised when display settings change.

--- a/Sources/DesktopManager/ScreenshotService.cs
+++ b/Sources/DesktopManager/ScreenshotService.cs
@@ -2,12 +2,14 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace DesktopManager;
 
 /// <summary>
 /// Provides methods for capturing screenshots of the desktop.
 /// </summary>
+[SupportedOSPlatform("windows")]
 public static class ScreenshotService {
     /// <summary>
     /// Captures a screenshot of the entire virtual screen.

--- a/Sources/Shared/SupportedOSPlatformAttribute.cs
+++ b/Sources/Shared/SupportedOSPlatformAttribute.cs
@@ -1,0 +1,13 @@
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.Versioning
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module | AttributeTargets.Class | AttributeTargets.Struct |
+                    AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property |
+                    AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate,
+                    AllowMultiple = true, Inherited = false)]
+    internal sealed class SupportedOSPlatformAttribute : Attribute
+    {
+        public SupportedOSPlatformAttribute(string platformName) { }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- annotate Windows-specific classes and methods for OS analyzers
- use OS guard in tests and fix possible null reference in example
- enable tests to build on net472
- polyfill `SupportedOSPlatform` attribute to avoid conditional compilation

## Testing
- `dotnet build Sources/DesktopManager.sln -v minimal`
- `dotnet test Sources/DesktopManager.sln --no-build` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68529a21acd0832e9be1604024271f95