### PR TITLE
Add FakeDesktopManager and unit tests

### DIFF
--- a/Sources/DesktopManager.Tests/FakeDesktopManager.cs
+++ b/Sources/DesktopManager.Tests/FakeDesktopManager.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+internal class FakeDesktopManager : IDesktopManager {
+    public List<(string id, string path)> SetWallpaperCalls = new();
+    public List<string> GetWallpaperIds = new();
+    public Dictionary<uint, string> DevicePaths = new();
+    public uint DevicePathCount = 1;
+    public uint BackgroundColor;
+    public DesktopWallpaperPosition WallpaperPosition;
+    public List<IntPtr> SetSlideshowCalls = new();
+    public DesktopSlideshowDirection LastAdvanceDirection;
+    public bool EnableCalled;
+
+    public void SetWallpaper(string monitorId, string wallpaper) => SetWallpaperCalls.Add((monitorId, wallpaper));
+
+    public string GetWallpaper(string monitorId) {
+        GetWallpaperIds.Add(monitorId);
+        return "wall";
+    }
+
+    public string GetMonitorDevicePathAt(uint monitorIndex) => DevicePaths.TryGetValue(monitorIndex, out var path) ? path : string.Empty;
+
+    public uint GetMonitorDevicePathCount() => DevicePathCount;
+
+    public RECT GetMonitorBounds(string monitorId) => new() { Left = 0, Top = 0, Right = 10, Bottom = 10 };
+
+    public void SetBackgroundColor(uint color) => BackgroundColor = color;
+
+    public uint GetBackgroundColor() => BackgroundColor;
+
+    public void SetPosition(DesktopWallpaperPosition position) => WallpaperPosition = position;
+
+    public DesktopWallpaperPosition GetPosition() => WallpaperPosition;
+
+    public void SetSlideshow(IntPtr items) => SetSlideshowCalls.Add(items);
+
+    public IntPtr GetSlideshow() => IntPtr.Zero;
+
+    public void SetSlideshowOptions(DesktopSlideshowDirection options, uint slideshowTick) { }
+
+    public uint GetSlideshowOptions(out DesktopSlideshowDirection options, out uint slideshowTick) {
+        options = DesktopSlideshowDirection.Forward;
+        slideshowTick = 0;
+        return 0;
+    }
+
+    public void AdvanceSlideshow(string monitorId, DesktopSlideshowDirection direction) => LastAdvanceDirection = direction;
+
+    public DesktopSlideshowDirection GetStatus() => DesktopSlideshowDirection.Forward;
+
+    public bool Enable() { EnableCalled = true; return true; }
+}

