### PR TITLE
Add stream and URL support for wallpapers

### DIFF
--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -43,6 +43,7 @@
       <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
       <PackageReference Include="System.Drawing.Common" Version="8.0.17" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace DesktopManager;
 
 /// <summary>
@@ -65,6 +67,24 @@ public class Monitors {
     }
 
     /// <summary>
+    /// Sets the wallpaper for a specific monitor using image data.
+    /// </summary>
+    /// <param name="monitorId">The ID of the monitor.</param>
+    /// <param name="imageStream">Stream containing image data.</param>
+    public void SetWallpaper(string monitorId, Stream imageStream) {
+        _monitorService.SetWallpaper(monitorId, imageStream);
+    }
+
+    /// <summary>
+    /// Sets the wallpaper for a specific monitor from a URL.
+    /// </summary>
+    /// <param name="monitorId">The ID of the monitor.</param>
+    /// <param name="url">URL pointing to the image.</param>
+    public void SetWallpaperFromUrl(string monitorId, string url) {
+        _monitorService.SetWallpaperFromUrl(monitorId, url);
+    }
+
+    /// <summary>
     /// Sets the wallpaper for a specific monitor by its index.
     /// </summary>
     /// <param name="index">The index of the monitor.</param>
@@ -74,11 +94,45 @@ public class Monitors {
     }
 
     /// <summary>
+    /// Sets the wallpaper for a monitor by its index using image data.
+    /// </summary>
+    /// <param name="index">The index of the monitor.</param>
+    /// <param name="imageStream">Stream containing image data.</param>
+    public void SetWallpaper(int index, Stream imageStream) {
+        _monitorService.SetWallpaper(index, imageStream);
+    }
+
+    /// <summary>
+    /// Sets the wallpaper for a monitor by its index from a URL.
+    /// </summary>
+    /// <param name="index">The index of the monitor.</param>
+    /// <param name="url">URL pointing to the image.</param>
+    public void SetWallpaperFromUrl(int index, string url) {
+        _monitorService.SetWallpaperFromUrl(index, url);
+    }
+
+    /// <summary>
     /// Sets the wallpaper for all monitors.
     /// </summary>
     /// <param name="wallpaperPath">The file path of the wallpaper image.</param>
     public void SetWallpaper(string wallpaperPath) {
         _monitorService.SetWallpaper(wallpaperPath);
+    }
+
+    /// <summary>
+    /// Sets the wallpaper for all monitors using image data.
+    /// </summary>
+    /// <param name="imageStream">Stream containing image data.</param>
+    public void SetWallpaper(Stream imageStream) {
+        _monitorService.SetWallpaper(imageStream);
+    }
+
+    /// <summary>
+    /// Sets the wallpaper for all monitors from a URL.
+    /// </summary>
+    /// <param name="url">URL pointing to the image.</param>
+    public void SetWallpaperFromUrl(string url) {
+        _monitorService.SetWallpaperFromUrl(url);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add HttpClient reference
- allow MonitorService to set wallpapers from streams and URLs
- expose new SetWallpaper helpers in Monitors class
- update cmdlet Set-DesktopWallpaper with -Url and -ImageData support

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.sln -c Release` *(fails: Could not find 'mono' host)*
- `pwsh ./DesktopManager.Tests.ps1` *(fails: Could not load module)*

------
https://chatgpt.com/codex/tasks/task_e_6854295f9030832ead5c0f4e4b286b99