### PR TITLE
Add support for sending text to windows

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,7 @@ It has following features:
 | Get-DesktopWindow | Enumerate visible windows |
 | Set-DesktopWindow | Move, resize or control windows |
 | Set-DesktopWindowSnap | Snap window to common positions |
+| Set-DesktopWindowText | Paste or type text into a window |
 | Start-DesktopWindowKeepAlive | Send periodic input to keep a window awake |
 | Stop-DesktopWindowKeepAlive | Stop sending keep-alive input |
 | Get-DesktopWindowKeepAlive | List windows with active keep-alive |
@@ -112,6 +113,7 @@ The table below shows the most relevant API methods behind each PowerShell cmdle
 | Get-DesktopWindow | `WindowManager.GetWindows` |
 | Set-DesktopWindow | `WindowManager.SetWindowPosition`, `MoveWindowToMonitor`, etc. |
 | Set-DesktopWindowSnap | `WindowManager.SnapWindow` |
+| Set-DesktopWindowText | `WindowInputService` |
 | Start-DesktopWindowKeepAlive | `WindowKeepAlive.Start` |
 | Stop-DesktopWindowKeepAlive | `WindowKeepAlive.Stop` or `StopAll` |
 | Get-DesktopWindowKeepAlive | `WindowKeepAlive.ActiveHandles` |
@@ -274,6 +276,10 @@ Get-DesktopWindow | Format-Table *
 ```powershell
 Set-DesktopWindow -Name '*Zadanie - Notepad' -Height 800 -Width 1200 -Left 100
 Set-DesktopWindow -Name '*Zadanie - Notepad' -State Maximize
+```
+
+```powershell
+Set-DesktopWindowText -Name '*Notepad*' -Text 'Hello world'
 ```
 
 ### Example in PowerShell - Activating and Setting Window Top-Most

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowText.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowText.cs
@@ -1,0 +1,64 @@
+using System.Management.Automation;
+using System.Runtime.Versioning;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Sets text in a desktop window.</summary>
+/// <para type="synopsis">Pastes or types text into a desktop window.</para>
+/// <example>
+///   <code>Set-DesktopWindowText -Name "Notepad" -Text "Hello"</code>
+/// </example>
+/// <example>
+///   <code>Set-DesktopWindowText -Name "Notepad" -Text "Hello" -Type</code>
+/// </example>
+[Cmdlet(VerbsCommon.Set, "DesktopWindowText", DefaultParameterSetName = "Paste", SupportsShouldProcess = true)]
+[SupportedOSPlatform("windows")]
+public sealed class CmdletSetDesktopWindowText : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Window title to match. Supports wildcards.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// <para type="description">Text to paste or type.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    public string Text { get; set; }
+
+    /// <summary>
+    /// <para type="description">Use the clipboard paste method.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Paste")]
+    public SwitchParameter Paste { get; set; }
+
+    /// <summary>
+    /// <para type="description">Simulate typing the text.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public SwitchParameter Type { get; set; }
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds between characters when typing.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public int Delay { get; set; } = 0;
+
+    /// <inheritdoc />
+    protected override void BeginProcessing() {
+        var manager = new WindowManager();
+        var windows = manager.GetWindows(Name);
+
+        foreach (var window in windows) {
+            string action = ParameterSetName == "Type" ? "Type text" : "Paste text";
+            if (ShouldProcess(window.Title, action)) {
+                if (ParameterSetName == "Type") {
+                    manager.TypeText(window, Text, Delay);
+                } else {
+                    manager.PasteText(window, Text);
+                }
+            }
+        }
+    }
+}
+

