### PR TITLE
Add wallpaper fallback using SystemParametersInfo

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
@@ -38,5 +38,47 @@ public class MonitorFallbackTests {
         Assert.IsTrue(rect.Right > rect.Left);
         Assert.IsTrue(rect.Bottom > rect.Top);
     }
+
+    [TestMethod]
+    public void SetAndGetWallpaper_FallsBackToSystemParametersInfo() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var service = new MonitorService(new FailingDesktopManager());
+        var monitors = service.GetMonitorsConnected();
+        if (monitors.Count == 0) {
+            Assert.Inconclusive("No monitors found");
+        }
+
+        string temp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".bmp");
+        using (var bmp = new System.Drawing.Bitmap(1, 1)) {
+            bmp.Save(temp, System.Drawing.Imaging.ImageFormat.Bmp);
+        }
+
+        service.SetWallpaper(monitors[0].DeviceId, temp);
+        var retrieved = service.GetWallpaper(monitors[0].DeviceId);
+
+        Assert.AreEqual(temp, retrieved);
+        System.IO.File.Delete(temp);
+    }
+
+    [TestMethod]
+    public void SetAndGetWallpaperPosition_FallsBackToRegistry() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var service = new MonitorService(new FailingDesktopManager());
+        var original = service.GetWallpaperPosition();
+        var newPos = original == DesktopWallpaperPosition.Center ? DesktopWallpaperPosition.Stretch : DesktopWallpaperPosition.Center;
+
+        service.SetWallpaperPosition(newPos);
+        var roundTrip = service.GetWallpaperPosition();
+
+        service.SetWallpaperPosition(original);
+
+        Assert.AreEqual(newPos, roundTrip);
+    }
 }
 

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -40,6 +40,7 @@
     </ItemGroup>
 
   <ItemGroup>
+      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
       <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 

--- a/Sources/DesktopManager/MonitorNativeMethods.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.cs
@@ -321,4 +321,46 @@ public static class MonitorNativeMethods {
     /// System metric index for the virtual screen height.
     /// </summary>
     public const int SM_CYVIRTUALSCREEN = 79;
+
+    /// <summary>
+    /// Sets or retrieves system-wide parameters, including desktop wallpaper.
+    /// </summary>
+    /// <param name="uiAction">The system-wide parameter to set or query.</param>
+    /// <param name="uiParam">Parameter whose usage depends on <paramref name="uiAction"/>.</param>
+    /// <param name="pvParam">Parameter whose usage and format depends on <paramref name="uiAction"/>.</param>
+    /// <param name="fWinIni">Flags specifying if the user profile is updated.</param>
+    /// <returns><c>true</c> if successful; otherwise <c>false</c>.</returns>
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, StringBuilder pvParam, uint fWinIni);
+
+    /// <summary>
+    /// Sets or retrieves system-wide parameters, including desktop wallpaper.
+    /// </summary>
+    /// <param name="uiAction">The system-wide parameter to set or query.</param>
+    /// <param name="uiParam">Parameter whose usage depends on <paramref name="uiAction"/>.</param>
+    /// <param name="pvParam">Parameter whose usage and format depends on <paramref name="uiAction"/>.</param>
+    /// <param name="fWinIni">Flags specifying if the user profile is updated.</param>
+    /// <returns><c>true</c> if successful; otherwise <c>false</c>.</returns>
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, string pvParam, uint fWinIni);
+
+    /// <summary>
+    /// Action code for setting the desktop wallpaper.
+    /// </summary>
+    public const uint SPI_SETDESKWALLPAPER = 0x0014;
+
+    /// <summary>
+    /// Action code for retrieving the desktop wallpaper.
+    /// </summary>
+    public const uint SPI_GETDESKWALLPAPER = 0x0073;
+
+    /// <summary>
+    /// Writes the new system-wide parameter to the user profile.
+    /// </summary>
+    public const uint SPIF_UPDATEINIFILE = 0x0001;
+
+    /// <summary>
+    /// Broadcasts the WM_SETTINGCHANGE message after updating the user profile.
+    /// </summary>
+    public const uint SPIF_SENDWININICHANGE = 0x0002;
 }


### PR DESCRIPTION
## Summary
- support SystemParametersInfo in native methods
- fallback to SystemParametersInfo when COM calls fail to set or get wallpaper
- use registry/SystemParametersInfo to manage wallpaper position when COM fails
- test COM failure paths for wallpaper and wallpaper position

## Testing
- `dotnet test Sources/DesktopManager.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68531d859204832eab1b569c97aa0c56