### PR TITLE
Add window snapping feature

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowSnap', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowSnap.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowSnap.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell {
+    /// <summary>Snaps a desktop window to a predefined position.</summary>
+    /// <para type="synopsis">Snaps a desktop window to a predefined position.</para>
+    /// <example>
+    ///   <para>Snap Notepad to the left half of the screen</para>
+    ///   <code>Set-DesktopWindowSnap -Name "*Notepad*" -Position Left</code>
+    /// </example>
+    [Cmdlet(VerbsCommon.Set, "DesktopWindowSnap", SupportsShouldProcess = true)]
+    public class CmdletSetDesktopWindowSnap : PSCmdlet {
+        /// <summary>
+        /// <para type="description">The window title to snap. Supports wildcards.</para>
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// <para type="description">The snap position.</para>
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 1)]
+        public SnapPosition Position { get; set; }
+
+        /// <summary>
+        /// Begin processing.
+        /// </summary>
+        protected override void BeginProcessing() {
+            var manager = new WindowManager();
+            var windows = manager.GetWindows(Name);
+            foreach (var window in windows) {
+                if (ShouldProcess($"Window '{window.Title}'", $"Snap {Position}")) {
+                    try {
+                        manager.SnapWindow(window, Position);
+                    } catch (Exception ex) {
+                        WriteWarning($"Failed to snap window '{window.Title}': {ex.Message}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager/SnapPosition.cs
+++ b/Sources/DesktopManager/SnapPosition.cs
@@ -1,0 +1,20 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Specifies a window snap position relative to the monitor.
+/// </summary>
+public enum SnapPosition
+{
+    /// <summary>Snap to the left half of the monitor.</summary>
+    Left,
+    /// <summary>Snap to the right half of the monitor.</summary>
+    Right,
+    /// <summary>Snap to the upper‑left quarter of the monitor.</summary>
+    TopLeft,
+    /// <summary>Snap to the upper‑right quarter of the monitor.</summary>
+    TopRight,
+    /// <summary>Snap to the lower‑left quarter of the monitor.</summary>
+    BottomLeft,
+    /// <summary>Snap to the lower‑right quarter of the monitor.</summary>
+    BottomRight
+}

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -170,6 +170,66 @@ namespace DesktopManager {
         }
 
         /// <summary>
+        /// Snaps a window to a predefined region of its monitor.
+        /// </summary>
+        /// <param name="window">The window to snap.</param>
+        /// <param name="position">The snap position.</param>
+        public void SnapWindow(WindowInfo window, SnapPosition position) {
+            if (window == null) {
+                throw new ArgumentNullException(nameof(window));
+            }
+
+            var monitor = _monitors.GetMonitors(index: window.MonitorIndex).FirstOrDefault();
+            if (monitor == null) {
+                monitor = _monitors.GetMonitors(primaryOnly: true).FirstOrDefault();
+                if (monitor == null) {
+                    throw new InvalidOperationException("No monitor found for snapping");
+                }
+            }
+
+            var bounds = monitor.GetMonitorBounds();
+            int monitorWidth = bounds.Right - bounds.Left;
+            int monitorHeight = bounds.Bottom - bounds.Top;
+
+            int width = monitorWidth;
+            int height = monitorHeight;
+            int left = bounds.Left;
+            int top = bounds.Top;
+
+            switch (position) {
+                case SnapPosition.Left:
+                    width = monitorWidth / 2;
+                    break;
+                case SnapPosition.Right:
+                    width = monitorWidth / 2;
+                    left += monitorWidth / 2;
+                    break;
+                case SnapPosition.TopLeft:
+                    width = monitorWidth / 2;
+                    height = monitorHeight / 2;
+                    break;
+                case SnapPosition.TopRight:
+                    width = monitorWidth / 2;
+                    height = monitorHeight / 2;
+                    left += monitorWidth / 2;
+                    break;
+                case SnapPosition.BottomLeft:
+                    width = monitorWidth / 2;
+                    height = monitorHeight / 2;
+                    top += monitorHeight / 2;
+                    break;
+                case SnapPosition.BottomRight:
+                    width = monitorWidth / 2;
+                    height = monitorHeight / 2;
+                    left += monitorWidth / 2;
+                    top += monitorHeight / 2;
+                    break;
+            }
+
+            SetWindowPosition(window, left, top, width, height);
+        }
+
+        /// <summary>
         /// Moves the specified window to the target monitor while preserving its relative position.
         /// </summary>
         /// <param name="windowInfo">The window to move.</param>


### PR DESCRIPTION
## Summary
- implement `SnapWindow` API for snapping windows to monitor regions
- add `SnapPosition` enum
- expose new PowerShell cmdlet `Set-DesktopWindowSnap`
- export cmdlet in module manifest

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.sln -c Release` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_685afa87afbc832e9a4155def1e80df9