### PR TITLE
Enforce exclusive monitor parameters

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopBrightness.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopBrightness.cs
@@ -54,10 +54,6 @@ public sealed class CmdletSetDesktopBrightness : PSCmdlet {
         string deviceId = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceId)) ? DeviceId : null;
         string deviceName = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceName)) ? DeviceName : null;
 
-        if (index != null && (deviceId != null || deviceName != null)) {
-            var ex = new ArgumentException("-Index cannot be combined with -DeviceId or -DeviceName.");
-            ThrowTerminatingError(new ErrorRecord(ex, "ParameterConflict", ErrorCategory.InvalidArgument, null));
-        }
 
         var getMonitors = monitors.GetMonitors(connectedOnly: null, primaryOnly: primaryOnly, index: index, deviceId: deviceId, deviceName: deviceName);
         foreach (var monitor in getMonitors) {

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaper.cs
@@ -136,10 +136,6 @@ public sealed class CmdletSetDesktopWallpaper : PSCmdlet {
         string deviceId = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceId)) ? DeviceId : null;
         string deviceName = MyInvocation.BoundParameters.ContainsKey(nameof(DeviceName)) ? DeviceName : null;
 
-        if (index != null && (deviceId != null || deviceName != null)) {
-            var ex = new ArgumentException("-Index cannot be combined with -DeviceId or -DeviceName.");
-            ThrowTerminatingError(new ErrorRecord(ex, "ParameterConflict", ErrorCategory.InvalidArgument, null));
-        }
 
         Monitors monitors = new Monitors();
         string target = hasPath ? WallpaperPath : hasUrl ? Url : "<stream>";

--- a/Tests/Brightness.Tests.ps1
+++ b/Tests/Brightness.Tests.ps1
@@ -12,5 +12,15 @@ describe 'Brightness cmdlets' {
     it 'supports WhatIf for Set-DesktopBrightness' -Skip:(-not $IsWindows) {
         { Set-DesktopBrightness -Index 0 -Brightness 50 -WhatIf } | Should -Not -Throw
     }
+
+    It 'Throws when using Index with DeviceId' -Skip:(-not $IsWindows) {
+        { Set-DesktopBrightness -Index 0 -DeviceId 'Dummy' -Brightness 50 } |
+            Should -Throw -ErrorId 'AmbiguousParameterSet,DesktopManager.PowerShell.CmdletSetDesktopBrightness'
+    }
+
+    It 'Throws when using Index with DeviceName' -Skip:(-not $IsWindows) {
+        { Set-DesktopBrightness -Index 0 -DeviceName 'Dummy' -Brightness 50 } |
+            Should -Throw -ErrorId 'AmbiguousParameterSet,DesktopManager.PowerShell.CmdletSetDesktopBrightness'
+    }
 }
 


### PR DESCRIPTION
## Summary
- enforce mutual exclusivity with parameter sets and remove redundant checks
- cover Set-DesktopBrightness with validation tests

## Testing
- `dotnet build Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj -c Debug`
- `Invoke-Pester -Output Detailed -Path Tests/SetDesktopWallpaper.Tests.ps1,Tests/Brightness.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68569f8245ac832e898bc9edfa0caadd