### PR TITLE
Add documentation for wallpaper history cmdlet

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaperHistory.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWallpaperHistory.cs
@@ -4,27 +4,29 @@ namespace DesktopManager.PowerShell;
 
 /// <summary>Updates wallpaper history file.</summary>
 [Cmdlet(VerbsCommon.Set, "DesktopWallpaperHistory", SupportsShouldProcess = true, DefaultParameterSetName = "Paths")]
-public sealed class CmdletSetDesktopWallpaperHistory : PSCmdlet
-{
+public sealed class CmdletSetDesktopWallpaperHistory : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Array of wallpaper file paths to store in the history file.</para>
+    /// </summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Paths")]
     public string[] WallpaperPath { get; set; }
 
+    /// <summary>
+    /// <para type="description">Clear existing wallpaper history entries.</para>
+    /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = "Clear")]
     public SwitchParameter Clear { get; set; }
 
-    protected override void BeginProcessing()
-    {
-        if (Clear.IsPresent)
-        {
-            if (ShouldProcess("Wallpaper history", "Clear"))
-            {
+    /// <summary>
+    /// Begin processing the command by writing or clearing wallpaper history entries.
+    /// </summary>
+    protected override void BeginProcessing() {
+        if (Clear.IsPresent) {
+            if (ShouldProcess("Wallpaper history", "Clear")) {
                 WallpaperHistory.SetHistory(Array.Empty<string>());
             }
-        }
-        else
-        {
-            if (ShouldProcess("Wallpaper history", "Set entries"))
-            {
+        } else {
+            if (ShouldProcess("Wallpaper history", "Set entries")) {
                 WallpaperHistory.SetHistory(WallpaperPath);
             }
         }


### PR DESCRIPTION
## Summary
- add XML comments for `WallpaperPath` and `Clear` properties
- document the `BeginProcessing` method in `CmdletSetDesktopWallpaperHistory`

## Testing
- `dotnet build Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj -c Debug`
- `pwsh DesktopManager.Tests.ps1` *(fails: Get-DesktopWallpaperHistory not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_685ba9b4b9c8832ebad2ae945d26b311