### PR TITLE
Add async SetWallpaperFromUrl methods

### DIFF
--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Win32;
 
 namespace DesktopManager;
@@ -47,13 +48,17 @@ public partial class MonitorService {
     /// <param name="monitorId">The monitor ID.</param>
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(string monitorId, string url) {
+        SetWallpaperFromUrlAsync(monitorId, url).GetAwaiter().GetResult();
+    }
+
+    public async Task SetWallpaperFromUrlAsync(string monitorId, string url) {
         if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
             throw new NotSupportedException($"Invalid wallpaper URL '{url}'. Only HTTP and HTTPS schemes are supported.");
         }
 
         using HttpClient client = new();
-        using Stream stream = client.GetStreamAsync(uri).GetAwaiter().GetResult();
+        using Stream stream = await client.GetStreamAsync(uri);
         SetWallpaper(monitorId, stream);
     }
 
@@ -89,8 +94,12 @@ public partial class MonitorService {
     /// <param name="index">The index of the monitor.</param>
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(int index, string url) {
+        SetWallpaperFromUrlAsync(index, url).GetAwaiter().GetResult();
+    }
+
+    public async Task SetWallpaperFromUrlAsync(int index, string url) {
         var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
-        SetWallpaperFromUrl(monitorId, url);
+        await SetWallpaperFromUrlAsync(monitorId, url);
     }
 
     /// <summary>
@@ -131,13 +140,17 @@ public partial class MonitorService {
     /// </summary>
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(string url) {
+        SetWallpaperFromUrlAsync(url).GetAwaiter().GetResult();
+    }
+
+    public async Task SetWallpaperFromUrlAsync(string url) {
         if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)) {
             throw new NotSupportedException($"Invalid wallpaper URL '{url}'. Only HTTP and HTTPS schemes are supported.");
         }
 
         using HttpClient client = new();
-        using Stream stream = client.GetStreamAsync(uri).GetAwaiter().GetResult();
+        using Stream stream = await client.GetStreamAsync(uri);
         SetWallpaper(stream);
     }
 

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 
 namespace DesktopManager;
 
@@ -84,6 +85,10 @@ public class Monitors {
         _monitorService.SetWallpaperFromUrl(monitorId, url);
     }
 
+    public Task SetWallpaperFromUrlAsync(string monitorId, string url) {
+        return _monitorService.SetWallpaperFromUrlAsync(monitorId, url);
+    }
+
     /// <summary>
     /// Sets the wallpaper for a specific monitor by its index.
     /// </summary>
@@ -111,6 +116,10 @@ public class Monitors {
         _monitorService.SetWallpaperFromUrl(index, url);
     }
 
+    public Task SetWallpaperFromUrlAsync(int index, string url) {
+        return _monitorService.SetWallpaperFromUrlAsync(index, url);
+    }
+
     /// <summary>
     /// Sets the wallpaper for all monitors.
     /// </summary>
@@ -133,6 +142,10 @@ public class Monitors {
     /// <param name="url">URL pointing to the image.</param>
     public void SetWallpaperFromUrl(string url) {
         _monitorService.SetWallpaperFromUrl(url);
+    }
+
+    public Task SetWallpaperFromUrlAsync(string url) {
+        return _monitorService.SetWallpaperFromUrlAsync(url);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add async variants of `SetWallpaperFromUrl`
- keep synchronous wrappers for backward compatibility

## Testing
- `dotnet test Sources/DesktopManager.sln --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path Tests -CI -PassThru`

------
https://chatgpt.com/codex/tasks/task_e_6857fb120228832ea578196f08a63580