### PR TITLE
Add unit tests for data classes and wildcard helper

### DIFF
--- a/Sources/DesktopManager.Tests/DisplayDeviceInfoTests.cs
+++ b/Sources/DesktopManager.Tests/DisplayDeviceInfoTests.cs
@@ -1,0 +1,18 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class DisplayDeviceInfoTests {
+    [TestMethod]
+    public void Constructor_SetsProperties() {
+        var device = new DISPLAY_DEVICE { cb = 1, DeviceName = "Name" };
+        var rect = new RECT { Left = 1, Top = 2, Right = 3, Bottom = 4 };
+
+        var info = new DisplayDeviceInfo(device, rect);
+
+        Assert.AreEqual(device, info.DisplayDevice);
+        Assert.AreEqual(rect, info.Bounds);
+    }
+}
+

--- a/Sources/DesktopManager.Tests/MonitorBoundsTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorBoundsTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorBoundsTests {
+    [TestMethod]
+    public void Constructor_SetsFields() {
+        var rect = new RECT { Left = 1, Top = 2, Right = 3, Bottom = 4 };
+
+        var bounds = new MonitorBounds(rect);
+
+        Assert.AreEqual(1, bounds.Left);
+        Assert.AreEqual(2, bounds.Top);
+        Assert.AreEqual(3, bounds.Right);
+        Assert.AreEqual(4, bounds.Bottom);
+    }
+}
+

--- a/Sources/DesktopManager.Tests/MonitorServiceAdditionalTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceAdditionalTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorServiceAdditionalTests {
+    [TestMethod]
+    public void GetMonitorPosition_ThrowsWhenMonitorMissing() {
+        var service = new MonitorService(new FakeDesktopManager());
+        Assert.ThrowsException<ArgumentException>(() => service.GetMonitorPosition("missing"));
+    }
+
+    [TestMethod]
+    public void GetMonitorsConnected_ReturnsEmptyWhenNoDeviceIds() {
+        var fake = new FakeDesktopManager { DevicePathCount = 2 };
+        var service = new MonitorService(fake);
+
+        var result = service.GetMonitorsConnected();
+
+        Assert.AreEqual(0, result.Count);
+    }
+}
+

--- a/Sources/DesktopManager.Tests/WindowManagerWildcardTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerWildcardTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowManagerWildcardTests {
+    private static bool InvokeMatches(string text, string pattern) {
+        var manager = (WindowManager)FormatterServices.GetUninitializedObject(typeof(WindowManager));
+        var method = typeof(WindowManager).GetMethod("MatchesWildcard", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (bool)method.Invoke(manager, new object[] { text, pattern });
+    }
+
+    [TestMethod]
+    public void MatchesWildcard_BasicPatterns() {
+        Assert.IsTrue(InvokeMatches("hello", "*"));
+        Assert.IsTrue(InvokeMatches("hello", "h*"));
+        Assert.IsTrue(InvokeMatches("hello", "*lo"));
+        Assert.IsTrue(InvokeMatches("hello", "he*lo"));
+        Assert.IsTrue(InvokeMatches("hello", "ell"));
+        Assert.IsFalse(InvokeMatches("hello", "abc*"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for `DisplayDeviceInfo` and `MonitorBounds`
- add MonitorService tests for missing cases
- exercise private wildcard matcher in `WindowManager`

## Testing
- `dotnet test Sources/DesktopManager.sln -c Release` *(fails: NU1100 Unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_68564bfc6de0832eb0a00173343c9b91