### PR TITLE
Improve monitor not found exception messages

### DIFF
--- a/Docs/Invoke-DesktopScreenshot.md
+++ b/Docs/Invoke-DesktopScreenshot.md
@@ -16,7 +16,7 @@ Invoke-DesktopScreenshot [-Path <String>] [-Index <Int32>] [-DeviceId <String>] 
 ```
 
 ## DESCRIPTION
-The **Invoke-DesktopScreenshot** cmdlet captures the current desktop image. When a path is specified, the screenshot is saved as a PNG file. Otherwise a `System.Drawing.Bitmap` object is returned. You can target a single monitor by index, device ID or device name, limit capture to the primary monitor, or capture an arbitrary region of the desktop.
+The **Invoke-DesktopScreenshot** cmdlet captures the current desktop image. When a path is specified, the screenshot is saved as a PNG file. Otherwise a `System.Drawing.Bitmap` object is returned. You can target a single monitor by index, device ID or device name, limit capture to the primary monitor, or capture an arbitrary region of the desktop. If no monitor matches the provided *DeviceId* or *DeviceName*, an `ArgumentException` is thrown and the message includes the identifier that was requested.
 
 ## PARAMETERS
 ### -Path

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -224,7 +224,7 @@ public partial class MonitorService {
                 return new MonitorPosition(monitor.Rect.Left, monitor.Rect.Top, monitor.Rect.Right, monitor.Rect.Bottom);
             }
         }
-        throw new ArgumentException("Monitor not found");
+        throw new ArgumentException($"Monitor with device ID '{deviceId}' not found");
     }
 
     /// <summary>
@@ -285,7 +285,7 @@ public partial class MonitorService {
             deviceNum++;
         }
 
-        throw new ArgumentException("Corresponding display device not found for the given Monitor ID.");
+        throw new ArgumentException($"Corresponding display device not found for monitor ID '{deviceId}'.");
     }
 
     /// <summary>

--- a/Sources/DesktopManager/ScreenshotService.cs
+++ b/Sources/DesktopManager/ScreenshotService.cs
@@ -39,7 +39,12 @@ public static class ScreenshotService {
         Monitors monitors = new();
         var monitor = monitors.GetMonitors(index: index, deviceId: deviceId, deviceName: deviceName).FirstOrDefault();
         if (monitor == null) {
-            throw new ArgumentException("Monitor not found");
+            string requested = !string.IsNullOrEmpty(deviceId)
+                ? $"DeviceId '{deviceId}'"
+                : !string.IsNullOrEmpty(deviceName)
+                    ? $"DeviceName '{deviceName}'"
+                    : "the specified criteria";
+            throw new ArgumentException($"Monitor not found for {requested}");
         }
 
         var rect = monitor.GetMonitorBounds();


### PR DESCRIPTION
## Summary
- show device identifier in monitor not found exceptions
- document monitor lookup failure behavior in the screenshot help

## Testing
- `pwsh -File DesktopManager.Tests.ps1` *(fails: Expected modules missing)*
- `dotnet test Sources/DesktopManager.sln` *(fails: mono host not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c84fc498832ebe774c90d82a1a9a