--- a/Sources/DesktopManager/ClipboardHelper.cs
+++ b/Sources/DesktopManager/ClipboardHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Helper methods for working with the Windows clipboard.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public static class ClipboardHelper {
+    /// <summary>
+    /// Places Unicode text on the clipboard.
+    /// </summary>
+    /// <param name="text">Text to place on the clipboard.</param>
+    public static void SetText(string text) {
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        if (!MonitorNativeMethods.OpenClipboard(IntPtr.Zero)) {
+            throw new InvalidOperationException("Unable to open clipboard.");
+        }
+
+        try {
+            if (!MonitorNativeMethods.EmptyClipboard()) {
+                throw new InvalidOperationException("Unable to empty clipboard.");
+            }
+
+            int bytes = (text.Length + 1) * 2;
+            IntPtr hGlobal = MonitorNativeMethods.GlobalAlloc(MonitorNativeMethods.GMEM_MOVEABLE, (UIntPtr)bytes);
+            if (hGlobal == IntPtr.Zero) {
+                throw new InvalidOperationException("GlobalAlloc failed.");
+            }
+
+            IntPtr target = MonitorNativeMethods.GlobalLock(hGlobal);
+            if (target == IntPtr.Zero) {
+                MonitorNativeMethods.GlobalFree(hGlobal);
+                throw new InvalidOperationException("GlobalLock failed.");
+            }
+
+            try {
+                Marshal.Copy(text.ToCharArray(), 0, target, text.Length);
+                Marshal.WriteInt16(target, text.Length * 2, 0);
+            } finally {
+                MonitorNativeMethods.GlobalUnlock(hGlobal);
+            }
+
+            if (MonitorNativeMethods.SetClipboardData(MonitorNativeMethods.CF_UNICODETEXT, hGlobal) == IntPtr.Zero) {
+                MonitorNativeMethods.GlobalFree(hGlobal);
+                throw new InvalidOperationException("SetClipboardData failed.");
+            }
+        } finally {
+            MonitorNativeMethods.CloseClipboard();
+        }
+    }
+}
+

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -115,6 +115,88 @@ public static partial class MonitorNativeMethods
     public static extern uint SendMessage(IntPtr hWnd, uint Msg, uint wParam, uint lParam);
 
     /// <summary>
+    /// Sends simulated input events to the system.
+    /// </summary>
+    /// <param name="nInputs">The number of structures in the array.</param>
+    /// <param name="pInputs">Array of <see cref="INPUT"/> structures.</param>
+    /// <param name="cbSize">Size of an <see cref="INPUT"/> structure.</param>
+    /// <returns>The number of events inserted.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    /// <summary>
+    /// Opens the clipboard for modification.
+    /// </summary>
+    /// <param name="hWndNewOwner">Handle to new clipboard owner.</param>
+    /// <returns>True if the clipboard was opened.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+    /// <summary>
+    /// Closes the clipboard.
+    /// </summary>
+    /// <returns>True if the clipboard was closed.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool CloseClipboard();
+
+    /// <summary>
+    /// Empties the clipboard.
+    /// </summary>
+    /// <returns>True if successful.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool EmptyClipboard();
+
+    /// <summary>
+    /// Places data on the clipboard.
+    /// </summary>
+    /// <param name="uFormat">Clipboard format.</param>
+    /// <param name="hMem">Handle to the data.</param>
+    /// <returns>Handle to the data on success.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+
+    /// <summary>
+    /// Retrieves data from the clipboard.
+    /// </summary>
+    /// <param name="uFormat">Clipboard format.</param>
+    /// <returns>Handle to the data.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr GetClipboardData(uint uFormat);
+
+    /// <summary>
+    /// Allocates global memory.
+    /// </summary>
+    /// <param name="uFlags">Allocation flags.</param>
+    /// <param name="dwBytes">Number of bytes.</param>
+    /// <returns>Handle to the allocated memory.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
+
+    /// <summary>
+    /// Locks a global memory block and returns a pointer to it.
+    /// </summary>
+    /// <param name="hMem">Handle to the memory.</param>
+    /// <returns>Pointer to the locked memory.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr GlobalLock(IntPtr hMem);
+
+    /// <summary>
+    /// Unlocks a global memory block.
+    /// </summary>
+    /// <param name="hMem">Handle to the memory.</param>
+    /// <returns>True if successful.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool GlobalUnlock(IntPtr hMem);
+
+    /// <summary>
+    /// Frees a global memory block.
+    /// </summary>
+    /// <param name="hMem">Handle to the memory.</param>
+    /// <returns>Handle to the memory.</returns>
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr GlobalFree(IntPtr hMem);
+
+    /// <summary>
     /// 32-bit variant of <c>GetWindowLongPtr</c>.
     /// </summary>
     /// <param name="hWnd">Window handle.</param>
@@ -230,4 +312,71 @@ public static partial class MonitorNativeMethods
     /// Message sent when a system-wide setting changes.
     /// </summary>
     public const uint WM_SETTINGCHANGE = 0x001A;
