### PR TITLE
Fix slideshow COM error handling

### DIFF
--- a/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
+++ b/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DesktopManager.Tests;
@@ -32,5 +34,20 @@ public class ErrorHandlingTests {
         typeof(MonitorService).GetMethod("SetWallpaperPositionFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, new object?[] { DesktopWallpaperPosition.Center });
         typeof(MonitorService).GetMethod("GetBackgroundColorFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, null);
         typeof(MonitorService).GetMethod("SetBackgroundColorFallback", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(service, new object?[] { 0u });
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for StartWallpaperSlideshow_InvalidPath_ThrowsInvalidOperationException.
+    /// </summary>
+    public void StartWallpaperSlideshow_InvalidPath_ThrowsInvalidOperationException() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var service = new MonitorService(new FakeDesktopManager());
+        string invalidPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.jpg");
+
+        Assert.ThrowsException<InvalidOperationException>(() => service.StartWallpaperSlideshow(new[] { invalidPath }));
     }
 }

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -512,7 +512,11 @@ public partial class MonitorService {
                 if (string.IsNullOrEmpty(path)) continue;
                 int hr = MonitorNativeMethods.SHCreateItemFromParsingName(path, IntPtr.Zero, ref iidShellItem, out IntPtr item);
                 if (hr != 0) {
-                    Marshal.ThrowExceptionForHR(hr);
+                    try {
+                        Marshal.ThrowExceptionForHR(hr);
+                    } catch (Exception ex) {
+                        throw new InvalidOperationException($"SHCreateItemFromParsingName failed for '{path}'", ex);
+                    }
                 }
                 object obj = Marshal.GetObjectForIUnknown(item);
                 collection.AddObject(obj);


### PR DESCRIPTION
## Summary
- improve COM exception context when creating shell items
- test invalid slideshow paths

## Testing
- `dotnet test DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0`
- `dotnet format DesktopManager.sln --verify-no-changes` *(fails: whitespace formatting errors)*
- `dotnet build DesktopManager.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_686d1f872258832eaf278378ce071bd7