### PR TITLE
Fix wallpaper download URI validation

### DIFF
--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -44,8 +44,13 @@ public partial class MonitorService {
     /// <param name="monitorId">The monitor ID.</param>
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(string monitorId, string url) {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
+            throw new NotSupportedException($"Invalid wallpaper URL '{url}'. Only HTTP and HTTPS schemes are supported.");
+        }
+
         using HttpClient client = new();
-        using Stream stream = client.GetStreamAsync(url).GetAwaiter().GetResult();
+        using Stream stream = client.GetStreamAsync(uri).GetAwaiter().GetResult();
         SetWallpaper(monitorId, stream);
     }
 
@@ -120,8 +125,13 @@ public partial class MonitorService {
     /// </summary>
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(string url) {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
+            throw new NotSupportedException($"Invalid wallpaper URL '{url}'. Only HTTP and HTTPS schemes are supported.");
+        }
+
         using HttpClient client = new();
-        using Stream stream = client.GetStreamAsync(url).GetAwaiter().GetResult();
+        using Stream stream = client.GetStreamAsync(uri).GetAwaiter().GetResult();
         SetWallpaper(stream);
     }
 


### PR DESCRIPTION
## Summary
- validate wallpaper URLs using `Uri.TryCreate`
- add clear error messages when URL validation fails

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8749dc8832eb3383f4b5d0082ad