### PR TITLE
Fix PrimaryOnly parameter type

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopScreenshot.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopScreenshot.cs
@@ -41,7 +41,7 @@ public sealed class CmdletInvokeDesktopScreenshot : PSCmdlet {
     /// <para type="description">Capture the primary monitor only.</para>
     /// </summary>
     [Parameter(Mandatory = false)]
-    public SwitchParameter? PrimaryOnly;
+    public SwitchParameter PrimaryOnly;
 
     /// <summary>
     /// <para type="description">Left coordinate of the region to capture.</para>

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopBrightness.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopBrightness.cs
@@ -31,7 +31,7 @@ public sealed class CmdletSetDesktopBrightness : PSCmdlet {
     /// <para type="description">Set brightness for the primary monitor only.</para>
     /// </summary>
     [Parameter(Mandatory = false, Position = 3, ParameterSetName = "PrimaryOnly")]
-    public SwitchParameter? PrimaryOnly;
+    public SwitchParameter PrimaryOnly;
 
     /// <summary>
     /// <para type="description">Brightness level to set.</para>

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopPosition.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopPosition.cs
@@ -42,7 +42,7 @@ public sealed class CmdletSetDesktopPosition : PSCmdlet {
     /// <para type="description">Set the position for the primary monitor only.</para>
     /// </summary>
     [Parameter(Mandatory = false, Position = 3, ParameterSetName = "PrimaryOnly")]
-    public SwitchParameter? PrimaryOnly;
+    public SwitchParameter PrimaryOnly;
 
     /// <summary>
     /// <para type="description">The left position of the monitor.</para>

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopResolution.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopResolution.cs
@@ -31,7 +31,7 @@ public sealed class CmdletSetDesktopResolution : PSCmdlet {
     /// <para type="description">Set resolution for the primary monitor only.</para>
     /// </summary>
     [Parameter(Mandatory = false, Position = 3, ParameterSetName = "PrimaryOnly")]
-    public SwitchParameter? PrimaryOnly;
+    public SwitchParameter PrimaryOnly;
 
     /// <summary>
     /// <para type="description">Resolution width.</para>

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
@@ -51,7 +51,7 @@ public sealed class CmdletSetDesktopWallpaper : PSCmdlet {
     /// <para type="description">Set the wallpaper for the primary monitor only.</para>
     /// </summary>
     [Parameter(Mandatory = false, Position = 4, ParameterSetName = "Index")]
-    public SwitchParameter? PrimaryOnly;
+    public SwitchParameter PrimaryOnly;
 
     /// <summary>
     /// <para type="description">Set the wallpaper for all monitors.</para>


### PR DESCRIPTION
## Summary
- use plain `SwitchParameter` for `PrimaryOnly`
- apply change across screenshot and desktop-setting cmdlets

## Testing
- `dotnet test Sources/DesktopManager.sln --no-build --verbosity minimal`
- `pwsh -File DesktopManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6856506cd8e8832ebe47271d45760bd4