### PR TITLE
Fix window title truncation

### DIFF
--- a/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
+++ b/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DesktopManager.Tests;
@@ -13,9 +14,13 @@ public class LogonWallpaperTests {
     /// Ensure SetLogonWallpaper does not throw for existing file.
     /// </summary>
     public void SetLogonWallpaper_NoThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
         var monitors = new Monitors();
         string temp = Path.GetTempFileName();
-        File.WriteAllBytes(temp, new byte[] {1});
+        File.WriteAllBytes(temp, new byte[] { 1 });
         try {
             monitors.SetLogonWallpaper(temp);
         } finally {

--- a/Sources/DesktopManager.Tests/WindowTitleLengthTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTitleLengthTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for verifying window titles are retrieved without truncation.
+/// </summary>
+public class WindowTitleLengthTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures GetWindows returns complete window titles.
+    /// </summary>
+    public void GetWindows_TitleIsNotTruncated() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        int expectedLength = MonitorNativeMethods.GetWindowTextLength(window.Handle);
+        Assert.AreEqual(expectedLength, window.Title.Length);
+    }
+}
+

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -43,7 +43,7 @@ namespace DesktopManager {
             foreach (var handle in handles) {
                 var titleLength = MonitorNativeMethods.GetWindowTextLength(handle);
                 if (titleLength > 0) {
-                    var titleBuilder = new StringBuilder(titleLength);
+                    var titleBuilder = new StringBuilder(titleLength + 1);
                     MonitorNativeMethods.GetWindowText(handle, titleBuilder, titleLength + 1);
                     var title = titleBuilder.ToString();
 


### PR DESCRIPTION
## Summary
- ensure GetWindows allocates space for the null terminator
- skip LogonWallpaper test on non-Windows
- add regression test for window title truncation

## Testing
- `dotnet test Sources/DesktopManager.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_686ce52561e0832ea16d1e5b8bd75e70