### PR TITLE
Implement window keep-alive examples

### DIFF
--- a/Examples/WindowKeepAlive.ps1
+++ b/Examples/WindowKeepAlive.ps1
@@ -1,0 +1,10 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Keep Notepad alive for one minute
+Start-DesktopWindowKeepAlive -Name '*Notepad*' -Interval 00:01:00
+
+# List active keep-alive sessions
+Get-DesktopWindowKeepAlive | ForEach-Object { "Keeping window $($_.Title) alive" }
+
+# Stop the keep-alive later
+# Stop-DesktopWindowKeepAlive -Name '*Notepad*'

--- a/Examples/WindowKeepAliveMonitor.ps1
+++ b/Examples/WindowKeepAliveMonitor.ps1
@@ -1,0 +1,12 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Keep RDP windows alive every 30 seconds and monitor activity
+Start-DesktopWindowKeepAlive -Name '*RDP*' -Interval 00:00:30
+
+for ($i = 0; $i -lt 3; $i++) {
+    Start-Sleep -Seconds 10
+    Get-DesktopWindowKeepAlive | ForEach-Object { "Active: $($_.Title)" }
+}
+
+# Stop RDP keep-alive sessions
+Stop-DesktopWindowKeepAlive -Name '*RDP*'

--- a/Examples/WindowKeepAliveMultiple.ps1
+++ b/Examples/WindowKeepAliveMultiple.ps1
@@ -1,0 +1,12 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Keep Notepad and Calculator windows alive
+Start-DesktopWindowKeepAlive -Name '*Notepad*'
+Start-DesktopWindowKeepAlive -Name '*Calculator*' -Interval 00:00:30
+
+# Wait a bit and show active sessions
+Start-Sleep -Seconds 5
+Get-DesktopWindowKeepAlive | Format-Table Title, Handle
+
+# Stop all keep-alive timers
+Stop-DesktopWindowKeepAlive -All

--- a/README.MD
+++ b/README.MD
@@ -51,6 +51,8 @@ It has following features:
 - Save and restore window layouts
 - Snap or move windows between monitors
 - Subscribe to resolution, orientation or display changes
+- Keep inactive windows awake using periodic input
+- Manage keep-alive sessions for windows
 
 
 ### Available PowerShell Cmdlets
@@ -76,6 +78,9 @@ It has following features:
 | Get-DesktopWindow | Enumerate visible windows |
 | Set-DesktopWindow | Move, resize or control windows |
 | Set-DesktopWindowSnap | Snap window to common positions |
+| Start-DesktopWindowKeepAlive | Send periodic input to keep a window awake |
+| Stop-DesktopWindowKeepAlive | Stop sending keep-alive input |
+| Get-DesktopWindowKeepAlive | List windows with active keep-alive |
 | Save-DesktopWindowLayout | Save current window layout to file |
 | Restore-DesktopWindowLayout | Restore saved window layout |
 | Register-DesktopMonitorEvent | Subscribe to display configuration changes |
@@ -107,6 +112,9 @@ The table below shows the most relevant API methods behind each PowerShell cmdle
 | Get-DesktopWindow | `WindowManager.GetWindows` |
 | Set-DesktopWindow | `WindowManager.SetWindowPosition`, `MoveWindowToMonitor`, etc. |
 | Set-DesktopWindowSnap | `WindowManager.SnapWindow` |
+| Start-DesktopWindowKeepAlive | `WindowKeepAlive.Start` |
+| Stop-DesktopWindowKeepAlive | `WindowKeepAlive.Stop` or `StopAll` |
+| Get-DesktopWindowKeepAlive | `WindowKeepAlive.ActiveHandles` |
 | Save-DesktopWindowLayout | `WindowManager.SaveLayout` |
 | Restore-DesktopWindowLayout | `WindowManager.LoadLayout` |
 | Register-DesktopMonitorEvent | `MonitorWatcher.DisplaySettingsChanged` |
