### PR TITLE
Implement standard dispose pattern for MonitorWatcher

### DIFF
--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -30,6 +30,7 @@ public sealed class MonitorWatcher : IDisposable {
     private const int ENUM_CURRENT_SETTINGS = -1;
 
     private Dictionary<string, MonitorState> _state = new();
+    private bool _disposed;
 
     private struct MonitorState {
         public int Width;
@@ -106,8 +107,19 @@ public sealed class MonitorWatcher : IDisposable {
     /// Unsubscribes from system events.
     /// </summary>
     public void Dispose() {
-        SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+        Dispose(true);
         GC.SuppressFinalize(this);
+    }
+
+    ~MonitorWatcher() {
+        Dispose(false);
+    }
+
+    private void Dispose(bool disposing) {
+        if (!_disposed) {
+            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+            _disposed = true;
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- follow standard dispose pattern in `MonitorWatcher`
- add finalizer to call `Dispose(false)`

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0 --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68597610d378832eb3effc5cefff80b5