### PR TITLE
Implement window layout save/restore

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Examples/SaveRestoreWindowLayout.ps1
+++ b/Examples/SaveRestoreWindowLayout.ps1
@@ -1,0 +1,9 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Save current window layout
+Save-DesktopWindowLayout -Path './layout.json'
+
+# ... move windows around ...
+
+# Restore saved layout
+Restore-DesktopWindowLayout -Path './layout.json'

--- a/PowerShell.Tests/WindowLayout.Tests.ps1
+++ b/PowerShell.Tests/WindowLayout.Tests.ps1
@@ -1,0 +1,12 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../DesktopManager.psd1" -Force
+}
+
+describe 'Save-DesktopWindowLayout and Restore-DesktopWindowLayout' {
+    it 'supports WhatIf for saving' {
+        { Save-DesktopWindowLayout -Path "$env:TEMP/layout.json" -WhatIf } | Should -Not -Throw
+    }
+    it 'supports WhatIf for restoring' {
+        { Restore-DesktopWindowLayout -Path "$env:TEMP/layout.json" -WhatIf } | Should -Not -Throw
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -215,3 +215,20 @@ Applications can subscribe to the `MonitorWatcher.DisplaySettingsChanged` event.
 ```csharp
 MonitorWatcherExample.Run(TimeSpan.FromSeconds(30));
 ```
+
+#### Example in PowerShell - Saving and Restoring Window Layout
+
+```powershell
+Save-DesktopWindowLayout -Path './layout.json'
+# ... move windows around ...
+Restore-DesktopWindowLayout -Path './layout.json'
+```
+
+#### Example in C# - Saving and Restoring Window Layout
+
+```csharp
+var manager = new WindowManager();
+manager.SaveLayout("layout.json");
+// ... move windows around ...
+manager.LoadLayout("layout.json");
+```

--- a/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Restores window positions from a saved layout.</summary>
+/// <para type="synopsis">Restores desktop window layout.</para>
+[Cmdlet(VerbsData.Restore, "DesktopWindowLayout", SupportsShouldProcess = true)]
+public sealed class CmdletRestoreDesktopWindowLayout : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Path to the layout file.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Path { get; set; }
+
+    /// <summary>
+    /// Begin processing.
+    /// </summary>
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        if (ShouldProcess(Path, "Restore window layout")) {
+            manager.LoadLayout(Path);
+        }
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSaveDesktopWindowLayout.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSaveDesktopWindowLayout.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Saves the current desktop window layout to a file.</summary>
+/// <para type="synopsis">Saves the current desktop window layout.</para>
+[Cmdlet(VerbsData.Save, "DesktopWindowLayout", SupportsShouldProcess = true)]
+public sealed class CmdletSaveDesktopWindowLayout : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Path where the layout should be stored.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Path { get; set; }
+
+    /// <summary>
+    /// Begin processing.
+    /// </summary>
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        if (ShouldProcess(Path, "Save window layout")) {
+            manager.SaveLayout(Path);
+            WriteObject(Path);
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowLayoutTests {
+    [TestMethod]
+    public void SaveAndLoadLayout_RoundTrips() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var original = manager.GetWindowPosition(window);
+        var path = System.IO.Path.GetTempFileName();
+
+        manager.SaveLayout(path);
+        manager.SetWindowPosition(window, original.Left + 20, original.Top + 20);
+        manager.LoadLayout(path);
+        var restored = manager.GetWindowPosition(window);
+
+        Assert.AreEqual(original.Left, restored.Left);
+        Assert.AreEqual(original.Top, restored.Top);
+
+        System.IO.File.Delete(path);
+    }
+}

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
       <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+      <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager/WindowInfo.cs
+++ b/Sources/DesktopManager/WindowInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace DesktopManager;
+using System.Text.Json.Serialization;
+
+namespace DesktopManager;
 /// <summary>
 /// Represents basic information about a window.
 /// </summary>
@@ -11,6 +13,7 @@ public class WindowInfo {
     /// <summary>
     /// Gets or sets the window handle.
     /// </summary>
+    [JsonIgnore]
     public IntPtr Handle { get; set; }
 
     /// <summary>

--- a/Sources/DesktopManager/WindowLayout.cs
+++ b/Sources/DesktopManager/WindowLayout.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Represents a collection of window positions that define a desktop layout.
+/// </summary>
+public class WindowLayout {
+    /// <summary>
+    /// Gets or sets the list of window positions in this layout.
+    /// </summary>
+    public List<WindowPosition> Windows { get; set; } = new();
+}

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -6,4 +6,12 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Get-DesktopMonitor' {
         Get-Command Get-DesktopMonitor | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Save-DesktopWindowLayout' {
+        Get-Command Save-DesktopWindowLayout | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Restore-DesktopWindowLayout' {
+        Get-Command Restore-DesktopWindowLayout | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## Summary
- record positions of multiple windows via new `WindowLayout` class
- allow saving and restoring layouts in `WindowManager`
- expose `Save-DesktopWindowLayout` and `Restore-DesktopWindowLayout` PowerShell cmdlets
- add tests and examples

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0 --no-build`
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68531e7c6aa0832e91bc1592dd239aba