### PR TITLE
Ensure wallpaper temp cleanup

### DIFF
--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -35,14 +35,11 @@ public partial class MonitorService {
     /// <param name="monitorId">The monitor ID.</param>
     /// <param name="imageStream">Stream containing image data.</param>
     public void SetWallpaper(string monitorId, Stream imageStream) {
-        string? temp = null;
+        string temp = WriteStreamToTempFile(imageStream);
         try {
-            temp = WriteStreamToTempFile(imageStream);
             SetWallpaper(monitorId, temp);
         } finally {
-            if (temp is not null) {
-                DeleteTempFile(temp);
-            }
+            DeleteTempFile(temp);
         }
     }
 
@@ -144,14 +141,11 @@ public partial class MonitorService {
     /// </summary>
     /// <param name="imageStream">Stream containing image data.</param>
     public void SetWallpaper(Stream imageStream) {
-        string? temp = null;
+        string temp = WriteStreamToTempFile(imageStream);
         try {
-            temp = WriteStreamToTempFile(imageStream);
             SetWallpaper(temp);
         } finally {
-            if (temp is not null) {
-                DeleteTempFile(temp);
-            }
+            DeleteTempFile(temp);
         }
     }
 

--- a/Tests/SetDesktopWallpaperCleanup.Tests.ps1
+++ b/Tests/SetDesktopWallpaperCleanup.Tests.ps1
@@ -1,0 +1,32 @@
+describe 'Set-DesktopWallpaper cleanup' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/..\DesktopManager.psd1" -Force
+    }
+
+    it 'removes temporary file when using ImageData' -Skip:(-not $IsWindows) {
+        $tempDir = Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tempDir | Out-Null
+        $oldTemp = $env:TEMP
+        $oldTmp  = $env:TMP
+        $env:TEMP = $tempDir
+        $env:TMP  = $tempDir
+        try {
+            $bytes  = 0..10
+            $stream = New-Object System.IO.MemoryStream
+            $stream.Write($bytes, 0, $bytes.Length)
+            $stream.Position = 0
+            try {
+                Set-DesktopWallpaper -All -ImageData $stream
+            } catch {
+                # ignore failures from COM APIs
+            }
+            $count = (Get-ChildItem -Path $tempDir).Count
+        } finally {
+            $stream.Dispose()
+            $env:TEMP = $oldTemp
+            $env:TMP  = $oldTmp
+            Remove-Item $tempDir -Recurse -Force
+        }
+        $count | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary
- ensure temp file cleanup in wallpaper methods
- add pester test for cleanup when using ImageData

## Testing
- `dotnet test Sources/DesktopManager.sln` *(fails: Could not find 'mono' host)*
- `pwsh -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: COM is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686ce5838620832eaead02c8c68fe131