+
+    /// <summary>
+    /// Message used to paste data from the clipboard.
+    /// </summary>
+    public const uint WM_PASTE = 0x0302;
+
+    /// <summary>
+    /// Clipboard format for Unicode text.
+    /// </summary>
+    public const uint CF_UNICODETEXT = 13;
+
+    /// <summary>
+    /// Memory allocation flag for movable memory.
+    /// </summary>
+    public const uint GMEM_MOVEABLE = 0x0002;
+
+    /// <summary>
+    /// Input type constant indicating keyboard input.
+    /// </summary>
+    public const uint INPUT_KEYBOARD = 1;
+
+    /// <summary>
+    /// Key event flag indicating key release.
+    /// </summary>
+    public const uint KEYEVENTF_KEYUP = 0x0002;
+
+    /// <summary>
+    /// Key event flag indicating Unicode scan code.
+    /// </summary>
+    public const uint KEYEVENTF_UNICODE = 0x0004;
+
+    /// <summary>
+    /// Represents an INPUT structure used with <see cref="SendInput"/>.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct INPUT {
+        /// <summary>Type of the input event.</summary>
+        public uint Type;
+        /// <summary>Input data.</summary>
+        public InputUnion Data;
+    }
+
+    /// <summary>
+    /// Union representing keyboard, mouse or hardware input data.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    public struct InputUnion {
+        /// <summary>Keyboard input data.</summary>
+        [FieldOffset(0)] public KEYBDINPUT Keyboard;
+    }
+
+    /// <summary>
+    /// Defines keyboard input for <see cref="SendInput"/>.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KEYBDINPUT {
+        /// <summary>Virtual key code.</summary>
+        public ushort Vk;
+        /// <summary>Hardware scan code.</summary>
+        public ushort Scan;
+        /// <summary>Flags specifying various aspects of keystroke.</summary>
+        public uint Flags;
+        /// <summary>Event timestamp.</summary>
+        public uint Time;
+        /// <summary>Additional information associated with the keystroke.</summary>
+        public IntPtr ExtraInfo;
+    }
 }

--- a/Sources/DesktopManager/WindowInputService.cs
+++ b/Sources/DesktopManager/WindowInputService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Provides methods for pasting or typing text into windows.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public static class WindowInputService {
+    /// <summary>
+    /// Pastes the specified text into the window using the clipboard.
+    /// </summary>
+    /// <param name="window">Target window.</param>
+    /// <param name="text">Text to paste.</param>
+    public static void PasteText(WindowInfo window, string text) {
+        if (window == null) {
+            throw new ArgumentNullException(nameof(window));
+        }
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        ClipboardHelper.SetText(text);
+        MonitorNativeMethods.SetForegroundWindow(window.Handle);
+        MonitorNativeMethods.SendMessage(window.Handle, MonitorNativeMethods.WM_PASTE, 0, 0);
+    }
+
+    /// <summary>
+    /// Types the specified text into the window using simulated keyboard input.
+    /// </summary>
+    /// <param name="window">Target window.</param>
+    /// <param name="text">Text to type.</param>
+    /// <param name="delay">Optional delay in milliseconds between characters.</param>
+    public static void TypeText(WindowInfo window, string text, int delay = 0) {
+        if (window == null) {
+            throw new ArgumentNullException(nameof(window));
+        }
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        MonitorNativeMethods.SetForegroundWindow(window.Handle);
+
+        foreach (char c in text) {
+            MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
+
+            inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+            inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+                Vk = 0,
+                Scan = c,
+                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE,
+                Time = 0,
+                ExtraInfo = IntPtr.Zero
+            };
+
+            inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+            inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+                Vk = 0,
+                Scan = c,
+                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE | MonitorNativeMethods.KEYEVENTF_KEYUP,
+                Time = 0,
+                ExtraInfo = IntPtr.Zero
+            };
+
+            MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
+
+            if (delay > 0) {
+                Thread.Sleep(delay);
+            }
+        }
+    }
+}
+

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -348,6 +348,25 @@ namespace DesktopManager {
         }
 
         /// <summary>
+        /// Pastes text into the specified window using the clipboard.
+        /// </summary>
+        /// <param name="windowInfo">The target window.</param>
+        /// <param name="text">Text to paste.</param>
+        public void PasteText(WindowInfo windowInfo, string text) {
+            WindowInputService.PasteText(windowInfo, text);
+        }
+
+        /// <summary>
+        /// Types text into the specified window by simulating keyboard input.
+        /// </summary>
+        /// <param name="windowInfo">The target window.</param>
+        /// <param name="text">Text to type.</param>
+        /// <param name="delay">Delay in milliseconds between characters.</param>
+        public void TypeText(WindowInfo windowInfo, string text, int delay = 0) {
+            WindowInputService.TypeText(windowInfo, text, delay);
+        }
+
+        /// <summary>
         /// Saves the current window layout to a JSON file.
         /// </summary>
         /// <param name="path">Destination path for the layout.</param>

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -48,4 +48,8 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Get-DesktopWindowKeepAlive' {
         Get-Command Get-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Set-DesktopWindowText' {
+        Get-Command Set-DesktopWindowText | Should -Not -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## Summary
- allow clipboard and keyboard input into windows
- expose new `Set-DesktopWindowText` cmdlet
- document the cmdlet and add usage example
- export new cmdlet from module
- basic test updated for command export

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682a0e3e9c832e801e85ccca610a18