### PR TITLE
Fix MonitorWatcher disposal logic and add finalizer test

### DIFF
--- a/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
+++ b/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DesktopManager.Tests;
@@ -13,6 +14,10 @@ public class LogonWallpaperTests {
     /// Ensure SetLogonWallpaper does not throw for existing file.
     /// </summary>
     public void SetLogonWallpaper_NoThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
         var monitors = new Monitors();
         string temp = Path.GetTempFileName();
         File.WriteAllBytes(temp, new byte[] {1});

--- a/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
@@ -25,4 +25,26 @@ public class MonitorWatcherTests {
         using var watcher = new MonitorWatcher();
         Assert.IsNotNull(watcher);
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures finalizer does not throw after disposal.
+    /// </summary>
+    public void MonitorWatcher_FinalizerSafeAfterDispose() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var watcher = new MonitorWatcher();
+        watcher.Dispose();
+        watcher = null;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        Assert.IsTrue(true);
+    }
 }

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -113,7 +113,6 @@ public sealed class MonitorWatcher : IDisposable {
     /// </summary>
     public void Dispose() {
         Dispose(true);
-        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -124,10 +123,16 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private void Dispose(bool disposing) {
-        if (!_disposed) {
-            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
-            _disposed = true;
+        if (_disposed) {
+            return;
         }
+
+        if (disposing) {
+            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+            GC.SuppressFinalize(this);
+        }
+
+        _disposed = true;
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- guard against double disposal in `MonitorWatcher`
- suppress finalization inside `Dispose`
- ensure `MonitorWatcher` finalizer is safe after disposal
- skip logon wallpaper test when not running on Windows

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0 --no-build --verbosity minimal`
- `dotnet build Sources/DesktopManager.sln --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ce58dd78c832ea1a5e535d0aedef2