### PR TITLE
Fix missing xml docs

### DIFF
--- a/Sources/DesktopManager.Tests/FakeDesktopManager.cs
+++ b/Sources/DesktopManager.Tests/FakeDesktopManager.cs
@@ -4,14 +4,31 @@ using System.Collections.Generic;
 namespace DesktopManager.Tests;
 
 internal class FakeDesktopManager : IDesktopManager {
+    /// <summary>Records parameters passed to <see cref="SetWallpaper"/>.</summary>
     public List<(string id, string path)> SetWallpaperCalls = new();
+
+    /// <summary>Stores monitor identifiers requested via <see cref="GetWallpaper"/>.</summary>
     public List<string> GetWallpaperIds = new();
+
+    /// <summary>Dictionary of device paths by index.</summary>
     public Dictionary<uint, string> DevicePaths = new();
+
+    /// <summary>Number of device paths available.</summary>
     public uint DevicePathCount = 1;
+
+    /// <summary>Value used when testing background color operations.</summary>
     public uint BackgroundColor;
+
+    /// <summary>Last set wallpaper position.</summary>
     public DesktopWallpaperPosition WallpaperPosition;
+
+    /// <summary>Tracks calls to slideshow operations.</summary>
     public List<IntPtr> SetSlideshowCalls = new();
+
+    /// <summary>Direction of the last AdvanceWallpaperSlide call.</summary>
     public DesktopSlideshowDirection LastAdvanceDirection;
+
+    /// <summary>Indicates whether <see cref="Enable"/> was invoked.</summary>
     public bool EnableCalled;
 
     /// <summary>

--- a/Sources/DesktopManager.Tests/MonitorServiceCleanupTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceCleanupTests.cs
@@ -11,6 +11,7 @@ namespace DesktopManager.Tests;
 /// </summary>
 public class MonitorServiceCleanupTests {
     private class ThrowingWallpaperDesktopManager : IDesktopManager {
+        /// <summary>Temporary path used during testing.</summary>
         public string? TempPath;
         /// <summary>
         /// Test for SetWallpaper.
@@ -82,10 +83,19 @@ public class MonitorServiceCleanupTests {
     }
 
     private class ThrowingStream : Stream {
+        /// <inheritdoc />
         public override bool CanRead => true;
+
+        /// <inheritdoc />
         public override bool CanSeek => false;
+
+        /// <inheritdoc />
         public override bool CanWrite => false;
+
+        /// <inheritdoc />
         public override long Length => 0;
+
+        /// <inheritdoc />
         public override long Position { get => 0; set => throw new NotSupportedException(); }
         /// <summary>
         /// Test for Flush.

--- a/Sources/DesktopManager/MonitorNativeMethods.Shell.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Shell.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace DesktopManager;
 
+/// <summary>
+/// Native shell-related platform invocations.
+/// </summary>
 public static partial class MonitorNativeMethods
 {
     /// <summary>

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace DesktopManager;
 
+/// <summary>
+/// Native window-related platform invocations.
+/// </summary>
 public static partial class MonitorNativeMethods
 {
     /// <summary>

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -8,6 +8,9 @@ using Microsoft.Win32;
 
 namespace DesktopManager;
 
+/// <summary>
+/// Provides methods for managing display-related monitor settings.
+/// </summary>
 public partial class MonitorService {
     /// <summary>
     /// Gets the desktop background color.

--- a/Sources/DesktopManager/MonitorService.Theme.cs
+++ b/Sources/DesktopManager/MonitorService.Theme.cs
@@ -3,6 +3,9 @@ using Microsoft.Win32;
 
 namespace DesktopManager;
 
+/// <summary>
+/// Provides access to Windows theme settings for monitors.
+/// </summary>
 public partial class MonitorService {
     /// <summary>
     /// Gets the current Windows color theme.

--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -9,6 +9,9 @@ using Microsoft.Win32;
 
 namespace DesktopManager;
 
+/// <summary>
+/// Provides wallpaper management functionality for monitors.
+/// </summary>
 public partial class MonitorService {
     /// <summary>
     /// Sets the wallpaper for a specific monitor.

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -33,8 +33,13 @@ public sealed class MonitorWatcher : IDisposable {
     private bool _disposed;
 
     private struct MonitorState {
+        /// <summary>Current width of the monitor.</summary>
         public int Width;
+
+        /// <summary>Current height of the monitor.</summary>
         public int Height;
+
+        /// <summary>Current orientation of the monitor.</summary>
         public int Orientation;
     }
 

--- a/Sources/Shared/SupportedOSPlatformAttribute.cs
+++ b/Sources/Shared/SupportedOSPlatformAttribute.cs
@@ -7,6 +7,10 @@ namespace System.Runtime.Versioning
                     AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute
     {
+        /// <summary>
+        /// Initializes a new instance for the specified platform name.
+        /// </summary>
+        /// <param name="platformName">Target platform name.</param>
         public SupportedOSPlatformAttribute(string platformName) { }
     }
 }


### PR DESCRIPTION
## Summary
- document display monitor service partial class
- document wallpaper service partial class
- document monitor theme service partial class
- add summaries for monitor native method classes
- document monitor watcher state fields
- document custom platform attribute
- add docs for test helpers

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `pwsh -NoLogo -Command Invoke-Pester -Path PowerShell.Tests -CI` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b80188768832e8dc5c5c36abc9c55