### PR TITLE
Fix display device interface retrieval

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorEnumerationTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Linq;
 
 namespace DesktopManager.Tests;
 
@@ -22,5 +23,20 @@ public class MonitorEnumerationTests
         var monitors = new Monitors().GetMonitorsConnected();
         Assert.IsNotNull(monitors);
         Assert.IsTrue(monitors.Count > 0, "No monitors were returned");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures enumerated monitors provide a non-empty device name.
+    /// </summary>
+    public void GetMonitorsConnected_DeviceNamesAvailable()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var monitors = new Monitors().GetMonitorsConnected();
+        Assert.IsTrue(monitors.All(m => !string.IsNullOrEmpty(m.DeviceName)), "DeviceName missing");
     }
 }

--- a/Sources/DesktopManager/EnumDisplayDevicesFlags.cs
+++ b/Sources/DesktopManager/EnumDisplayDevicesFlags.cs
@@ -1,0 +1,14 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Flags for <see cref="MonitorNativeMethods.EnumDisplayDevices"/>.
+/// </summary>
+[Flags]
+public enum EnumDisplayDevicesFlags : uint {
+    /// <summary>No flags.</summary>
+    None = 0,
+    /// <summary>
+    /// Requests that <see cref="DISPLAY_DEVICE.DeviceID"/> contain the device interface name.
+    /// </summary>
+    EDD_GET_DEVICE_INTERFACE_NAME = 0x00000001
+}

--- a/Sources/DesktopManager/MonitorNativeMethods.Display.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Display.cs
@@ -23,7 +23,7 @@ public static partial class MonitorNativeMethods {
     /// <param name="lpDevice">The device name.</param>
     /// <param name="iDevNum">The index of the display device.</param>
     /// <param name="lpDisplayDevice">A pointer to a <see cref="DISPLAY_DEVICE"/> structure that receives the information.</param>
-    /// <param name="dwFlags">Set this flag to 0.</param>
+    /// <param name="dwFlags">Combination of <see cref="EnumDisplayDevicesFlags"/> values.</param>
     /// <returns>True if the function succeeds; otherwise, false.</returns>
     [DllImport("user32.dll", CharSet = CharSet.Auto)]
     public static extern bool EnumDisplayDevices(string lpDevice, uint iDevNum, ref DISPLAY_DEVICE lpDisplayDevice, uint dwFlags);

--- a/Sources/DesktopManager/MonitorService.Core.cs
+++ b/Sources/DesktopManager/MonitorService.Core.cs
@@ -81,7 +81,7 @@ public partial class MonitorService {
                     // Populate new properties
                     DISPLAY_DEVICE d = new DISPLAY_DEVICE();
                     d.cb = Marshal.SizeOf(d);
-                    if (MonitorNativeMethods.EnumDisplayDevices(null, i, ref d, 0)) {
+                    if (MonitorNativeMethods.EnumDisplayDevices(null, i, ref d, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
                         monitor.DeviceName = d.DeviceName;
                         monitor.DeviceString = d.DeviceString;
                         monitor.StateFlags = d.StateFlags;
@@ -108,7 +108,7 @@ public partial class MonitorService {
             if (MonitorNativeMethods.GetMonitorInfo(hMonitor, ref info)) {
                 DISPLAY_DEVICE device = new DISPLAY_DEVICE();
                 device.cb = Marshal.SizeOf(device);
-                if (MonitorNativeMethods.EnumDisplayDevices(info.szDevice, 0, ref device, 0)) {
+                if (MonitorNativeMethods.EnumDisplayDevices(info.szDevice, 0, ref device, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
                     var monitor = new Monitor(this) {
                         Index = index,
                         DeviceId = info.szDevice,

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -275,7 +275,7 @@ public partial class MonitorService {
         d.cb = Marshal.SizeOf(d);
         int deviceNum = 0;
 
-        while (MonitorNativeMethods.EnumDisplayDevices(null, (uint)deviceNum, ref d, 0)) {
+        while (MonitorNativeMethods.EnumDisplayDevices(null, (uint)deviceNum, ref d, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
             if ((d.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) != 0) {
                 DEVMODE devMode = new DEVMODE();
                 devMode.dmSize = (short)Marshal.SizeOf(typeof(DEVMODE));
@@ -541,7 +541,7 @@ public partial class MonitorService {
         d.cb = Marshal.SizeOf(d);
 
         int deviceNum = 0;
-        while (MonitorNativeMethods.EnumDisplayDevices(null, (uint)deviceNum, ref d, 0)) {
+        while (MonitorNativeMethods.EnumDisplayDevices(null, (uint)deviceNum, ref d, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
             Console.WriteLine($"Device Name: {d.DeviceName}");
             Console.WriteLine($"Device String: {d.DeviceString}");
             Console.WriteLine($"State Flags: {d.StateFlags}");
@@ -564,7 +564,7 @@ public partial class MonitorService {
         device.cb = Marshal.SizeOf(device);
 
         uint deviceNum = 0;
-        while (MonitorNativeMethods.EnumDisplayDevices(null, deviceNum, ref device, 0)) {
+        while (MonitorNativeMethods.EnumDisplayDevices(null, deviceNum, ref device, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
             if ((device.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) != 0) {
                 devices.Add(device);
             }

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -91,7 +91,7 @@ public sealed class MonitorWatcher : IDisposable {
         DISPLAY_DEVICE device = new();
         device.cb = Marshal.SizeOf(device);
         uint index = 0;
-        while (MonitorNativeMethods.EnumDisplayDevices(null, index, ref device, 0)) {
+        while (MonitorNativeMethods.EnumDisplayDevices(null, index, ref device, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
             if ((device.StateFlags & DisplayDeviceStateFlags.AttachedToDesktop) != 0) {
                 DEVMODE mode = new();
                 mode.dmSize = (short)Marshal.SizeOf<DEVMODE>();


### PR DESCRIPTION
## Summary
- ensure EnumDisplayDevices retrieves device interface names
- add EnumDisplayDevicesFlags enum
- update monitor enumeration to use the new flag
- verify device names in unit tests

## Testing
- `dotnet test Sources/DesktopManager.sln -f net8.0`
- `dotnet build Sources/DesktopManager.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686d1f9a98f4832eb048e858af7455e1