### PR TITLE
Fix SaveLayout path resolution and add relative path test

### DIFF
--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -67,4 +67,31 @@ public class WindowLayoutTests {
 
         System.IO.File.Delete(path);
     }
+
+    [TestMethod]
+    public void SaveLayout_RelativePath_CreatesFile() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString());
+        System.IO.Directory.CreateDirectory(tempDir);
+        var originalDir = System.Environment.CurrentDirectory;
+        System.Environment.CurrentDirectory = tempDir;
+        try {
+            var relative = System.IO.Path.Combine("sub", "layout.json");
+            manager.SaveLayout(relative);
+            var fullPath = System.IO.Path.Combine(tempDir, relative);
+            Assert.IsTrue(System.IO.File.Exists(fullPath));
+        } finally {
+            System.Environment.CurrentDirectory = originalDir;
+            System.IO.Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -285,7 +285,12 @@ namespace DesktopManager {
             };
             var json = System.Text.Json.JsonSerializer.Serialize(layout,
                 new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-            System.IO.File.WriteAllText(path, json);
+            var fullPath = System.IO.Path.GetFullPath(path);
+            var directory = System.IO.Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory)) {
+                System.IO.Directory.CreateDirectory(directory);
+            }
+            System.IO.File.WriteAllText(fullPath, json);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure SaveLayout resolves relative paths and creates directories
- test that SaveLayout can write using relative paths

## Testing
- `dotnet test Sources/DesktopManager.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685975e31df4832e9e35fa3ba60df6bf