### PR TITLE
Fix window move condition

### DIFF
--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -159,7 +159,7 @@ namespace DesktopManager {
             int flags = MonitorNativeMethods.SWP_NOZORDER;
 
             // If position is -1, don't move
-            if (left < 0 && top < 0) {
+            if (left == -1 && top == -1) {
                 flags |= SWP_NOMOVE;
             }
 
@@ -171,8 +171,8 @@ namespace DesktopManager {
             if (!MonitorNativeMethods.SetWindowPos(
                 windowInfo.Handle,
                 IntPtr.Zero,
-                left < 0 ? windowInfo.Left : left,
-                top < 0 ? windowInfo.Top : top,
+                left == -1 ? windowInfo.Left : left,
+                top == -1 ? windowInfo.Top : top,
                 width < 0 ? windowInfo.Width : width,
                 height < 0 ? windowInfo.Height : height,
                 flags)) {


### PR DESCRIPTION
## Summary
- move windows only when left and top aren't -1

## Testing
- `dotnet build Sources/DesktopManager.sln --configuration Release --no-restore`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0 --no-restore --logger "trx;LogFileName=test-results.trx" --results-directory TestResults --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6864cbeac6c0832e9f479e6fee4e7ce9