### PR TITLE
Add summary docs for tests and examples

### DIFF
--- a/Sources/DesktopManager.Example/MonitorWatcherExample.cs
+++ b/Sources/DesktopManager.Example/MonitorWatcherExample.cs
@@ -3,6 +3,9 @@ using System.Threading.Tasks;
 
 namespace DesktopManager.Example;
 
+/// <summary>
+/// Example class MonitorWatcherExample.
+/// </summary>
 internal static class MonitorWatcherExample {
     /// <summary>
     /// Runs the monitor watcher example for the specified duration.

--- a/Sources/DesktopManager.Example/ResolutionOrientationDemo.cs
+++ b/Sources/DesktopManager.Example/ResolutionOrientationDemo.cs
@@ -2,6 +2,9 @@ using System.Linq;
 
 namespace DesktopManager.Example;
 
+/// <summary>
+/// Example class ResolutionOrientationDemo.
+/// </summary>
 internal static class ResolutionOrientationDemo {
     /// <summary>
     /// Demonstrates changing resolution and orientation on the first monitor.

--- a/Sources/DesktopManager.Tests/BackgroundColorTests.cs
+++ b/Sources/DesktopManager.Tests/BackgroundColorTests.cs
@@ -3,8 +3,14 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for BackgroundColorTests.
+/// </summary>
 public class BackgroundColorTests {
     [TestMethod]
+    /// <summary>
+    /// Test for SetAndGetBackgroundColor_RoundTrips.
+    /// </summary>
     public void SetAndGetBackgroundColor_RoundTrips() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/DisplayDeviceInfoTests.cs
+++ b/Sources/DesktopManager.Tests/DisplayDeviceInfoTests.cs
@@ -3,8 +3,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for DisplayDeviceInfoTests.
+/// </summary>
 public class DisplayDeviceInfoTests {
     [TestMethod]
+    /// <summary>
+    /// Test for Constructor_SetsProperties.
+    /// </summary>
     public void Constructor_SetsProperties() {
         var device = new DISPLAY_DEVICE { cb = 1, DeviceName = "Name" };
         var rect = new RECT { Left = 1, Top = 2, Right = 3, Bottom = 4 };

--- a/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
+++ b/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
@@ -5,8 +5,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for ErrorHandlingTests.
+/// </summary>
 public class ErrorHandlingTests {
     [TestMethod]
+    /// <summary>
+    /// Test for DeleteTempFile_NoThrowOnMissingFile.
+    /// </summary>
     public void DeleteTempFile_NoThrowOnMissingFile() {
         var method = typeof(MonitorService).GetMethod("DeleteTempFile", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(method);
@@ -14,6 +20,9 @@ public class ErrorHandlingTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for FallbackMethods_DoNotThrow.
+    /// </summary>
     public void FallbackMethods_DoNotThrow() {
         var service = new MonitorService(new FakeDesktopManager());
         if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {

--- a/Sources/DesktopManager.Tests/FakeDesktopManager.cs
+++ b/Sources/DesktopManager.Tests/FakeDesktopManager.cs
@@ -14,42 +14,90 @@ internal class FakeDesktopManager : IDesktopManager {
     public DesktopSlideshowDirection LastAdvanceDirection;
     public bool EnableCalled;
 
+    /// <summary>
+    /// Test for SetWallpaper.
+    /// </summary>
     public void SetWallpaper(string monitorId, string wallpaper) => SetWallpaperCalls.Add((monitorId, wallpaper));
 
+    /// <summary>
+    /// Test for GetWallpaper.
+    /// </summary>
     public string GetWallpaper(string monitorId) {
         GetWallpaperIds.Add(monitorId);
         return "wall";
     }
 
+    /// <summary>
+    /// Test for GetMonitorDevicePathAt.
+    /// </summary>
     public string GetMonitorDevicePathAt(uint monitorIndex) => DevicePaths.TryGetValue(monitorIndex, out var path) ? path : string.Empty;
 
+    /// <summary>
+    /// Test for GetMonitorDevicePathCount.
+    /// </summary>
     public uint GetMonitorDevicePathCount() => DevicePathCount;
 
+    /// <summary>
+    /// Test for GetMonitorBounds.
+    /// </summary>
     public RECT GetMonitorBounds(string monitorId) => new() { Left = 0, Top = 0, Right = 10, Bottom = 10 };
 
+    /// <summary>
+    /// Test for SetBackgroundColor.
+    /// </summary>
     public void SetBackgroundColor(uint color) => BackgroundColor = color;
 
+    /// <summary>
+    /// Test for GetBackgroundColor.
+    /// </summary>
     public uint GetBackgroundColor() => BackgroundColor;
 
+    /// <summary>
+    /// Test for SetPosition.
+    /// </summary>
     public void SetPosition(DesktopWallpaperPosition position) => WallpaperPosition = position;
 
+    /// <summary>
+    /// Test for GetPosition.
+    /// </summary>
     public DesktopWallpaperPosition GetPosition() => WallpaperPosition;
 
+    /// <summary>
+    /// Test for SetSlideshow.
+    /// </summary>
     public void SetSlideshow(IntPtr items) => SetSlideshowCalls.Add(items);
 
+    /// <summary>
+    /// Test for GetSlideshow.
+    /// </summary>
     public IntPtr GetSlideshow() => IntPtr.Zero;
 
+    /// <summary>
+    /// Test for SetSlideshowOptions.
+    /// </summary>
     public void SetSlideshowOptions(DesktopSlideshowDirection options, uint slideshowTick) { }
 
+    /// <summary>
+    /// Test for GetSlideshowOptions.
+    /// </summary>
     public uint GetSlideshowOptions(out DesktopSlideshowDirection options, out uint slideshowTick) {
         options = DesktopSlideshowDirection.Forward;
         slideshowTick = 0;
         return 0;
     }
 
+    /// <summary>
+    /// Test for AdvanceSlideshow.
+    /// </summary>
     public void AdvanceSlideshow(string monitorId, DesktopSlideshowDirection direction) => LastAdvanceDirection = direction;
 
+    /// <summary>
+    /// Test for GetStatus.
+    /// </summary>
     public DesktopSlideshowDirection GetStatus() => DesktopSlideshowDirection.Forward;
 
+    /// <summary>
+    /// Test for Enable.
+    /// </summary>
     public bool Enable() { EnableCalled = true; return true; }
 }

--- a/Sources/DesktopManager.Tests/MonitorBoundsTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorBoundsTests.cs
@@ -3,8 +3,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorBoundsTests.
+/// </summary>
 public class MonitorBoundsTests {
     [TestMethod]
+    /// <summary>
+    /// Test for Constructor_SetsFields.
+    /// </summary>
     public void Constructor_SetsFields() {
         var rect = new RECT { Left = 1, Top = 2, Right = 3, Bottom = 4 };
 

--- a/Sources/DesktopManager.Tests/MonitorBrightnessTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorBrightnessTests.cs
@@ -4,8 +4,14 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorBrightnessTests.
+/// </summary>
 public class MonitorBrightnessTests {
     [TestMethod]
+    /// <summary>
+    /// Test for GetAndSetBrightness_DoesNotThrow.
+    /// </summary>
     public void GetAndSetBrightness_DoesNotThrow() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
@@ -3,9 +3,15 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorEnumerationTests.
+/// </summary>
 public class MonitorEnumerationTests
 {
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorsConnected_ReturnsAtLeastOne.
+    /// </summary>
     public void GetMonitorsConnected_ReturnsAtLeastOne()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
@@ -4,27 +4,81 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorFallbackTests.
+/// </summary>
 public class MonitorFallbackTests {
     private class FailingDesktopManager : IDesktopManager {
+        /// <summary>
+        /// Test for SetWallpaper.
+        /// </summary>
         public void SetWallpaper(string monitorId, string wallpaper) => throw new COMException();
+        /// <summary>
+        /// Test for GetWallpaper.
+        /// </summary>
         public string GetWallpaper(string monitorId) => throw new COMException();
+        /// <summary>
+        /// Test for GetMonitorDevicePathAt.
+        /// </summary>
         public string GetMonitorDevicePathAt(uint monitorIndex) => throw new COMException();
+        /// <summary>
+        /// Test for GetMonitorDevicePathCount.
+        /// </summary>
         public uint GetMonitorDevicePathCount() => throw new COMException();
+        /// <summary>
+        /// Test for GetMonitorBounds.
+        /// </summary>
         public RECT GetMonitorBounds(string monitorId) => throw new COMException();
+        /// <summary>
+        /// Test for SetBackgroundColor.
+        /// </summary>
         public void SetBackgroundColor(uint color) => throw new COMException();
+        /// <summary>
+        /// Test for GetBackgroundColor.
+        /// </summary>
         public uint GetBackgroundColor() => throw new COMException();
+        /// <summary>
+        /// Test for SetPosition.
+        /// </summary>
         public void SetPosition(DesktopWallpaperPosition position) => throw new COMException();
+        /// <summary>
+        /// Test for GetPosition.
+        /// </summary>
         public DesktopWallpaperPosition GetPosition() => throw new COMException();
+        /// <summary>
+        /// Test for SetSlideshow.
+        /// </summary>
         public void SetSlideshow(IntPtr items) => throw new COMException();
+        /// <summary>
+        /// Test for GetSlideshow.
+        /// </summary>
         public IntPtr GetSlideshow() => throw new COMException();
+        /// <summary>
+        /// Test for SetSlideshowOptions.
+        /// </summary>
         public void SetSlideshowOptions(DesktopSlideshowDirection options, uint slideshowTick) => throw new COMException();
+        /// <summary>
+        /// Test for GetSlideshowOptions.
+        /// </summary>
         public uint GetSlideshowOptions(out DesktopSlideshowDirection options, out uint slideshowTick) { throw new COMException(); }
+        /// <summary>
+        /// Test for AdvanceSlideshow.
+        /// </summary>
         public void AdvanceSlideshow(string monitorId, DesktopSlideshowDirection direction) => throw new COMException();
+        /// <summary>
+        /// Test for GetStatus.
+        /// </summary>
         public DesktopSlideshowDirection GetStatus() => throw new COMException();
+        /// <summary>
+        /// Test for Enable.
+        /// </summary>
         public bool Enable() => throw new COMException();
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for EnumeratesMonitors_WhenDesktopManagerFails.
+    /// </summary>
     public void EnumeratesMonitors_WhenDesktopManagerFails() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -40,6 +94,9 @@ public class MonitorFallbackTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetAndGetWallpaper_FallsBackToSystemParametersInfo.
+    /// </summary>
     public void SetAndGetWallpaper_FallsBackToSystemParametersInfo() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -64,6 +121,9 @@ public class MonitorFallbackTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetAndGetWallpaperPosition_FallsBackToRegistry.
+    /// </summary>
     public void SetAndGetWallpaperPosition_FallsBackToRegistry() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -82,6 +142,9 @@ public class MonitorFallbackTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetAndGetBackgroundColor_FallsBackToRegistry.
+    /// </summary>
     public void SetAndGetBackgroundColor_FallsBackToRegistry() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
@@ -4,8 +4,14 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorResolutionOrientationTests.
+/// </summary>
 public class MonitorResolutionOrientationTests {
     [TestMethod]
+    /// <summary>
+    /// Test for SetResolutionAndOrientation_DoesNotThrow.
+    /// </summary>
     public void SetResolutionAndOrientation_DoesNotThrow() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorServiceAdditionalTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceAdditionalTests.cs
@@ -4,14 +4,23 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorServiceAdditionalTests.
+/// </summary>
 public class MonitorServiceAdditionalTests {
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorPosition_ThrowsWhenMonitorMissing.
+    /// </summary>
     public void GetMonitorPosition_ThrowsWhenMonitorMissing() {
         var service = new MonitorService(new FakeDesktopManager());
         Assert.ThrowsException<ArgumentException>(() => service.GetMonitorPosition("missing"));
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorsConnected_ReturnsEmptyWhenNoDeviceIds.
+    /// </summary>
     public void GetMonitorsConnected_ReturnsEmptyWhenNoDeviceIds() {
         var fake = new FakeDesktopManager { DevicePathCount = 2 };
         var service = new MonitorService(fake);
@@ -22,6 +31,9 @@ public class MonitorServiceAdditionalTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorBrightness_ThrowsWhenMonitorMissing.
+    /// </summary>
     public void GetMonitorBrightness_ThrowsWhenMonitorMissing() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -32,6 +44,9 @@ public class MonitorServiceAdditionalTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetMonitorBrightness_ThrowsWhenMonitorMissing.
+    /// </summary>
     public void SetMonitorBrightness_ThrowsWhenMonitorMissing() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorServiceCleanupTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceCleanupTests.cs
@@ -6,27 +6,78 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorServiceCleanupTests.
+/// </summary>
 public class MonitorServiceCleanupTests {
     private class ThrowingWallpaperDesktopManager : IDesktopManager {
         public string? TempPath;
+        /// <summary>
+        /// Test for SetWallpaper.
+        /// </summary>
         public void SetWallpaper(string monitorId, string wallpaper) {
             TempPath = wallpaper;
             throw new COMException();
         }
+        /// <summary>
+        /// Test for GetWallpaper.
+        /// </summary>
         public string GetWallpaper(string monitorId) => "wall";
+        /// <summary>
+        /// Test for GetMonitorDevicePathAt.
+        /// </summary>
         public string GetMonitorDevicePathAt(uint monitorIndex) => "id";
+        /// <summary>
+        /// Test for GetMonitorDevicePathCount.
+        /// </summary>
         public uint GetMonitorDevicePathCount() => 1;
+        /// <summary>
+        /// Test for GetMonitorBounds.
+        /// </summary>
         public RECT GetMonitorBounds(string monitorId) => new();
+        /// <summary>
+        /// Test for SetBackgroundColor.
+        /// </summary>
         public void SetBackgroundColor(uint color) { }
+        /// <summary>
+        /// Test for GetBackgroundColor.
+        /// </summary>
         public uint GetBackgroundColor() => 0;
+        /// <summary>
+        /// Test for SetPosition.
+        /// </summary>
         public void SetPosition(DesktopWallpaperPosition position) { }
+        /// <summary>
+        /// Test for GetPosition.
+        /// </summary>
         public DesktopWallpaperPosition GetPosition() => DesktopWallpaperPosition.Center;
+        /// <summary>
+        /// Test for SetSlideshow.
+        /// </summary>
         public void SetSlideshow(IntPtr items) { }
+        /// <summary>
+        /// Test for GetSlideshow.
+        /// </summary>
         public IntPtr GetSlideshow() => IntPtr.Zero;
+        /// <summary>
+        /// Test for SetSlideshowOptions.
+        /// </summary>
         public void SetSlideshowOptions(DesktopSlideshowDirection options, uint slideshowTick) { }
+        /// <summary>
+        /// Test for GetSlideshowOptions.
+        /// </summary>
         public uint GetSlideshowOptions(out DesktopSlideshowDirection options, out uint slideshowTick) { options = DesktopSlideshowDirection.Forward; slideshowTick = 0; return 0; }
+        /// <summary>
+        /// Test for AdvanceSlideshow.
+        /// </summary>
         public void AdvanceSlideshow(string monitorId, DesktopSlideshowDirection direction) { }
+        /// <summary>
+        /// Test for GetStatus.
+        /// </summary>
         public DesktopSlideshowDirection GetStatus() => DesktopSlideshowDirection.Forward;
+        /// <summary>
+        /// Test for Enable.
+        /// </summary>
         public bool Enable() => true;
     }
 
@@ -36,14 +87,32 @@ public class MonitorServiceCleanupTests {
         public override bool CanWrite => false;
         public override long Length => 0;
         public override long Position { get => 0; set => throw new NotSupportedException(); }
+        /// <summary>
+        /// Test for Flush.
+        /// </summary>
         public override void Flush() { }
+        /// <summary>
+        /// Test for Read.
+        /// </summary>
         public override int Read(byte[] buffer, int offset, int count) => throw new IOException();
+        /// <summary>
+        /// Test for Seek.
+        /// </summary>
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        /// <summary>
+        /// Test for SetLength.
+        /// </summary>
         public override void SetLength(long value) => throw new NotSupportedException();
+        /// <summary>
+        /// Test for Write.
+        /// </summary>
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_FromStream_DeletesTempFileOnFailure.
+    /// </summary>
     public void SetWallpaper_FromStream_DeletesTempFileOnFailure() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -57,6 +126,9 @@ public class MonitorServiceCleanupTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_AllMonitors_FromStream_DeletesTempFileOnFailure.
+    /// </summary>
     public void SetWallpaper_AllMonitors_FromStream_DeletesTempFileOnFailure() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -70,6 +142,9 @@ public class MonitorServiceCleanupTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_FromStream_DeletesTempFileOnWriteFailure.
+    /// </summary>
     public void SetWallpaper_FromStream_DeletesTempFileOnWriteFailure() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -94,6 +169,9 @@ public class MonitorServiceCleanupTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_AllMonitors_FromStream_DeletesTempFileOnWriteFailure.
+    /// </summary>
     public void SetWallpaper_AllMonitors_FromStream_DeletesTempFileOnWriteFailure() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorServiceInitializationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceInitializationTests.cs
@@ -5,27 +5,81 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorServiceInitializationTests.
+/// </summary>
 public class MonitorServiceInitializationTests {
     private class FailingEnableDesktopManager : IDesktopManager {
+        /// <summary>
+        /// Test for SetWallpaper.
+        /// </summary>
         public void SetWallpaper(string monitorId, string wallpaper) { }
+        /// <summary>
+        /// Test for GetWallpaper.
+        /// </summary>
         public string GetWallpaper(string monitorId) => string.Empty;
+        /// <summary>
+        /// Test for GetMonitorDevicePathAt.
+        /// </summary>
         public string GetMonitorDevicePathAt(uint monitorIndex) => string.Empty;
+        /// <summary>
+        /// Test for GetMonitorDevicePathCount.
+        /// </summary>
         public uint GetMonitorDevicePathCount() => 0;
+        /// <summary>
+        /// Test for GetMonitorBounds.
+        /// </summary>
         public RECT GetMonitorBounds(string monitorId) => new();
+        /// <summary>
+        /// Test for SetBackgroundColor.
+        /// </summary>
         public void SetBackgroundColor(uint color) { }
+        /// <summary>
+        /// Test for GetBackgroundColor.
+        /// </summary>
         public uint GetBackgroundColor() => 0;
+        /// <summary>
+        /// Test for SetPosition.
+        /// </summary>
         public void SetPosition(DesktopWallpaperPosition position) { }
+        /// <summary>
+        /// Test for GetPosition.
+        /// </summary>
         public DesktopWallpaperPosition GetPosition() => DesktopWallpaperPosition.Center;
+        /// <summary>
+        /// Test for SetSlideshow.
+        /// </summary>
         public void SetSlideshow(IntPtr items) { }
+        /// <summary>
+        /// Test for GetSlideshow.
+        /// </summary>
         public IntPtr GetSlideshow() => IntPtr.Zero;
+        /// <summary>
+        /// Test for SetSlideshowOptions.
+        /// </summary>
         public void SetSlideshowOptions(DesktopSlideshowDirection options, uint slideshowTick) { }
+        /// <summary>
+        /// Test for GetSlideshowOptions.
+        /// </summary>
         public uint GetSlideshowOptions(out DesktopSlideshowDirection options, out uint slideshowTick) { options = DesktopSlideshowDirection.Forward; slideshowTick = 0; return 0; }
+        /// <summary>
+        /// Test for AdvanceSlideshow.
+        /// </summary>
         public void AdvanceSlideshow(string monitorId, DesktopSlideshowDirection direction) { }
+        /// <summary>
+        /// Test for GetStatus.
+        /// </summary>
         public DesktopSlideshowDirection GetStatus() => DesktopSlideshowDirection.Forward;
+        /// <summary>
+        /// Test for Enable.
+        /// </summary>
         public bool Enable() => throw new COMException();
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for Constructor_LogsMessage_WhenEnableThrows.
+    /// </summary>
     public void Constructor_LogsMessage_WhenEnableThrows() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/MonitorServiceTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceTests.cs
@@ -5,8 +5,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorServiceTests.
+/// </summary>
 public class MonitorServiceTests {
     [TestMethod]
+    /// <summary>
+    /// Test for Constructor_CallsEnable.
+    /// </summary>
     public void Constructor_CallsEnable() {
         var fake = new FakeDesktopManager();
         _ = new MonitorService(fake);
@@ -14,6 +20,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_ForwardsCall.
+    /// </summary>
     public void SetWallpaper_ForwardsCall() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -22,6 +31,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetWallpaper_ForwardsCall.
+    /// </summary>
     public void GetWallpaper_ForwardsCall() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -31,6 +43,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_ByIndex_UsesDevicePath.
+    /// </summary>
     public void SetWallpaper_ByIndex_UsesDevicePath() {
         var fake = new FakeDesktopManager();
         fake.DevicePaths[0] = "dev";
@@ -39,6 +54,9 @@ public class MonitorServiceTests {
         Assert.AreEqual(("dev", "w"), fake.SetWallpaperCalls[0]);
     }
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_ByIndex_MissingPathUsesEmptyString.
+    /// </summary>
     public void SetWallpaper_ByIndex_MissingPathUsesEmptyString() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -48,6 +66,9 @@ public class MonitorServiceTests {
 
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_FromStream_DeletesTempFile.
+    /// </summary>
     public void SetWallpaper_FromStream_DeletesTempFile() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -58,6 +79,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_StreamNull_Throws.
+    /// </summary>
     public void SetWallpaper_StreamNull_Throws() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -65,6 +89,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_FromUrl_InvalidSchemeThrows.
+    /// </summary>
     public void SetWallpaper_FromUrl_InvalidSchemeThrows() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -78,6 +105,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetWallpaper_ByIndex_ForwardsCall.
+    /// </summary>
     public void GetWallpaper_ByIndex_ForwardsCall() {
         var fake = new FakeDesktopManager();
         fake.DevicePaths[0] = "d";
@@ -88,6 +118,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaperPosition_Forwards.
+    /// </summary>
     public void SetWallpaperPosition_Forwards() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -96,6 +129,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetWallpaperPosition_Forwards.
+    /// </summary>
     public void GetWallpaperPosition_Forwards() {
         var fake = new FakeDesktopManager();
         fake.WallpaperPosition = DesktopWallpaperPosition.Tile;
@@ -104,6 +140,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetBackgroundColor_Forwards.
+    /// </summary>
     public void SetBackgroundColor_Forwards() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -112,6 +151,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetBackgroundColor_Forwards.
+    /// </summary>
     public void GetBackgroundColor_Forwards() {
         var fake = new FakeDesktopManager { BackgroundColor = 7 };
         var service = new MonitorService(fake);
@@ -119,6 +161,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for StopWallpaperSlideshow_CallsSetSlideshowWithZero.
+    /// </summary>
     public void StopWallpaperSlideshow_CallsSetSlideshowWithZero() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -127,6 +172,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for AdvanceWallpaperSlide_ForwardsDirection.
+    /// </summary>
     public void AdvanceWallpaperSlide_ForwardsDirection() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -135,6 +183,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for StartWallpaperSlideshow_ThrowsOnNull.
+    /// </summary>
     public void StartWallpaperSlideshow_ThrowsOnNull() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -142,6 +193,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorDevicePathAt_Forwards.
+    /// </summary>
     public void GetMonitorDevicePathAt_Forwards() {
         var fake = new FakeDesktopManager();
         fake.DevicePaths[0] = "xx";
@@ -150,6 +204,9 @@ public class MonitorServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorBounds_Forwards.
+    /// </summary>
     public void GetMonitorBounds_Forwards() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);

--- a/Sources/DesktopManager.Tests/MonitorTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorTests.cs
@@ -4,12 +4,18 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for MonitorTests.
+/// </summary>
 public class MonitorTests {
     private static void SetId(Monitor m, string id) {
         typeof(Monitor).GetProperty("DeviceId")!.SetValue(m, id);
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SetWallpaper_ForwardsCall.
+    /// </summary>
     public void SetWallpaper_ForwardsCall() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
@@ -23,6 +29,9 @@ public class MonitorTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetWallpaper_ForwardsCallAndReturnsValue.
+    /// </summary>
     public void GetWallpaper_ForwardsCallAndReturnsValue() {
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);

--- a/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
@@ -5,8 +5,14 @@ namespace DesktopManager.Tests;
 
 [TestClass]
 [SupportedOSPlatform("windows")]
+/// <summary>
+/// Test class for MonitorWatcherTests.
+/// </summary>
 public class MonitorWatcherTests {
     [TestMethod]
+    /// <summary>
+    /// Test for MonitorWatcher_CanBeCreated.
+    /// </summary>
     public void MonitorWatcher_CanBeCreated() {
 #if NET5_0_OR_GREATER
         if (!OperatingSystem.IsWindows()) {

--- a/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
+++ b/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
@@ -5,13 +5,22 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for ScreenshotServiceTests.
+/// </summary>
 public class ScreenshotServiceTests {
     [TestMethod]
+    /// <summary>
+    /// Test for CaptureRegion_InvalidDimensions_Throws.
+    /// </summary>
     public void CaptureRegion_InvalidDimensions_Throws() {
         Assert.ThrowsException<ArgumentException>(() => ScreenshotService.CaptureRegion(0, 0, 0, 0));
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for CaptureScreen_ReturnsBitmap.
+    /// </summary>
     public void CaptureScreen_ReturnsBitmap() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -24,6 +33,9 @@ public class ScreenshotServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for CaptureMonitor_InvalidIndex_Throws.
+    /// </summary>
     public void CaptureMonitor_InvalidIndex_Throws() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -33,6 +45,9 @@ public class ScreenshotServiceTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for CaptureMonitor_ByIndex_ReturnsBitmap.
+    /// </summary>
     public void CaptureMonitor_ByIndex_ReturnsBitmap() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -6,9 +6,15 @@ using System.Linq;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WallpaperHistoryTests.
+/// </summary>
 public class WallpaperHistoryTests
 {
     [TestMethod]
+    /// <summary>
+    /// Test for AddEntry_WritesFile.
+    /// </summary>
     public void AddEntry_WritesFile()
     {
         var temp = Path.GetTempFileName();
@@ -32,6 +38,9 @@ public class WallpaperHistoryTests
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for AddEntry_EnforcesMaximum.
+    /// </summary>
     public void AddEntry_EnforcesMaximum()
     {
         var temp = Path.GetTempFileName();

--- a/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
+++ b/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
@@ -5,8 +5,14 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowActivationPositioningTests.
+/// </summary>
 public class WindowActivationPositioningTests {
     [TestMethod]
+    /// <summary>
+    /// Test for SetWindowPosition_ResizesWindow.
+    /// </summary>
     public void SetWindowPosition_ResizesWindow() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -33,6 +39,9 @@ public class WindowActivationPositioningTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for ActivateWindow_InvalidHandle_Throws.
+    /// </summary>
     public void ActivateWindow_InvalidHandle_Throws() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -5,8 +5,14 @@ using DesktopManager;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowLayoutTests.
+/// </summary>
 public class WindowLayoutTests {
     [TestMethod]
+    /// <summary>
+    /// Test for SaveAndLoadLayout_RoundTrips.
+    /// </summary>
     public void SaveAndLoadLayout_RoundTrips() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -41,6 +47,9 @@ public class WindowLayoutTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for LoadLayout_InvalidJson_Throws.
+    /// </summary>
     public void LoadLayout_InvalidJson_Throws() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -56,6 +65,9 @@ public class WindowLayoutTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for LoadLayout_ValidateMissingProperties_Throws.
+    /// </summary>
     public void LoadLayout_ValidateMissingProperties_Throws() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -77,6 +89,9 @@ public class WindowLayoutTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for SaveLayout_RelativePath_CreatesFile.
+    /// </summary>
     public void SaveLayout_RelativePath_CreatesFile() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/WindowManagerWildcardTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerWildcardTests.cs
@@ -5,6 +5,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowManagerWildcardTests.
+/// </summary>
 public class WindowManagerWildcardTests {
     private static bool InvokeMatches(string text, string pattern) {
         var manager = (WindowManager)FormatterServices.GetUninitializedObject(typeof(WindowManager));
@@ -13,6 +16,9 @@ public class WindowManagerWildcardTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for MatchesWildcard_BasicPatterns.
+    /// </summary>
     public void MatchesWildcard_BasicPatterns() {
         Assert.IsTrue(InvokeMatches("hello", "*"));
         Assert.IsTrue(InvokeMatches("hello", "h*"));
@@ -23,6 +29,9 @@ public class WindowManagerWildcardTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for MatchesWildcard_ExtendedPatterns.
+    /// </summary>
     public void MatchesWildcard_ExtendedPatterns() {
         Assert.IsTrue(InvokeMatches("hello", "h*o"));
         Assert.IsTrue(InvokeMatches("hello", "h*l?"));

--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -5,8 +5,14 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowPositionTests.
+/// </summary>
 public class WindowPositionTests {
     [TestMethod]
+    /// <summary>
+    /// Test for GetAndSetWindowPosition_RoundTrips.
+    /// </summary>
     public void GetAndSetWindowPosition_RoundTrips() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -29,6 +35,9 @@ public class WindowPositionTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for MoveWindow_DoesNotChangeZOrder.
+    /// </summary>
     public void MoveWindow_DoesNotChangeZOrder() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
@@ -55,6 +64,9 @@ public class WindowPositionTests {
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for GetWindowPosition_InvalidHandle_Throws.
+    /// </summary>
     public void GetWindowPosition_InvalidHandle_Throws() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");

--- a/Sources/DesktopManager.Tests/WindowTitleMatchingTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTitleMatchingTests.cs
@@ -4,9 +4,15 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowTitleMatchingTests.
+/// </summary>
 public class WindowTitleMatchingTests
 {
     [TestMethod]
+    /// <summary>
+    /// Test for GetWindows_TitleMatchingIsCaseInsensitive.
+    /// </summary>
     public void GetWindows_TitleMatchingIsCaseInsensitive()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -5,9 +5,15 @@ using System.Runtime.InteropServices;
 namespace DesktopManager.Tests;
 
 [TestClass]
+/// <summary>
+/// Test class for WindowTopMostActivationTests.
+/// </summary>
 public class WindowTopMostActivationTests
 {
     [TestMethod]
+    /// <summary>
+    /// Test for SetWindowTopMost_TogglesState.
+    /// </summary>
     public void SetWindowTopMost_TogglesState()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -36,6 +42,9 @@ public class WindowTopMostActivationTests
     }
 
     [TestMethod]
+    /// <summary>
+    /// Test for ActivateWindow_BringsToFront.
+    /// </summary>
     public void ActivateWindow_BringsToFront()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
## Summary
- add missing XML doc comments for test classes and methods
- document example helper classes

## Testing
- `dotnet test DesktopManager.sln` *(fails: mono missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867750ed228832ebd6165cd20dcc567