### PR TITLE
Add wallpaper history cmdlets

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow', 'Get-DesktopWallpaperHistory', 'Set-DesktopWallpaperHistory')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PowerShell.Tests/WallpaperHistory.Tests.ps1
+++ b/PowerShell.Tests/WallpaperHistory.Tests.ps1
@@ -1,0 +1,15 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../DesktopManager.psd1" -Force
+}
+
+describe 'Wallpaper history cmdlets' {
+    it 'exports Get-DesktopWallpaperHistory' {
+        Get-Command Get-DesktopWallpaperHistory | Should -Not -BeNullOrEmpty
+    }
+    it 'exports Set-DesktopWallpaperHistory' {
+        Get-Command Set-DesktopWallpaperHistory | Should -Not -BeNullOrEmpty
+    }
+    it 'supports clearing history' {
+        { Set-DesktopWallpaperHistory -Clear -WhatIf } | Should -Not -Throw
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletGetDesktopWallpaperHistory.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetDesktopWallpaperHistory.cs
@@ -1,0 +1,17 @@
+
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Returns stored wallpaper history.</summary>
+[Cmdlet(VerbsCommon.Get, "DesktopWallpaperHistory")]
+public sealed class CmdletGetDesktopWallpaperHistory : PSCmdlet
+{
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing()
+    {
+        List<string> history = WallpaperHistory.GetHistory();
+        WriteObject(history, true);
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaperHistory.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaperHistory.cs
@@ -1,0 +1,32 @@
+
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Updates wallpaper history file.</summary>
+[Cmdlet(VerbsCommon.Set, "DesktopWallpaperHistory", SupportsShouldProcess = true, DefaultParameterSetName = "Paths")]
+public sealed class CmdletSetDesktopWallpaperHistory : PSCmdlet
+{
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Paths")]
+    public string[] WallpaperPath { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Clear")]
+    public SwitchParameter Clear { get; set; }
+
+    protected override void BeginProcessing()
+    {
+        if (Clear.IsPresent)
+        {
+            if (ShouldProcess("Wallpaper history", "Clear"))
+            {
+                WallpaperHistory.SetHistory(Array.Empty<string>());
+            }
+        }
+        else
+        {
+            if (ShouldProcess("Wallpaper history", "Set entries"))
+            {
+                WallpaperHistory.SetHistory(WallpaperPath);
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class WallpaperHistoryTests
+{
+    [TestMethod]
+    public void AddEntry_WritesFile()
+    {
+        var temp = Path.GetTempFileName();
+        Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", temp);
+        try
+        {
+            WallpaperHistory.SetHistory(Array.Empty<string>());
+            WallpaperHistory.AddEntry("wall1");
+            var history = WallpaperHistory.GetHistory();
+            Assert.AreEqual(1, history.Count);
+            Assert.AreEqual("wall1", history.First());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", null);
+            if (File.Exists(temp))
+            {
+                File.Delete(temp);
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -23,6 +23,7 @@ public partial class MonitorService {
         } catch (COMException) {
             SetSystemWallpaper(wallpaperPath);
         }
+        WallpaperHistory.AddEntry(wallpaperPath);
     }
 
     /// <summary>
@@ -60,6 +61,7 @@ public partial class MonitorService {
         using HttpClient client = new();
         using Stream stream = await client.GetStreamAsync(uri);
         SetWallpaper(monitorId, stream);
+        WallpaperHistory.AddEntry(url);
     }
 
     /// <summary>
@@ -76,6 +78,7 @@ public partial class MonitorService {
         } catch (COMException) {
             SetSystemWallpaper(wallpaperPath);
         }
+        WallpaperHistory.AddEntry(wallpaperPath);
     }
 
     /// <summary>
@@ -100,6 +103,7 @@ public partial class MonitorService {
     public async Task SetWallpaperFromUrlAsync(int index, string url) {
         var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
         await SetWallpaperFromUrlAsync(monitorId, url);
+        WallpaperHistory.AddEntry(url);
     }
 
     /// <summary>
@@ -117,6 +121,7 @@ public partial class MonitorService {
         } catch (COMException) {
             SetSystemWallpaper(wallpaperPath);
         }
+        WallpaperHistory.AddEntry(wallpaperPath);
     }
 
     /// <summary>
@@ -152,6 +157,7 @@ public partial class MonitorService {
         using HttpClient client = new();
         using Stream stream = await client.GetStreamAsync(uri);
         SetWallpaper(stream);
+        WallpaperHistory.AddEntry(url);
     }
 
     /// <summary>

--- a/Sources/DesktopManager/WallpaperHistory.cs
+++ b/Sources/DesktopManager/WallpaperHistory.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace DesktopManager;
+
+public static class WallpaperHistory
+{
+    private static readonly object _lock = new();
+
+    private static string HistoryFilePath =>
+        Environment.GetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH") ??
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "DesktopManager", "wallpaper-history.json");
+
+    public static List<string> GetHistory()
+    {
+        lock (_lock)
+        {
+            if (!File.Exists(HistoryFilePath))
+            {
+                return new List<string>();
+            }
+            try
+            {
+                string json = File.ReadAllText(HistoryFilePath);
+                var history = JsonSerializer.Deserialize<List<string>>(json);
+                return history ?? new List<string>();
+            }
+            catch (JsonException)
+            {
+                return new List<string>();
+            }
+        }
+    }
+
+    public static void SetHistory(IEnumerable<string> paths)
+    {
+        lock (_lock)
+        {
+            string? dir = Path.GetDirectoryName(HistoryFilePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            string json = JsonSerializer.Serialize(paths);
+            File.WriteAllText(HistoryFilePath, json);
+        }
+    }
+
+    public static void AddEntry(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+        lock (_lock)
+        {
+            var history = GetHistory();
+            history.Remove(path);
+            history.Insert(0, path);
+            SetHistory(history);
+        }
+    }
+}

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -30,4 +30,10 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Register-DesktopResolutionEvent' {
         Get-Command Register-DesktopResolutionEvent | Should -Not -BeNullOrEmpty
     }
+    It 'Exports Get-DesktopWallpaperHistory' {
+        Get-Command Get-DesktopWallpaperHistory | Should -Not -BeNullOrEmpty
+    }
+    It 'Exports Set-DesktopWallpaperHistory' {
+        Get-Command Set-DesktopWallpaperHistory | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## Summary
- track wallpaper paths in a JSON file
- add cmdlets to view/set wallpaper history
- update module manifest
- test wallpaper history functionality in MSTest and Pester

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.sln -c Release` *(fails: Could not find 'mono' host)*
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: Expected cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afadb0690832ebfe14e6355ebe07a