@@ -319,6 +327,61 @@ var manager = new WindowManager();
 manager.SaveLayout("layout.json");
 // ... move windows around ...
 manager.LoadLayout("layout.json", validate: true);
+```
+
+#### Examples in PowerShell - Window Keep-Alive Cmdlets
+
+```powershell
+# Keep Notepad alive for one minute
+Start-DesktopWindowKeepAlive -Name '*Notepad*' -Interval 00:01:00
+
+# List active sessions
+Get-DesktopWindowKeepAlive
+
+# Stop the session
+Stop-DesktopWindowKeepAlive -Name '*Notepad*'
+```
+
+```powershell
+# Keep Notepad and Calculator alive
+Start-DesktopWindowKeepAlive -Name '*Notepad*'
+Start-DesktopWindowKeepAlive -Name '*Calculator*' -Interval 00:00:30
+Start-Sleep -Seconds 5
+Get-DesktopWindowKeepAlive | Format-Table Title, Handle
+Stop-DesktopWindowKeepAlive -All
+```
+
+```powershell
+# Monitor RDP windows
+Start-DesktopWindowKeepAlive -Name '*RDP*' -Interval 00:00:30
+1..3 | ForEach-Object {
+    Start-Sleep -Seconds 10
+    Get-DesktopWindowKeepAlive | ForEach-Object { "Active: $($_.Title)" }
+}
+Stop-DesktopWindowKeepAlive -Name '*RDP*'
+```
+
+#### Examples in C# - Window Keep-Alive
+
+```csharp
+var manager = new WindowManager();
+var notepad = manager.GetWindows("*Notepad*").FirstOrDefault();
+if (notepad != null) {
+    WindowKeepAlive.Instance.Start(notepad, TimeSpan.FromMinutes(1));
+}
+```
+
+```csharp
+foreach (var window in new WindowManager().GetWindows("*Chrome*")) {
+    WindowKeepAlive.Instance.Start(window, TimeSpan.FromSeconds(30));
+}
+```
+
+```csharp
+foreach (var handle in WindowKeepAlive.Instance.ActiveHandles) {
+    Console.WriteLine($"Keeping {handle} alive");
+}
+WindowKeepAlive.Instance.StopAll();
 ```
 
 ### C# API Highlights

--- a/Sources/DesktopManager.Example/Program.cs
+++ b/Sources/DesktopManager.Example/Program.cs
@@ -75,6 +75,9 @@ namespace DesktopManager.Example {
             // Demonstrate window management features
             WindowExamples.Run();
 
+            // Demonstrate window keep-alive features
+            WindowKeepAliveExample.Run();
+
             // Run monitor watcher example for 30 seconds
             MonitorWatcherExample.RunAsync(TimeSpan.FromSeconds(30)).Wait();
           

--- a/Sources/DesktopManager.Example/WindowKeepAliveExample.cs
+++ b/Sources/DesktopManager.Example/WindowKeepAliveExample.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace DesktopManager.Example;
+
+/// <summary>
+/// Demonstrates using <see cref="WindowKeepAlive"/> to keep windows awake.
+/// </summary>
+internal static class WindowKeepAliveExample {
+    /// <summary>Runs the keep-alive examples.</summary>
+    public static void Run() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Console.WriteLine("Window keep-alive examples require Windows.");
+            return;
+        }
+
+        Simple();
+        Multiple();
+        QueryAndStop();
+    }
+
+    private static void Simple() {
+        var manager = new WindowManager();
+        var window = manager.GetWindows("*Notepad*").FirstOrDefault();
+        if (window == null) {
+            Console.WriteLine("Notepad not found.");
+            return;
+        }
+
+        WindowKeepAlive.Instance.Start(window, TimeSpan.FromSeconds(30));
+        Console.WriteLine("Keeping Notepad alive for 5 seconds...");
+        Thread.Sleep(TimeSpan.FromSeconds(5));
+        WindowKeepAlive.Instance.Stop(window.Handle);
+    }
+
+    private static void Multiple() {
+        var manager = new WindowManager();
+        var windows = manager.GetWindows("*Chrome*");
+        foreach (var w in windows) {
+            WindowKeepAlive.Instance.Start(w, TimeSpan.FromSeconds(15));
+        }
+    }
+
+    private static void QueryAndStop() {
+        foreach (var handle in WindowKeepAlive.Instance.ActiveHandles.ToList()) {
+            Console.WriteLine($"Active keep-alive: {handle}");
+        }
+
+        WindowKeepAlive.Instance.StopAll();
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletGetDesktopWindowKeepAlive.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetDesktopWindowKeepAlive.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Lists windows currently kept alive.</summary>
+/// <para type="synopsis">Lists windows currently kept alive.</para>
+/// <para type="description">Returns information about windows that have active keep-alive timers.</para>
+[Cmdlet(VerbsCommon.Get, "DesktopWindowKeepAlive")]
+public sealed class CmdletGetDesktopWindowKeepAlive : PSCmdlet {
+    /// <inheritdoc/>
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        var handles = WindowKeepAlive.Instance.ActiveHandles.ToList();
+        var windows = manager.GetWindows().Where(w => handles.Contains(w.Handle));
+        WriteObject(windows, true);
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletStartDesktopWindowKeepAlive.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletStartDesktopWindowKeepAlive.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Starts sending keep-alive input to a window.</summary>
+/// <para type="synopsis">Starts sending keep-alive input to a window.</para>
+/// <para type="description">Periodically sends a harmless input message to the specified window so that the session stays active.</para>
+/// <example>
+///   <code>Start-DesktopWindowKeepAlive -Name "*Notepad*"</code>
+/// </example>
+[Cmdlet(VerbsLifecycle.Start, "DesktopWindowKeepAlive", SupportsShouldProcess = true)]
+public sealed class CmdletStartDesktopWindowKeepAlive : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Window title to match. Supports wildcards.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// <para type="description">Interval between keep-alive messages.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public TimeSpan Interval { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <inheritdoc/>
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        var windows = manager.GetWindows(Name);
+        foreach (var window in windows) {
+            if (ShouldProcess(window.Title, $"Start keep-alive every {Interval}")) {
+                WindowKeepAlive.Instance.Start(window, Interval);
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletStopDesktopWindowKeepAlive.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletStopDesktopWindowKeepAlive.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Stops keep-alive messages for a window.</summary>
+/// <para type="synopsis">Stops keep-alive messages for a window.</para>
+/// <para type="description">Stops sending periodic input messages previously started with Start-DesktopWindowKeepAlive.</para>
+/// <example>
+///   <code>Stop-DesktopWindowKeepAlive -Name "*Notepad*"</code>
+/// </example>
+[Cmdlet(VerbsLifecycle.Stop, "DesktopWindowKeepAlive", SupportsShouldProcess = true)]
+public sealed class CmdletStopDesktopWindowKeepAlive : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Window title to match. Supports wildcards.</para>
+    /// </summary>
+    [Parameter(Position = 0)]
+    public string Name { get; set; } = "*";
+
+    /// <summary>
+    /// <para type="description">Stop all keep-alive sessions.</para>
+    /// </summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter All { get; set; }
+
+    /// <inheritdoc/>
+    protected override void BeginProcessing() {
+        if (All.IsPresent) {
+            if (ShouldProcess("All windows", "Stop keep-alive")) {
+                WindowKeepAlive.Instance.StopAll();
+            }
+            return;
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows(Name);
+        foreach (var window in windows) {
+            if (ShouldProcess(window.Title, "Stop keep-alive")) {
+                WindowKeepAlive.Instance.Stop(window.Handle);
+            }
+        }
+    }
+}

--- a/Sources/DesktopManager/WindowKeepAlive.cs
+++ b/Sources/DesktopManager/WindowKeepAlive.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+using System.Threading;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Provides a simple mechanism to keep windows awake by periodically sending
+/// a harmless input message. Messages are skipped when the window is
+/// currently active to avoid interrupting the user.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowKeepAlive : IDisposable {
+    private static readonly Lazy<WindowKeepAlive> _instance = new(() => new WindowKeepAlive());
+
+    /// <summary>
+    /// Gets the global instance of the <see cref="WindowKeepAlive"/> service.
+    /// </summary>
+    public static WindowKeepAlive Instance => _instance.Value;
+
+    private readonly ConcurrentDictionary<IntPtr, Timer> _timers = new();
+
+    private WindowKeepAlive() {
+    }
+
+    /// <summary>
+    /// Starts sending keep alive messages to the specified window.
+    /// </summary>
+    /// <param name="window">Window to keep alive.</param>
+    /// <param name="interval">Interval between messages.</param>
+    public void Start(WindowInfo window, TimeSpan interval) {
+        if (window == null) {
+            throw new ArgumentNullException(nameof(window));
+        }
+        Start(window.Handle, interval);
+    }
+
+    /// <summary>
+    /// Starts sending keep alive messages to the specified window handle.
+    /// </summary>
+    /// <param name="handle">Handle of the window.</param>
+    /// <param name="interval">Interval between messages.</param>
+    public void Start(IntPtr handle, TimeSpan interval) {
+        if (interval <= TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(interval));
+        }
+
+        if (_timers.ContainsKey(handle)) {
+            return;
+        }
+
+        var timer = new Timer(KeepAliveCallback, handle, interval, interval);
+        _timers[handle] = timer;
+    }
+
+    /// <summary>
+    /// Stops sending keep alive messages for the specified window.
+    /// </summary>
+    /// <param name="handle">Window handle.</param>
+    public void Stop(IntPtr handle) {
+        if (_timers.TryRemove(handle, out var timer)) {
+            timer.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Stops all keep alive sessions.
+    /// </summary>
+    public void StopAll() {
+        foreach (var handle in _timers.Keys) {
+            Stop(handle);
+        }
+    }
+
+    /// <summary>
+    /// Checks if keep alive is active for the specified window handle.
+    /// </summary>
+    public bool IsActive(IntPtr handle) {
+        return _timers.ContainsKey(handle);
+    }
+
+    /// <summary>
+    /// Gets handles currently under keep alive.
+    /// </summary>
+    public IEnumerable<IntPtr> ActiveHandles => _timers.Keys;
+
+    private void KeepAliveCallback(object? state) {
+        if (state is not IntPtr handle) {
+            return;
+        }
+
+        if (MonitorNativeMethods.GetForegroundWindow() == handle) {
+            return;
+        }
+
+        MonitorNativeMethods.SendMessage(handle, WM_MOUSEMOVE, 0, 0);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        foreach (var timer in _timers.Values) {
+            timer.Dispose();
+        }
+        _timers.Clear();
+    }
+
+    private const uint WM_MOUSEMOVE = 0x0200;
+}

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -36,4 +36,16 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Set-DesktopWallpaperHistory' {
         Get-Command Set-DesktopWallpaperHistory | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Start-DesktopWindowKeepAlive' {
+        Get-Command Start-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Stop-DesktopWindowKeepAlive' {
+        Get-Command Stop-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Get-DesktopWindowKeepAlive' {
+        Get-Command Get-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## Summary
- add `WindowKeepAliveExample` to C# example project
- call new example from Program.cs
- switch PowerShell keep-alive sample to cmdlets and add two more scripts
- document PowerShell and C# keep-alive usage in README

## Testing
- `dotnet restore Sources/DesktopManager.sln`
- `dotnet build Sources/DesktopManager.sln -c Release`
- `pwsh -NoProfile -Command "Import-Module ./DesktopManager.psd1 -Force; Invoke-Pester -CI"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867857bbf60832eab54fc610bb88920