### PR TITLE
Implement desktop background color support

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Docs/Get-DesktopBackgroundColor.md
+++ b/Docs/Get-DesktopBackgroundColor.md
@@ -1,0 +1,27 @@
+---
+external help file: DesktopManager-help.xml
+Module Name: DesktopManager
+online version:
+schema: 2.0.0
+---
+
+# Get-DesktopBackgroundColor
+
+## SYNOPSIS
+Retrieves the current desktop background color.
+
+## DESCRIPTION
+Returns the desktop background color as a numeric RGB value.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-DesktopBackgroundColor
+```
+Gets the current background color.
+
+## OUTPUTS
+
+### System.UInt32
+

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -20,6 +20,12 @@ Locale: en-US
 ### [Set-DesktopWallpaper](Set-DesktopWallpaper.md)
 {{ Fill in the Synopsis }}
 
+### [Get-DesktopBackgroundColor](Get-DesktopBackgroundColor.md)
+{{ Fill in the Synopsis }}
+
+### [Set-DesktopBackgroundColor](Set-DesktopBackgroundColor.md)
+{{ Fill in the Synopsis }}
+
 ### [Invoke-DesktopScreenshot](Invoke-DesktopScreenshot.md)
 Capture a screenshot of all monitors, a single monitor or an arbitrary region.
 

--- a/Docs/Set-DesktopBackgroundColor.md
+++ b/Docs/Set-DesktopBackgroundColor.md
@@ -1,0 +1,48 @@
+---
+external help file: DesktopManager-help.xml
+Module Name: DesktopManager
+online version:
+schema: 2.0.0
+---
+
+# Set-DesktopBackgroundColor
+
+## SYNOPSIS
+Changes the desktop background color.
+
+## DESCRIPTION
+Sets the desktop background to the specified RGB color.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-DesktopBackgroundColor -Color 0x0000FF
+```
+Sets the background color to blue.
+
+## PARAMETERS
+
+### -Color
+RGB value of the new background color.
+
+```yaml
+Type: UInt32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+

--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,7 @@ It has following features:
 - Get information about display devices
 - Get information about wallpapers
 - Set wallpapers
+- Get/Set desktop background color
 - Get/Set monitor position
 - Get/Set window position
 - Get/Set window state (minimize, maximize, restore)
@@ -145,6 +146,8 @@ Get-DesktopWallpaper -Index 0
 
 Set-DesktopWallpaper -Index 1 -WallpaperPath "C:\Support\GitHub\ImagePlayground\Sources\ImagePlayground.Examples\bin\Debug\net7.0\Images\KulekWSluchawkach.jpg" -Position Fit
 Set-DesktopWallpaper -Index 0 -WallpaperPath "C:\Users\przemyslaw.klys\Downloads\IMG_4820.jpg"
+Set-DesktopBackgroundColor -Color 0x0000FF
+Get-DesktopBackgroundColor
 ```
 
 ```powershell

--- a/Sources/DesktopManager.PowerShell/CmdletGetDesktopBackgroundColor.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetDesktopBackgroundColor.cs
@@ -1,0 +1,16 @@
+using System.Management.Automation;
+using DesktopManager;
+namespace DesktopManager.PowerShell;
+
+/// <summary>Gets the desktop background color.</summary>
+/// <para type="synopsis">Gets the desktop background color.</para>
+[Cmdlet(VerbsCommon.Get, "DesktopBackgroundColor")]
+public sealed class CmdletGetDesktopBackgroundColor : PSCmdlet {
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing() {
+        Monitors monitors = new Monitors();
+        WriteObject(monitors.GetBackgroundColor());
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopBackgroundColor.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopBackgroundColor.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+using DesktopManager;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Sets the desktop background color.</summary>
+/// <para type="synopsis">Sets the desktop background color.</para>
+[Cmdlet(VerbsCommon.Set, "DesktopBackgroundColor", SupportsShouldProcess = true)]
+public sealed class CmdletSetDesktopBackgroundColor : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Color as RGB value.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public uint Color;
+
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing() {
+        if (ShouldProcess("Desktop", $"Set background color to 0x{Color:X6}")) {
+            Monitors monitors = new Monitors();
+            monitors.SetBackgroundColor(Color);
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/BackgroundColorTests.cs
+++ b/Sources/DesktopManager.Tests/BackgroundColorTests.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class BackgroundColorTests {
+    [TestMethod]
+    public void SetAndGetBackgroundColor_RoundTrips() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var monitors = new Monitors();
+        uint original = monitors.GetBackgroundColor();
+        uint newColor = original == 0xFF0000u ? 0x00FF00u : 0xFF0000u;
+
+        monitors.SetBackgroundColor(newColor);
+        uint roundTrip = monitors.GetBackgroundColor();
+        monitors.SetBackgroundColor(original);
+
+        Assert.AreEqual(newColor, roundTrip);
+    }
+}

--- a/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
@@ -80,5 +80,23 @@ public class MonitorFallbackTests {
 
         Assert.AreEqual(newPos, roundTrip);
     }
+
+    [TestMethod]
+    public void SetAndGetBackgroundColor_FallsBackToRegistry() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var service = new MonitorService(new FailingDesktopManager());
+        uint original = service.GetBackgroundColor();
+        uint newColor = original == 0xFFFFFFu ? 0x0000FFu : 0xFFFFFFu;
+
+        service.SetBackgroundColor(newColor);
+        uint roundTrip = service.GetBackgroundColor();
+
+        service.SetBackgroundColor(original);
+
+        Assert.AreEqual(newColor, roundTrip);
+    }
 }
 

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -125,6 +125,22 @@ public class Monitors {
     }
 
     /// <summary>
+    /// Gets the desktop background color.
+    /// </summary>
+    /// <returns>The background color as RGB value.</returns>
+    public uint GetBackgroundColor() {
+        return _monitorService.GetBackgroundColor();
+    }
+
+    /// <summary>
+    /// Sets the desktop background color.
+    /// </summary>
+    /// <param name="color">Color as RGB value.</param>
+    public void SetBackgroundColor(uint color) {
+        _monitorService.SetBackgroundColor(color);
+    }
+
+    /// <summary>
     /// Gets the bounds of a monitor by its ID.
     /// </summary>
     /// <param name="monitorId">The ID of the monitor.</param>

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -14,4 +14,12 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Restore-DesktopWindowLayout' {
         Get-Command Restore-DesktopWindowLayout | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Get-DesktopBackgroundColor' {
+        Get-Command Get-DesktopBackgroundColor | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Set-DesktopBackgroundColor' {
+        Get-Command Set-DesktopBackgroundColor | Should -Not -BeNullOrEmpty
+    }
 }

--- a/Tests/DesktopBackgroundColor.Tests.ps1
+++ b/Tests/DesktopBackgroundColor.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Desktop background color cmdlets' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/..\DesktopManager.psd1" -Force
+    }
+
+    It 'Supports WhatIf for Set-DesktopBackgroundColor' {
+        { Set-DesktopBackgroundColor -Color 0x123456 -WhatIf } | Should -Not -Throw
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+        It 'Returns a UInt32 from Get-DesktopBackgroundColor' {
+            $color = Get-DesktopBackgroundColor
+            $color.GetType().FullName | Should -Be 'System.UInt32'
+        }
+    } else {
+        It 'Get-DesktopBackgroundColor throws on non-Windows' {
+            { Get-DesktopBackgroundColor } | Should -Throw -ExceptionType System.PlatformNotSupportedException
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add background color wrappers in MonitorService
- expose color helpers in Monitors
- add Get-DesktopBackgroundColor and Set-DesktopBackgroundColor cmdlets
- document background color cmdlets
- update module exports and README
- ensure cmdlets exported in tests

## Testing
- `dotnet build Sources/DesktopManager.sln`
- `pwsh DesktopManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6853ffe46e5c832eac05029dd1be2393