### PR TITLE
Improve error handling in MonitorService

### DIFF
--- a/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
+++ b/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class ErrorHandlingTests {
+    [TestMethod]
+    public void DeleteTempFile_NoThrowOnMissingFile() {
+        var method = typeof(MonitorService).GetMethod("DeleteTempFile", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        method.Invoke(null, new object?[] { System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString()) });
+    }
+
+    [TestMethod]
+    public void FallbackMethods_DoNotThrow() {
+        var service = new MonitorService(new FakeDesktopManager());
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires non-Windows platform to trigger fallback exceptions.");
+        }
+        typeof(MonitorService).GetMethod("GetWallpaperPositionFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, null);
+        typeof(MonitorService).GetMethod("SetWallpaperPositionFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, new object?[] { DesktopWallpaperPosition.Center });
+        typeof(MonitorService).GetMethod("GetBackgroundColorFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, null);
+        typeof(MonitorService).GetMethod("SetBackgroundColorFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, new object?[] { 0u });
+    }
+}

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -115,7 +115,8 @@ public partial class MonitorService {
     private static void DeleteTempFile(string path) {
         try {
             File.Delete(path);
-        } catch {
+        } catch (Exception ex) {
+            Console.WriteLine($"DeleteTempFile failed: {ex.Message}");
         }
     }
 
@@ -137,7 +138,8 @@ public partial class MonitorService {
                     _ => DesktopWallpaperPosition.Center
                 };
             }
-        } catch {
+        } catch (Exception ex) {
+            Console.WriteLine($"GetWallpaperPositionFallback failed: {ex.Message}");
         }
         return DesktopWallpaperPosition.Center;
     }
@@ -174,7 +176,8 @@ public partial class MonitorService {
                 }
                 SetSystemWallpaper(GetSystemWallpaper());
             }
-        } catch {
+        } catch (Exception ex) {
+            Console.WriteLine($"SetWallpaperPositionFallback failed: {ex.Message}");
         }
     }
 
@@ -193,7 +196,8 @@ public partial class MonitorService {
                     }
                 }
             }
-        } catch {
+        } catch (Exception ex) {
+            Console.WriteLine($"GetBackgroundColorFallback failed: {ex.Message}");
         }
         return 0;
     }
@@ -207,7 +211,8 @@ public partial class MonitorService {
                 byte b = (byte)((color >> 16) & 0xFF);
                 key.SetValue("Background", $"{r} {g} {b}");
             }
-        } catch {
+        } catch (Exception ex) {
+            Console.WriteLine($"SetBackgroundColorFallback failed: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- log errors in monitor registry fallback helpers
- add unit tests for error handling

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Debug -f net8.0`
- `pwsh -NoProfile -c ./DesktopManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6856508f9c68832ea26098fa612b8d58