### PR TITLE
Limit wallpaper history

### DIFF
--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -30,4 +30,28 @@ public class WallpaperHistoryTests
             }
         }
     }
+
+    [TestMethod]
+    public void AddEntry_EnforcesMaximum()
+    {
+        var temp = Path.GetTempFileName();
+        Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", temp);
+        try
+        {
+            WallpaperHistory.SetHistory(Enumerable.Range(0, 60).Select(i => $"wall{i}"));
+            WallpaperHistory.AddEntry("new");
+            var history = WallpaperHistory.GetHistory();
+            Assert.AreEqual(50, history.Count);
+            Assert.AreEqual("new", history.First());
+            Assert.AreEqual("wall48", history.Last());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", null);
+            if (File.Exists(temp))
+            {
+                File.Delete(temp);
+            }
+        }
+    }
 }

--- a/Sources/DesktopManager/WallpaperHistory.cs
+++ b/Sources/DesktopManager/WallpaperHistory.cs
@@ -19,6 +19,9 @@ public static class WallpaperHistory
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "DesktopManager", "wallpaper-history.json");
 
+    /// <summary>Maximum number of entries persisted in history.</summary>
+    private const int MaxEntries = 50;
+
     /// <summary>
     /// Reads the wallpaper history from the persistent storage.
     /// </summary>
@@ -65,6 +68,7 @@ public static class WallpaperHistory
     /// <summary>
     /// Adds the specified path to the history placing it at the top.
     /// If the path already exists it is moved to the first position.
+    /// The history is truncated to <see cref="MaxEntries"/> items.
     /// </summary>
     /// <param name="path">The wallpaper file path to record.</param>
     public static void AddEntry(string path)
@@ -78,6 +82,10 @@ public static class WallpaperHistory
             var history = GetHistory();
             history.Remove(path);
             history.Insert(0, path);
+            if (history.Count > MaxEntries)
+            {
+                history.RemoveRange(MaxEntries, history.Count - MaxEntries);
+            }
             SetHistory(history);
         }
     }


### PR DESCRIPTION
## Summary
- cap wallpaper history at 50 entries and truncate accordingly
- add regression test for the new limit

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --verbosity minimal --framework net8.0`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --no-build --verbosity minimal --framework net472` *(fails: Could not find 'mono' host)*
- `pwsh ./DesktopManager.Tests.ps1` *(fails: CommandNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6864cc0937dc832e89382402f26ad361