### PR TITLE
Add WindowLayout support

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Set-DesktopPosition', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
@@ -1,0 +1,26 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Restores desktop window layout from a file.</summary>
+/// <para type="synopsis">Restores window positions saved earlier.</para>
+/// <example>
+///   <para>Restore layout from a file</para>
+///   <code>Restore-DesktopWindowLayout -Path C:\layout.json</code>
+/// </example>
+[Cmdlet(VerbsData.Restore, "DesktopWindowLayout", SupportsShouldProcess = true)]
+public sealed class CmdletRestoreDesktopWindowLayout : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Path to layout file.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Path { get; set; }
+
+    /// <summary>Begin processing.</summary>
+    protected override void BeginProcessing() {
+        if (ShouldProcess(Path, "Restore desktop window layout")) {
+            var manager = new WindowManager();
+            manager.LoadLayout(Path);
+        }
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSaveDesktopWindowLayout.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSaveDesktopWindowLayout.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Saves the current desktop window layout.</summary>
+/// <para type="synopsis">Saves window positions to a file.</para>
+/// <example>
+///   <para>Save layout to a file</para>
+///   <code>Save-DesktopWindowLayout -Path C:\layout.json</code>
+/// </example>
+[Cmdlet(VerbsData.Save, "DesktopWindowLayout")]
+public sealed class CmdletSaveDesktopWindowLayout : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Path to save the layout.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Path { get; set; }
+
+    /// <summary>Begin processing.</summary>
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        manager.SaveLayout(Path);
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowLayoutTests {
+    [TestMethod]
+    public void SaveAndLoadLayout_DoesNotThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var path = System.IO.Path.GetTempFileName();
+        manager.SaveLayout(path);
+        Assert.IsTrue(File.Exists(path));
+        manager.LoadLayout(path);
+        File.Delete(path);
+    }
+}

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -35,8 +35,12 @@
         <PackageReadmeFile>README.MD</PackageReadmeFile>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
         <Content Include="..\..\Assets\Icons\DesktopManager.ico" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/DesktopManager/WindowLayout.cs
+++ b/Sources/DesktopManager/WindowLayout.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Represents a layout containing positions for multiple windows.
+/// </summary>
+public class WindowLayout {
+    /// <summary>
+    /// Gets or sets collection of window positions.
+    /// </summary>
+    public List<WindowPosition> Windows { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- add `WindowLayout` class
- persist window layouts with `SaveLayout` and `LoadLayout`
- expose new PowerShell cmdlets `Save-DesktopWindowLayout` and `Restore-DesktopWindowLayout`
- export new cmdlets in module manifest
- unit test for layout serialization

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6852f724c758832ebc157f1da98d48a9