### PR TITLE
chore: 🔧 update package references

### DIFF
--- a/Sources/DesktopManager.Example/DesktopManager.Example.csproj
+++ b/Sources/DesktopManager.Example/DesktopManager.Example.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.49.1" />
+        <PackageReference Include="Spectre.Console" Version="0.50.0" />
     </ItemGroup>
 
 </Project>

--- a/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
+++ b/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
@@ -14,7 +14,6 @@
     </PropertyGroup>
   <ItemGroup>
       <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
-      <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
@@ -11,10 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>DesktopManager</AssemblyName>
@@ -41,8 +41,8 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-      <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
-      <PackageReference Include="System.Text.Json" Version="8.0.0" />
+      <PackageReference Include="System.Drawing.Common" Version="8.0.17" />
+      <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Bump `Spectre.Console` to version `0.50.0`
* Remove `System.Drawing.Common` from PowerShell project
* Update `System.Drawing.Common` to version `8.0.17` and `System.Text.Json` to version `8.0.5` in DesktopManager project
* Update `coverlet.collector`, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, and `MSTest.TestFramework` versions in tests