### PR TITLE
Add logon wallpaper feature

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 @{
-    AliasesToExport        = @('Get-DesktopMonitors')
+    AliasesToExport        = @('Get-DesktopMonitors', 'Set-LockScreenWallpaper', 'Get-LockScreenWallpaper')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow', 'Get-LogonWallpaper', 'Set-LogonWallpaper')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Examples/SetLockScreenWallpaper.ps1
+++ b/Examples/SetLockScreenWallpaper.ps1
@@ -1,0 +1,6 @@
+Import-Module ..\DesktopManager.psd1 -Force
+
+$wallpaper = Get-ChildItem -Path . -Filter *.jpg | Select-Object -First 1
+if ($null -ne $wallpaper) {
+    Set-LockScreenWallpaper -ImagePath $wallpaper.FullName -WhatIf
+}

--- a/Examples/SetLogonWallpaper.ps1
+++ b/Examples/SetLogonWallpaper.ps1
@@ -1,0 +1,6 @@
+Import-Module ..\DesktopManager.psd1 -Force
+
+$wallpaper = Get-ChildItem -Path . -Filter *.jpg | Select-Object -First 1
+if ($null -ne $wallpaper) {
+    Set-LogonWallpaper -ImagePath $wallpaper.FullName -WhatIf
+}

--- a/Sources/DesktopManager.PowerShell/CmdletGetLogonWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetLogonWallpaper.cs
@@ -1,0 +1,17 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Gets the current logon (lock screen) wallpaper.</summary>
+/// <para type="synopsis">Retrieves the logon wallpaper path using native API when possible and falls back to registry.</para>
+[Cmdlet(VerbsCommon.Get, "LogonWallpaper")]
+[Alias("Get-LockScreenWallpaper")]
+public sealed class CmdletGetLogonWallpaper : PSCmdlet {
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing() {
+        Monitors monitors = new Monitors();
+        WriteObject(monitors.GetLogonWallpaper());
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletSetLogonWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetLogonWallpaper.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Sets the logon (lock screen) wallpaper.</summary>
+/// <para type="synopsis">Sets the logon wallpaper using native API when possible and falls back to registry.</para>
+[Cmdlet(VerbsCommon.Set, "LogonWallpaper", SupportsShouldProcess = true)]
+[Alias("Set-LockScreenWallpaper")]
+public sealed class CmdletSetLogonWallpaper : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Path to the image file.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string ImagePath;
+
+    /// <summary>
+    /// Begin processing the command.
+    /// </summary>
+    protected override void BeginProcessing() {
+        if (!File.Exists(ImagePath)) {
+            ThrowTerminatingError(new ErrorRecord(new FileNotFoundException($"File '{ImagePath}' not found."), "FileNotFound", ErrorCategory.InvalidArgument, ImagePath));
+        }
+
+        if (ShouldProcess("System", $"Set logon wallpaper to '{ImagePath}'")) {
+            Monitors monitors = new Monitors();
+            monitors.SetLogonWallpaper(ImagePath);
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
+++ b/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Test class for logon wallpaper functionality.
+/// </summary>
+public class LogonWallpaperTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensure SetLogonWallpaper does not throw for existing file.
+    /// </summary>
+    public void SetLogonWallpaper_NoThrow() {
+        var monitors = new Monitors();
+        string temp = Path.GetTempFileName();
+        File.WriteAllBytes(temp, new byte[] {1});
+        try {
+            monitors.SetLogonWallpaper(temp);
+        } finally {
+            File.Delete(temp);
+        }
+        Assert.IsTrue(true);
+    }
+}

--- a/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Provides methods to manage logon (lock screen) wallpaper.
+/// </summary>
+public partial class MonitorService {
+    private const string RegistryPath = @"SOFTWARE\Policies\Microsoft\Windows\Personalization";
+    private const string RegistryValue = "LockScreenImage";
+
+    /// <summary>
+    /// Sets the logon wallpaper image path.
+    /// </summary>
+    /// <param name="imagePath">Path to the image file.</param>
+    [SupportedOSPlatform("windows")]
+    public void SetLogonWallpaper(string imagePath) {
+        try {
+            Type? lockScreenType = Type.GetType("Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime");
+            Type? storageFileType = Type.GetType("Windows.Storage.StorageFile, Windows, ContentType=WindowsRuntime");
+            if (lockScreenType != null && storageFileType != null) {
+                var getFileMethod = storageFileType.GetMethod("GetFileFromPathAsync");
+                var fileOp = getFileMethod?.Invoke(null, new object[] { imagePath });
+                var asTask = fileOp?.GetType().GetMethod("AsTask");
+                var fileTask = asTask?.Invoke(fileOp, null) as System.Threading.Tasks.Task;
+                fileTask?.Wait();
+                var file = fileTask?.GetType().GetProperty("Result")?.GetValue(fileTask);
+                var setMethod = lockScreenType.GetMethod("SetImageFileAsync");
+                var setOp = setMethod?.Invoke(null, new object[] { file });
+                var opTask = setOp?.GetType().GetMethod("AsTask")?.Invoke(setOp, null) as System.Threading.Tasks.Task;
+                opTask?.Wait();
+                return;
+            }
+        } catch {
+            // ignore and use fallback
+        }
+        SetLogonWallpaperFallback(imagePath);
+    }
+
+    private static void SetLogonWallpaperFallback(string imagePath) {
+        try {
+            using RegistryKey? key = Registry.LocalMachine.CreateSubKey(RegistryPath);
+            key?.SetValue(RegistryValue, imagePath, RegistryValueKind.String);
+        } catch (Exception ex) {
+            Console.WriteLine($"SetLogonWallpaperFallback failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Gets the current logon wallpaper path if available.
+    /// </summary>
+    /// <returns>Path to the logon wallpaper or empty string.</returns>
+    [SupportedOSPlatform("windows")]
+    public string GetLogonWallpaper() {
+        try {
+            Type? lockScreenType = Type.GetType("Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime");
+            if (lockScreenType != null) {
+                var getMethod = lockScreenType.GetMethod("GetImageStream");
+                var streamObj = getMethod?.Invoke(null, null);
+                if (streamObj != null) {
+                    var asStreamForRead = streamObj.GetType().GetMethod("AsStreamForRead");
+                    using var stream = asStreamForRead?.Invoke(streamObj, null) as Stream;
+                    if (stream != null) {
+                        string temp = Path.GetTempFileName();
+                        using FileStream fs = new FileStream(temp, FileMode.Create, FileAccess.Write);
+                        stream.CopyTo(fs);
+                        return temp;
+                    }
+                }
+            }
+        } catch {
+            // ignore and use fallback
+        }
+        return GetLogonWallpaperFallback();
+    }
+
+    private static string GetLogonWallpaperFallback() {
+        try {
+            using RegistryKey? key = Registry.LocalMachine.OpenSubKey(RegistryPath);
+            if (key != null && key.GetValue(RegistryValue) is string value) {
+                return value;
+            }
+        } catch (Exception ex) {
+            Console.WriteLine($"GetLogonWallpaperFallback failed: {ex.Message}");
+        }
+        return string.Empty;
+    }
+}

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -233,6 +233,22 @@ public class Monitors {
     }
 
     /// <summary>
+    /// Sets the logon (lock screen) wallpaper.
+    /// </summary>
+    /// <param name="imagePath">Path to the image file.</param>
+    public void SetLogonWallpaper(string imagePath) {
+        _monitorService.SetLogonWallpaper(imagePath);
+    }
+
+    /// <summary>
+    /// Gets the current logon (lock screen) wallpaper path if available.
+    /// </summary>
+    /// <returns>Path to the wallpaper or empty string.</returns>
+    public string GetLogonWallpaper() {
+        return _monitorService.GetLogonWallpaper();
+    }
+
+    /// <summary>
     /// Gets the bounds of a monitor by its ID.
     /// </summary>
     /// <param name="monitorId">The ID of the monitor.</param>

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -52,4 +52,20 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Set-DesktopWindowText' {
         Get-Command Set-DesktopWindowText | Should -Not -BeNullOrEmpty
     }
+
+    It 'Exports Set-LogonWallpaper' {
+        Get-Command Set-LogonWallpaper | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Get-LogonWallpaper' {
+        Get-Command Get-LogonWallpaper | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Set-LockScreenWallpaper alias' {
+        Get-Command Set-LockScreenWallpaper | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Exports Get-LockScreenWallpaper alias' {
+        Get-Command Get-LockScreenWallpaper | Should -Not -BeNullOrEmpty
+    }
 }

--- a/Tests/SetLogonWallpaper.Tests.ps1
+++ b/Tests/SetLogonWallpaper.Tests.ps1
@@ -1,0 +1,25 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/..\DesktopManager.psd1" -Force
+}
+
+describe 'Set-LogonWallpaper' {
+    it 'supports WhatIf mode' -Skip:(-not $IsWindows) {
+        $tmp = New-TemporaryFile
+        try {
+            { Set-LogonWallpaper -ImagePath $tmp -WhatIf } | Should -Not -Throw
+        } finally {
+            Remove-Item $tmp -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+describe 'Set-LockScreenWallpaper alias' {
+    it 'supports WhatIf mode' -Skip:(-not $IsWindows) {
+        $tmp = New-TemporaryFile
+        try {
+            { Set-LockScreenWallpaper -ImagePath $tmp -WhatIf } | Should -Not -Throw
+        } finally {
+            Remove-Item $tmp -ErrorAction SilentlyContinue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support locking screen wallpaper functionality with native fallback to registry
- alias logon wallpaper cmdlets as lock screen versions
- export new aliases in module manifest
- provide example usage and Pester tests
- revert unneeded csproj target framework changes

## Testing
- `dotnet build Sources/DesktopManager/DesktopManager.csproj -c Release`
- `dotnet build Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj -c Release`
- `dotnet build Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File DesktopManager.Tests.ps1` *(failed: CommandNotFoundException)*


------
https://chatgpt.com/codex/tasks/task_e_686cb566b934832eb4e0d9f536781032