### PR TITLE
Fix StopAll concurrency issue

### DIFF
--- a/Sources/DesktopManager.Tests/WindowKeepAliveTests.cs
+++ b/Sources/DesktopManager.Tests/WindowKeepAliveTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for the <see cref="WindowKeepAlive"/> service.
+/// </summary>
+public class WindowKeepAliveTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensure StopAll does not throw when timers are active.
+    /// </summary>
+    public void StopAll_DoesNotThrow() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var keepAlive = WindowKeepAlive.Instance;
+        keepAlive.Start(new IntPtr(1), TimeSpan.FromMilliseconds(10));
+        keepAlive.Start(new IntPtr(2), TimeSpan.FromMilliseconds(10));
+
+        Thread.Sleep(50);
+
+        try {
+            keepAlive.StopAll();
+        } finally {
+            keepAlive.Dispose();
+        }
+
+        Assert.IsTrue(true);
+    }
+}

--- a/Sources/DesktopManager/WindowKeepAlive.cs
+++ b/Sources/DesktopManager/WindowKeepAlive.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
+using System.Linq;
 using System.Threading;
 
 namespace DesktopManager;
@@ -69,7 +70,8 @@ public sealed class WindowKeepAlive : IDisposable {
     /// Stops all keep alive sessions.
     /// </summary>
     public void StopAll() {
-        foreach (var handle in _timers.Keys) {
+        var handles = _timers.Keys.ToList();
+        foreach (var handle in handles) {
             Stop(handle);
         }
     }


### PR DESCRIPTION
## Summary
- update WindowKeepAlive StopAll to snapshot keys before iteration for thread safety
- add MSTest for StopAll

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0 --no-build` *(fails: System.PlatformNotSupportedException: COM is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686ce5690f2c832ea8648413d2fa1bec