### PR TITLE
Persist window state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Sources/*/bin
 Sources/*/*/obj
 Sources/*/*/bin
 Sources/packages/*
+dotnet-install.sh
+packages-microsoft-prod.deb

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Runtime.InteropServices;
+using DesktopManager;
 
 namespace DesktopManager.Tests;
 
@@ -19,15 +20,22 @@ public class WindowLayoutTests {
 
         var window = windows.First();
         var original = manager.GetWindowPosition(window);
+        var originalState = original.State;
         var path = System.IO.Path.GetTempFileName();
 
         manager.SaveLayout(path);
         manager.SetWindowPosition(window, original.Left + 20, original.Top + 20);
+        if (originalState == WindowState.Maximize) {
+            manager.MinimizeWindow(window);
+        } else {
+            manager.MaximizeWindow(window);
+        }
         manager.LoadLayout(path);
         var restored = manager.GetWindowPosition(window);
 
         Assert.AreEqual(original.Left, restored.Left);
         Assert.AreEqual(original.Top, restored.Top);
+        Assert.AreEqual(originalState, restored.State);
 
         System.IO.File.Delete(path);
     }

--- a/Sources/DesktopManager/WindowInfo.cs
+++ b/Sources/DesktopManager/WindowInfo.cs
@@ -81,8 +81,4 @@ public class WindowInfo {
 /// Represents the position and size information of a window.
 /// </summary>
 public class WindowPosition : WindowInfo {
-    /// <summary>
-    /// Gets or sets the state of the window when the layout was saved.
-    /// </summary>
-    public new WindowState? State { get; set; }
 }

--- a/Sources/DesktopManager/WindowInfo.cs
+++ b/Sources/DesktopManager/WindowInfo.cs
@@ -81,4 +81,8 @@ public class WindowInfo {
 /// Represents the position and size information of a window.
 /// </summary>
 public class WindowPosition : WindowInfo {
+    /// <summary>
+    /// Gets or sets the state of the window when the layout was saved.
+    /// </summary>
+    public new WindowState? State { get; set; }
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -334,6 +334,8 @@ namespace DesktopManager {
             foreach (var target in layout.Windows) {
                 var window = current.FirstOrDefault(w => w.ProcessId == target.ProcessId && w.Title == target.Title);
                 if (window != null) {
+                    // restore window to allow repositioning
+                    RestoreWindow(window);
                     SetWindowPosition(window, target.Left, target.Top, target.Width, target.Height);
                     if (target.State.HasValue) {
                         switch (target.State.Value) {
@@ -344,7 +346,7 @@ namespace DesktopManager {
                                 MaximizeWindow(window);
                                 break;
                             case WindowState.Normal:
-                                RestoreWindow(window);
+                                // already restored above
                                 break;
                             case WindowState.Close:
                                 CloseWindow(window);

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -118,7 +118,8 @@ namespace DesktopManager {
                     Left = rect.Left,
                     Top = rect.Top,
                     Right = rect.Right,
-                    Bottom = rect.Bottom
+                    Bottom = rect.Bottom,
+                    State = windowInfo.State
                 };
             }
             throw new InvalidOperationException("Failed to get window position");
@@ -339,6 +340,7 @@ namespace DesktopManager {
                                 CloseWindow(window);
                                 break;
                         }
+                        window.State = target.State;
                     }
                 }
             }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -111,6 +111,16 @@ namespace DesktopManager {
         public WindowPosition GetWindowPosition(WindowInfo windowInfo) {
             RECT rect = new RECT();
             if (MonitorNativeMethods.GetWindowRect(windowInfo.Handle, out rect)) {
+                // Re-evaluate the current state directly from the window to avoid stale data
+                IntPtr stylePtr = MonitorNativeMethods.GetWindowLongPtr(windowInfo.Handle, MonitorNativeMethods.GWL_STYLE);
+                int style = unchecked((int)(long)stylePtr);
+                var state = WindowState.Normal;
+                if ((style & MonitorNativeMethods.WS_MINIMIZE) != 0) {
+                    state = WindowState.Minimize;
+                } else if ((style & MonitorNativeMethods.WS_MAXIMIZE) != 0) {
+                    state = WindowState.Maximize;
+                }
+
                 return new WindowPosition {
                     Title = windowInfo.Title,
                     Handle = windowInfo.Handle,
@@ -119,7 +129,7 @@ namespace DesktopManager {
                     Top = rect.Top,
                     Right = rect.Right,
                     Bottom = rect.Bottom,
-                    State = windowInfo.State
+                    State = state
                 };
             }
             throw new InvalidOperationException("Failed to get window position");


### PR DESCRIPTION
## Summary
- add new `State` property to `WindowPosition`
- include window state when capturing window positions
- ensure layout loading updates the window state
- test layout persistence of window state

## Testing
- `dotnet build Sources/DesktopManager/DesktopManager.csproj`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj` *(fails for `net472` due to missing `mono`, but `net8.0` tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_685afaa140b0832e80f5da855267c70e