### PR TITLE
Handle no-op monitor moves

### DIFF
--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -76,4 +76,59 @@ public class WindowPositionTests {
         var dummy = new WindowInfo { Handle = IntPtr.Zero };
         Assert.ThrowsException<InvalidOperationException>(() => manager.GetWindowPosition(dummy));
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for MoveWindowToMonitor_OnSameMonitor_ReturnsFalse.
+    /// </summary>
+    public void MoveWindowToMonitor_OnSameMonitor_ReturnsFalse() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var monitors = new Monitors().GetMonitors(index: window.MonitorIndex);
+        var monitor = monitors.FirstOrDefault();
+        if (monitor == null) {
+            Assert.Inconclusive("Monitor not found");
+        }
+
+        bool moved = manager.MoveWindowToMonitor(window, monitor);
+
+        Assert.IsFalse(moved);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for MoveWindowToMonitor_OnDifferentMonitor_ReturnsTrue.
+    /// </summary>
+    public void MoveWindowToMonitor_OnDifferentMonitor_ReturnsTrue() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var monitors = new Monitors().GetMonitors();
+        if (monitors.Count < 2) {
+            Assert.Inconclusive("Need at least two monitors");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var target = monitors.First(m => m.Index != window.MonitorIndex);
+
+        bool moved = manager.MoveWindowToMonitor(window, target);
+
+        Assert.IsTrue(moved);
+    }
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -245,7 +245,11 @@ namespace DesktopManager {
         /// </summary>
         /// <param name="windowInfo">The window to move.</param>
         /// <param name="targetMonitor">The monitor to move the window to.</param>
-        public void MoveWindowToMonitor(WindowInfo windowInfo, Monitor targetMonitor) {
+        /// <returns>
+        /// True if the window was repositioned; false if the window was already on the target monitor
+        /// at the same coordinates.
+        /// </returns>
+        public bool MoveWindowToMonitor(WindowInfo windowInfo, Monitor targetMonitor) {
             if (targetMonitor == null) {
                 throw new ArgumentNullException(nameof(targetMonitor));
             }
@@ -271,7 +275,15 @@ namespace DesktopManager {
             int newLeft = targetBounds.Left + offsetX;
             int newTop = targetBounds.Top + offsetY;
 
+            if (currentBounds.Left == targetBounds.Left &&
+                currentBounds.Top == targetBounds.Top &&
+                currentBounds.Right == targetBounds.Right &&
+                currentBounds.Bottom == targetBounds.Bottom) {
+                return false;
+            }
+
             SetWindowPosition(windowInfo, newLeft, newTop);
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- return a status from `MoveWindowToMonitor` when called
- add XML comments describing new behaviour
- test moving windows to monitors

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d1f932a74832e8516c76773130d61