### PR TITLE
Replace console writes with ILogger

### DIFF
--- a/Sources/DesktopManager.Tests/FakeLogger.cs
+++ b/Sources/DesktopManager.Tests/FakeLogger.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopManager.Tests;
+
+internal class FakeLogger<T> : ILogger<T>
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/Sources/DesktopManager.Tests/MonitorServiceInitializationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceInitializationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DesktopManager.Tests;
@@ -88,10 +90,11 @@ public class MonitorServiceInitializationTests {
         using var sw = new System.IO.StringWriter();
         var original = Console.Out;
         Console.SetOut(sw);
-        new MonitorService(new FailingEnableDesktopManager());
+        var logger = new FakeLogger<MonitorService>();
+        _ = new MonitorService(new FailingEnableDesktopManager(), logger);
         Console.SetOut(original);
-
-        StringAssert.Contains(sw.ToString(), "DesktopManager initialization failed");
+        Assert.AreEqual(string.Empty, sw.ToString());
+        Assert.IsTrue(logger.Entries.Any(e => e.Message.Contains("DesktopManager initialization failed")));
     }
 }
 

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -44,6 +44,7 @@
       <PackageReference Include="System.Drawing.Common" Version="8.0.17" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
+using Microsoft.Extensions.Logging;
 
 namespace DesktopManager;
 
@@ -40,12 +41,12 @@ public partial class MonitorService {
         SetLogonWallpaperFallback(imagePath);
     }
 
-    private static void SetLogonWallpaperFallback(string imagePath) {
+    private void SetLogonWallpaperFallback(string imagePath) {
         try {
             using RegistryKey? key = Registry.LocalMachine.CreateSubKey(RegistryPath);
             key?.SetValue(RegistryValue, imagePath, RegistryValueKind.String);
         } catch (Exception ex) {
-            Console.WriteLine($"SetLogonWallpaperFallback failed: {ex.Message}");
+            _logger.LogError(ex, "SetLogonWallpaperFallback failed");
         }
     }
 
@@ -77,14 +78,14 @@ public partial class MonitorService {
         return GetLogonWallpaperFallback();
     }
 
-    private static string GetLogonWallpaperFallback() {
+    private string GetLogonWallpaperFallback() {
         try {
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey(RegistryPath);
             if (key != null && key.GetValue(RegistryValue) is string value) {
                 return value;
             }
         } catch (Exception ex) {
-            Console.WriteLine($"GetLogonWallpaperFallback failed: {ex.Message}");
+            _logger.LogError(ex, "GetLogonWallpaperFallback failed");
         }
         return string.Empty;
     }

--- a/Sources/DesktopManager/MonitorService.Theme.cs
+++ b/Sources/DesktopManager/MonitorService.Theme.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Win32;
+using Microsoft.Extensions.Logging;
 
 namespace DesktopManager;
 
@@ -21,7 +22,7 @@ public partial class MonitorService {
                 }
             }
         } catch (Exception ex) {
-            Console.WriteLine($"GetSystemTheme failed: {ex.Message}");
+            _logger.LogError(ex, "GetSystemTheme failed");
         }
         return SystemTheme.Light;
     }
@@ -40,15 +41,15 @@ public partial class MonitorService {
             }
             RefreshTheme();
         } catch (Exception ex) {
-            Console.WriteLine($"SetSystemTheme failed: {ex.Message}");
+            _logger.LogError(ex, "SetSystemTheme failed");
         }
     }
 
-    private static void RefreshTheme() {
+    private void RefreshTheme() {
         try {
             MonitorNativeMethods.SendMessage(MonitorNativeMethods.HWND_BROADCAST, MonitorNativeMethods.WM_SETTINGCHANGE, 0, 0);
         } catch (Exception ex) {
-            Console.WriteLine($"RefreshTheme failed: {ex.Message}");
+            _logger.LogError(ex, "RefreshTheme failed");
         }
     }
 }

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace DesktopManager;
 
@@ -13,9 +14,17 @@ public class Monitors {
     /// <summary>
     /// Initializes a new instance of the <see cref="Monitors"/> class.
     /// </summary>
-    public Monitors() {
-        IDesktopManager desktopManager = (IDesktopManager)new DesktopManagerWrapper(); // Explicit cast
-        _monitorService = new MonitorService(desktopManager);
+    public Monitors() : this(null, null) {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Monitors"/> class with optional dependencies.
+    /// </summary>
+    /// <param name="desktopManager">Custom <see cref="IDesktopManager"/> implementation.</param>
+    /// <param name="logger">Optional logger instance.</param>
+    public Monitors(IDesktopManager? desktopManager = null, ILogger<MonitorService>? logger = null) {
+        IDesktopManager dm = desktopManager ?? (IDesktopManager)new DesktopManagerWrapper();
+        _monitorService = new MonitorService(dm, logger);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add ILogger.Abstractions to DesktopManager
- replace Console.WriteLine with ILogger logging across services
- allow logger injection in Monitors and MonitorService
- update initialization test to use FakeLogger
- add FakeLogger helper

## Testing
- `dotnet build Sources/DesktopManager.sln --no-restore`
- `pwsh ./DesktopManager.Tests.ps1` *(fails: COM is not supported)*
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --no-build --verbosity minimal` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_686ce57c9d0c832eb068ff4b922a288a