### PR TITLE
Add display orientation & resolution watcher events

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -220,6 +220,13 @@ Use `Register-DesktopMonitorEvent` to react when monitors are plugged in or the 
 Register-DesktopMonitorEvent -Duration 30 -Action { Write-Host 'Display settings changed' }
 ```
 
+Use `Register-DesktopOrientationEvent` or `Register-DesktopResolutionEvent` to handle orientation or resolution changes individually.
+
+```powershell
+Register-DesktopResolutionEvent -Duration 30 -Action { Write-Host 'Resolution changed' }
+Register-DesktopOrientationEvent -Duration 30 -Action { Write-Host 'Orientation changed' }
+```
+
 #### Example in C# - Monitoring Display Changes
 
 Applications can subscribe to the `MonitorWatcher.DisplaySettingsChanged` event.

--- a/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopOrientationEvent.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopOrientationEvent.cs
@@ -1,0 +1,49 @@
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+using System;
+using System.Management.Automation;
+using System.Timers;
+using System.Runtime.Versioning;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Registers for desktop orientation change events.</summary>
+/// <para type="synopsis">Registers for desktop orientation change events.</para>
+/// <para type="description">Subscribes to orientation changes and returns the event subscription.</para>
+/// <example>
+///   <summary>Monitor orientation changes for five minutes</summary>
+///   <code>Register-DesktopOrientationEvent -Duration (New-TimeSpan -Minutes 5)</code>
+/// </example>
+[Cmdlet(VerbsLifecycle.Register, "DesktopOrientationEvent")]
+[SupportedOSPlatform("windows")]
+public sealed class CmdletRegisterDesktopOrientationEvent : PSCmdlet {
+    /// <summary>
+    /// <para type="description">The script block to run when the event is raised.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public ScriptBlock Action { get; set; }
+
+    /// <summary>
+    /// <para type="description">The duration to monitor before automatically unregistering.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>Begin processing.</summary>
+    protected override void BeginProcessing() {
+        var watcher = new MonitorWatcher();
+        var subscriber = Events.SubscribeEvent(watcher, nameof(MonitorWatcher.OrientationChanged), "MonitorWatcher", null, Action, true, false);
+        WriteObject(subscriber);
+
+        if (Duration > TimeSpan.Zero) {
+            var timer = new Timer(Duration.TotalMilliseconds) { AutoReset = false };
+            timer.Elapsed += (_, _) => {
+                Events.UnsubscribeEvent(subscriber);
+                watcher.Dispose();
+                timer.Dispose();
+            };
+            timer.Start();
+        }
+    }
+}
+
+#endif

--- a/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopResolutionEvent.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletRegisterDesktopResolutionEvent.cs
@@ -1,0 +1,49 @@
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+using System;
+using System.Management.Automation;
+using System.Timers;
+using System.Runtime.Versioning;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Registers for desktop resolution change events.</summary>
+/// <para type="synopsis">Registers for desktop resolution change events.</para>
+/// <para type="description">Subscribes to resolution changes and returns the event subscription.</para>
+/// <example>
+///   <summary>Monitor resolution changes for five minutes</summary>
+///   <code>Register-DesktopResolutionEvent -Duration (New-TimeSpan -Minutes 5)</code>
+/// </example>
+[Cmdlet(VerbsLifecycle.Register, "DesktopResolutionEvent")]
+[SupportedOSPlatform("windows")]
+public sealed class CmdletRegisterDesktopResolutionEvent : PSCmdlet {
+    /// <summary>
+    /// <para type="description">The script block to run when the event is raised.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public ScriptBlock Action { get; set; }
+
+    /// <summary>
+    /// <para type="description">The duration to monitor before automatically unregistering.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public TimeSpan Duration { get; set; }
+
+    /// <summary>Begin processing.</summary>
+    protected override void BeginProcessing() {
+        var watcher = new MonitorWatcher();
+        var subscriber = Events.SubscribeEvent(watcher, nameof(MonitorWatcher.ResolutionChanged), "MonitorWatcher", null, Action, true, false);
+        WriteObject(subscriber);
+
+        if (Duration > TimeSpan.Zero) {
+            var timer = new Timer(Duration.TotalMilliseconds) { AutoReset = false };
+            timer.Elapsed += (_, _) => {
+                Events.UnsubscribeEvent(subscriber);
+                watcher.Dispose();
+                timer.Dispose();
+            };
+            timer.Start();
+        }
+    }
+}
+
+#endif

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
+using System.Collections.Generic;
 
 namespace DesktopManager;
 
@@ -17,6 +18,26 @@ public sealed class MonitorWatcher : IDisposable {
     public event EventHandler DisplaySettingsChanged;
 
     /// <summary>
+    /// Raised when monitor orientation changes.
+    /// </summary>
+    public event EventHandler OrientationChanged;
+
+    /// <summary>
+    /// Raised when monitor resolution changes.
+    /// </summary>
+    public event EventHandler ResolutionChanged;
+
+    private const int ENUM_CURRENT_SETTINGS = -1;
+
+    private Dictionary<string, MonitorState> _state = new();
+
+    private struct MonitorState {
+        public int Width;
+        public int Height;
+        public int Orientation;
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MonitorWatcher"/> class.
     /// </summary>
     /// <exception cref="PlatformNotSupportedException">Thrown when not running on Windows.</exception>
@@ -25,11 +46,60 @@ public sealed class MonitorWatcher : IDisposable {
             throw new PlatformNotSupportedException("MonitorWatcher is supported only on Windows.");
         }
 
+        _state = GetCurrentStates();
         SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
     }
 
     private void OnDisplaySettingsChanged(object sender, EventArgs e) {
+        var current = GetCurrentStates();
+        bool orientationChanged = false;
+        bool resolutionChanged = false;
+
+        foreach (var item in current) {
+            if (_state.TryGetValue(item.Key, out var prev)) {
+                if (prev.Orientation != item.Value.Orientation) {
+                    orientationChanged = true;
+                }
+                if (prev.Width != item.Value.Width || prev.Height != item.Value.Height) {
+                    resolutionChanged = true;
+                }
+            } else {
+                orientationChanged = true;
+                resolutionChanged = true;
+            }
+        }
+
+        _state = current;
+
         DisplaySettingsChanged?.Invoke(this, EventArgs.Empty);
+        if (orientationChanged) {
+            OrientationChanged?.Invoke(this, EventArgs.Empty);
+        }
+        if (resolutionChanged) {
+            ResolutionChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private Dictionary<string, MonitorState> GetCurrentStates() {
+        Dictionary<string, MonitorState> states = new();
+        DISPLAY_DEVICE device = new();
+        device.cb = Marshal.SizeOf(device);
+        uint index = 0;
+        while (MonitorNativeMethods.EnumDisplayDevices(null, index, ref device, 0)) {
+            if ((device.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) != 0) {
+                DEVMODE mode = new();
+                mode.dmSize = (short)Marshal.SizeOf<DEVMODE>();
+                if (MonitorNativeMethods.EnumDisplaySettings(device.DeviceName, ENUM_CURRENT_SETTINGS, ref mode)) {
+                    states[device.DeviceName] = new MonitorState {
+                        Width = mode.dmPelsWidth,
+                        Height = mode.dmPelsHeight,
+                        Orientation = mode.dmDisplayOrientation
+                    };
+                }
+            }
+            index++;
+        }
+        return states;
     }
 
     /// <summary>

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -22,4 +22,12 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Set-DesktopBackgroundColor' {
         Get-Command Set-DesktopBackgroundColor | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Register-DesktopOrientationEvent' {
+        Get-Command Register-DesktopOrientationEvent | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Register-DesktopResolutionEvent' {
+        Get-Command Register-DesktopResolutionEvent | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## Summary
- watch for resolution and orientation changes
- expose Register-DesktopOrientationEvent and Register-DesktopResolutionEvent
- document new event cmdlets
- test module exports for new events

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release --framework net8.0 --no-build --verbosity normal`
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569fa7a4f8832eb0101e39b8648601