### PR TITLE
Add screenshot and window management tests

### DIFF
--- a/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
+++ b/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class ScreenshotServiceTests {
+    [TestMethod]
+    public void CaptureRegion_InvalidDimensions_Throws() {
+        Assert.ThrowsException<ArgumentException>(() => ScreenshotService.CaptureRegion(0, 0, 0, 0));
+    }
+
+    [TestMethod]
+    public void CaptureScreen_ReturnsBitmap() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var bmp = ScreenshotService.CaptureScreen();
+        Assert.IsNotNull(bmp);
+        Assert.IsTrue(bmp.Width > 0);
+        Assert.IsTrue(bmp.Height > 0);
+    }
+
+    [TestMethod]
+    public void CaptureMonitor_InvalidIndex_Throws() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        Assert.ThrowsException<ArgumentException>(() => ScreenshotService.CaptureMonitor(index: 999));
+    }
+
+    [TestMethod]
+    public void CaptureMonitor_ByIndex_ReturnsBitmap() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var bmp = ScreenshotService.CaptureMonitor(index: 0);
+        Assert.IsNotNull(bmp);
+        Assert.IsTrue(bmp.Width > 0);
+        Assert.IsTrue(bmp.Height > 0);
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
+++ b/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WindowActivationPositioningTests {
+    [TestMethod]
+    public void SetWindowPosition_ResizesWindow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var original = manager.GetWindowPosition(window);
+
+        int newWidth = original.Width + 10;
+        int newHeight = original.Height + 10;
+        manager.SetWindowPosition(window, original.Left, original.Top, newWidth, newHeight);
+        var resized = manager.GetWindowPosition(window);
+
+        Assert.AreEqual(newWidth, resized.Width);
+        Assert.AreEqual(newHeight, resized.Height);
+
+        manager.SetWindowPosition(window, original.Left, original.Top, original.Width, original.Height);
+    }
+
+    [TestMethod]
+    public void ActivateWindow_InvalidHandle_Throws() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var dummy = new WindowInfo { Handle = IntPtr.Zero };
+        Assert.ThrowsException<InvalidOperationException>(() => manager.ActivateWindow(dummy));
+    }
+}


### PR DESCRIPTION
## Summary
- test negative dimensions in ScreenshotService
- test CaptureScreen, CaptureMonitor
- test SetWindowPosition resizing and ActivateWindow error

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --no-build --framework net8.0 --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6856507542f4832eab8c2def12ec4f4a