### PR TITLE
Handle invalid layout JSON

### DIFF
--- a/Examples/SaveRestoreWindowLayout.ps1
+++ b/Examples/SaveRestoreWindowLayout.ps1
@@ -6,4 +6,4 @@ Save-DesktopWindowLayout -Path './layout.json'
 # ... move windows around ...
 
 # Restore saved layout
-Restore-DesktopWindowLayout -Path './layout.json'
+Restore-DesktopWindowLayout -Path './layout.json' -Validate

--- a/README.MD
+++ b/README.MD
@@ -233,7 +233,7 @@ MonitorWatcherExample.Run(TimeSpan.FromSeconds(30));
 ```powershell
 Save-DesktopWindowLayout -Path './layout.json'
 # ... move windows around ...
-Restore-DesktopWindowLayout -Path './layout.json'
+Restore-DesktopWindowLayout -Path './layout.json' -Validate
 ```
 
 #### Example in C# - Saving and Restoring Window Layout
@@ -242,5 +242,5 @@ Restore-DesktopWindowLayout -Path './layout.json'
 var manager = new WindowManager();
 manager.SaveLayout("layout.json");
 // ... move windows around ...
-manager.LoadLayout("layout.json");
+manager.LoadLayout("layout.json", validate: true);
 ```

--- a/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRestoreDesktopWindowLayout.cs
@@ -13,12 +13,18 @@ public sealed class CmdletRestoreDesktopWindowLayout : PSCmdlet {
     public string Path { get; set; }
 
     /// <summary>
+    /// <para type="description">Validate layout before applying.</para>
+    /// </summary>
+    [Parameter()]
+    public SwitchParameter Validate { get; set; }
+
+    /// <summary>
     /// Begin processing.
     /// </summary>
     protected override void BeginProcessing() {
         var manager = new WindowManager();
         if (ShouldProcess(Path, "Restore window layout")) {
-            manager.LoadLayout(Path);
+            manager.LoadLayout(Path, Validate.IsPresent);
         }
     }
 }

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -31,4 +31,40 @@ public class WindowLayoutTests {
 
         System.IO.File.Delete(path);
     }
+
+    [TestMethod]
+    public void LoadLayout_InvalidJson_Throws() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var path = System.IO.Path.GetTempFileName();
+        System.IO.File.WriteAllText(path, "{ invalid }");
+
+        Assert.ThrowsException<InvalidOperationException>(() => manager.LoadLayout(path));
+
+        System.IO.File.Delete(path);
+    }
+
+    [TestMethod]
+    public void LoadLayout_ValidateMissingProperties_Throws() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var path = System.IO.Path.GetTempFileName();
+        var json = "{\"Windows\":[{\"Title\":\"Test\"}]}";
+        System.IO.File.WriteAllText(path, json);
+
+        Assert.ThrowsException<System.IO.InvalidDataException>(() => manager.LoadLayout(path, validate: true));
+
+        System.IO.File.Delete(path);
+    }
 }


### PR DESCRIPTION
## Summary
- catch JsonException in layout loader
- add validation option for required layout fields
- expose `-Validate` switch in PowerShell cmdlet
- document validation usage
- add basic tests for invalid layout scenarios

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release -f net8.0`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Output Detailed"` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6855c856cd78832ea3ba30c81bd349d5