### PR TITLE
Handle missing monitors in screenshot capture

### DIFF
--- a/Docs/Invoke-DesktopScreenshot.md
+++ b/Docs/Invoke-DesktopScreenshot.md
@@ -16,7 +16,7 @@ Invoke-DesktopScreenshot [-Path <String>] [-Index <Int32>] [-DeviceId <String>] 
 ```
 
 ## DESCRIPTION
-The **Invoke-DesktopScreenshot** cmdlet captures the current desktop image. When a path is specified, the screenshot is saved as a PNG file. Otherwise a `System.Drawing.Bitmap` object is returned. You can target a single monitor by index, device ID or device name, limit capture to the primary monitor, or capture an arbitrary region of the desktop. If no monitor matches the provided *DeviceId* or *DeviceName*, an `ArgumentException` is thrown and the message includes the identifier that was requested.
+The **Invoke-DesktopScreenshot** cmdlet captures the current desktop image. When a path is specified, the screenshot is saved as a PNG file. Otherwise a `System.Drawing.Bitmap` object is returned. You can target a single monitor by index, device ID or device name, limit capture to the primary monitor, or capture an arbitrary region of the desktop. If no monitor matches the provided *DeviceId* or *DeviceName*, an `ArgumentException` is thrown and the message includes the identifier that was requested. If no monitors are detected on the system, an `InvalidOperationException` is thrown.
 
 ## PARAMETERS
 ### -Path

--- a/Sources/DesktopManager/ScreenshotService.cs
+++ b/Sources/DesktopManager/ScreenshotService.cs
@@ -18,7 +18,12 @@ public static class ScreenshotService {
     public static Bitmap CaptureScreen() {
         Monitors monitors = new();
         var rects = monitors.GetMonitors(connectedOnly: true)
-                            .Select(m => m.GetMonitorBounds());
+                            .Select(m => m.GetMonitorBounds())
+                            .ToList();
+
+        if (!rects.Any()) {
+            throw new InvalidOperationException("No monitors detected");
+        }
 
         int left = rects.Min(r => r.Left);
         int top = rects.Min(r => r.Top);


### PR DESCRIPTION
## Summary
- throw `InvalidOperationException` when capturing the screen without any monitors
- document the new behavior

## Testing
- `dotnet build Sources/DesktopManager.sln`
- `dotnet test Sources/DesktopManager.sln --no-build` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_6864cbf87254832ebc3df9b331534879