### PR TITLE
Add test for invalid handle in GetWindowPosition

### DIFF
--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -51,5 +52,16 @@ public class WindowPositionTests {
         manager.SetWindowPosition(window, original.Left, original.Top);
 
         Assert.AreEqual(indexBefore, indexAfterMove);
+    }
+
+    [TestMethod]
+    public void GetWindowPosition_InvalidHandle_Throws() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var dummy = new WindowInfo { Handle = IntPtr.Zero };
+        Assert.ThrowsException<InvalidOperationException>(() => manager.GetWindowPosition(dummy));
     }
 }


### PR DESCRIPTION
## Summary
- add an invalid-handle test for `GetWindowPosition`

## Testing
- `dotnet build Sources/DesktopManager.sln`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --no-build --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_685975f0cd7c832ea803f47e96512e32