### PR TITLE
Use MAX_PATH constant

### DIFF
--- a/Sources/DesktopManager/MonitorNativeMethods.Shell.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Shell.cs
@@ -44,6 +44,11 @@ public static partial class MonitorNativeMethods
     public const uint SPIF_UPDATEINIFILE = 0x0001;
 
     /// <summary>
+    /// Maximum length of a Windows file path.
+    /// </summary>
+    public const int MAX_PATH = 260;
+
+    /// <summary>
     /// Broadcasts the WM_SETTINGCHANGE message after updating the user profile.
     /// </summary>
     public const uint SPIF_SENDWININICHANGE = 0x0002;

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -98,7 +98,7 @@ public partial class MonitorService {
     }
 
     private string GetSystemWallpaper() {
-        StringBuilder sb = new StringBuilder(260);
+        StringBuilder sb = new StringBuilder(MonitorNativeMethods.MAX_PATH);
         if (MonitorNativeMethods.SystemParametersInfo(MonitorNativeMethods.SPI_GETDESKWALLPAPER, (uint)sb.Capacity, sb, 0)) {
             return sb.ToString();
         }


### PR DESCRIPTION
## Summary
- define `MAX_PATH` constant for Windows paths
- use `MAX_PATH` when retrieving the current wallpaper

## Testing
- `dotnet build Sources/DesktopManager.sln --configuration Release`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0 --no-build --verbosity normal` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_6864cc0392bc832ea12e021bb386d61d