### PR TITLE
Handle temp file cleanup on errors

### DIFF
--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -107,9 +107,14 @@ public partial class MonitorService {
 
     private static string WriteStreamToTempFile(Stream stream) {
         string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        using FileStream fs = File.Create(path);
-        stream.CopyTo(fs);
-        return path;
+        try {
+            using FileStream fs = File.Create(path);
+            stream.CopyTo(fs);
+            return path;
+        } catch {
+            DeleteTempFile(path);
+            throw;
+        }
     }
 
     private static void DeleteTempFile(string path) {


### PR DESCRIPTION
## Summary
- ensure temporary files are deleted when `WriteStreamToTempFile` or `SetWallpaper` fail
- add regression tests covering failures in both stages

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Debug -f net8.0 -v n`

------
https://chatgpt.com/codex/tasks/task_e_68569f78f894832e9404dbab5f7d8e9c