--- a/Sources/DesktopManager.Tests/MonitorServiceTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorServiceTests {
+    [TestMethod]
+    public void Constructor_CallsEnable() {
+        var fake = new FakeDesktopManager();
+        _ = new MonitorService(fake);
+        Assert.IsTrue(fake.EnableCalled);
+    }
+
+    [TestMethod]
+    public void SetWallpaper_ForwardsCall() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.SetWallpaper("mon", "wall");
+        Assert.AreEqual(("mon", "wall"), fake.SetWallpaperCalls[0]);
+    }
+
+    [TestMethod]
+    public void GetWallpaper_ForwardsCall() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        var result = service.GetWallpaper("m");
+        Assert.AreEqual("wall", result);
+        Assert.AreEqual("m", fake.GetWallpaperIds[0]);
+    }
+
+    [TestMethod]
+    public void SetWallpaper_ByIndex_UsesDevicePath() {
+        var fake = new FakeDesktopManager();
+        fake.DevicePaths[0] = "dev";
+        var service = new MonitorService(fake);
+        service.SetWallpaper(0, "w");
+        Assert.AreEqual(("dev", "w"), fake.SetWallpaperCalls[0]);
+    }
+    [TestMethod]
+    public void SetWallpaper_ByIndex_MissingPathUsesEmptyString() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.SetWallpaper(1, "img");
+        Assert.AreEqual(("", "img"), fake.SetWallpaperCalls[0]);
+    }
+
+
+    [TestMethod]
+    public void SetWallpaper_FromStream_DeletesTempFile() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        using var ms = new MemoryStream(new byte[] {1,2,3});
+        service.SetWallpaper("mon", ms);
+        string path = fake.SetWallpaperCalls[0].path;
+        Assert.IsFalse(File.Exists(path));
+    }
+
+    [TestMethod]
+    public void SetWallpaper_StreamNull_Throws() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        Assert.ThrowsException<NullReferenceException>(() => service.SetWallpaper("id", (Stream)null));
+    }
+
+    [TestMethod]
+    public void SetWallpaper_FromUrl_InvalidSchemeThrows() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        string temp = Path.GetTempFileName();
+        File.WriteAllBytes(temp, new byte[] {1});
+        try {
+            Assert.ThrowsException<NotSupportedException>(() => service.SetWallpaperFromUrl("m", new Uri(temp).AbsoluteUri));
+        } finally {
+            File.Delete(temp);
+        }
+    }
+
+    [TestMethod]
+    public void GetWallpaper_ByIndex_ForwardsCall() {
+        var fake = new FakeDesktopManager();
+        fake.DevicePaths[0] = "d";
+        var service = new MonitorService(fake);
+        var res = service.GetWallpaper(0);
+        Assert.AreEqual("wall", res);
+        Assert.AreEqual("d", fake.GetWallpaperIds[0]);
+    }
+
+    [TestMethod]
+    public void SetWallpaperPosition_Forwards() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.SetWallpaperPosition(DesktopWallpaperPosition.Span);
+        Assert.AreEqual(DesktopWallpaperPosition.Span, fake.WallpaperPosition);
+    }
+
+    [TestMethod]
+    public void GetWallpaperPosition_Forwards() {
+        var fake = new FakeDesktopManager();
+        fake.WallpaperPosition = DesktopWallpaperPosition.Tile;
+        var service = new MonitorService(fake);
+        Assert.AreEqual(DesktopWallpaperPosition.Tile, service.GetWallpaperPosition());
+    }
+
+    [TestMethod]
+    public void SetBackgroundColor_Forwards() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.SetBackgroundColor(5);
+        Assert.AreEqual((uint)5, fake.BackgroundColor);
+    }
+
+    [TestMethod]
+    public void GetBackgroundColor_Forwards() {
+        var fake = new FakeDesktopManager { BackgroundColor = 7 };
+        var service = new MonitorService(fake);
+        Assert.AreEqual((uint)7, service.GetBackgroundColor());
+    }
+
+    [TestMethod]
+    public void StopWallpaperSlideshow_CallsSetSlideshowWithZero() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.StopWallpaperSlideshow();
+        Assert.AreEqual(IntPtr.Zero, fake.SetSlideshowCalls[0]);
+    }
+
+    [TestMethod]
+    public void AdvanceWallpaperSlide_ForwardsDirection() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        service.AdvanceWallpaperSlide(DesktopSlideshowDirection.Backward);
+        Assert.AreEqual(DesktopSlideshowDirection.Backward, fake.LastAdvanceDirection);
+    }
+
+    [TestMethod]
+    public void StartWallpaperSlideshow_ThrowsOnNull() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        Assert.ThrowsException<ArgumentNullException>(() => service.StartWallpaperSlideshow(null));
+    }
+
+    [TestMethod]
+    public void GetMonitorDevicePathAt_Forwards() {
+        var fake = new FakeDesktopManager();
+        fake.DevicePaths[0] = "xx";
+        var service = new MonitorService(fake);
+        Assert.AreEqual("xx", service.GetMonitorDevicePathAt(0));
+    }
+
+    [TestMethod]
+    public void GetMonitorBounds_Forwards() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        var rect = service.GetMonitorBounds("id");
+        Assert.AreEqual(10, rect.Right);
+    }
+}

--- a/Sources/DesktopManager.Tests/MonitorTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorTests {
+    private static void SetId(Monitor m, string id) {
+        typeof(Monitor).GetProperty("DeviceId")!.SetValue(m, id);
+    }
+
+    [TestMethod]
+    public void SetWallpaper_ForwardsCall() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        var monitor = new Monitor(service);
+        SetId(monitor, "id");
+
+        monitor.SetWallpaper("path");
+
+        Assert.AreEqual(1, fake.SetWallpaperCalls.Count);
+        Assert.AreEqual(("id", "path"), fake.SetWallpaperCalls[0]);
+    }
+
+    [TestMethod]
+    public void GetWallpaper_ForwardsCallAndReturnsValue() {
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+        var monitor = new Monitor(service);
+        SetId(monitor, "x");
+
+        string result = monitor.GetWallpaper();
+
+        Assert.AreEqual(1, fake.GetWallpaperIds.Count);
+        Assert.AreEqual("x", fake.GetWallpaperIds[0]);
+        Assert.AreEqual("wall", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `FakeDesktopManager` test helper
- create new `MonitorServiceTests` and `MonitorTests`
- cover 20 scenarios with the fake desktop manager

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68546dde6150832e8cfea3b6063241e2