### PR TITLE
Ensure monitor lookup ignores case

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorServiceCaseInsensitiveTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceCaseInsensitiveTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Test class for MonitorServiceCaseInsensitiveTests.
+/// </summary>
+public class MonitorServiceCaseInsensitiveTests {
+    [TestMethod]
+    /// <summary>
+    /// Test for GetMonitorPosition_IsCaseInsensitive.
+    /// </summary>
+    public void GetMonitorPosition_IsCaseInsensitive() {
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var fake = new FakeDesktopManager();
+        fake.DevicePaths[0] = "MON1";
+        var service = new MonitorService(fake);
+
+        var pos = service.GetMonitorPosition("mon1");
+
+        Assert.AreEqual(0, pos.Left);
+        Assert.AreEqual(0, pos.Top);
+        Assert.AreEqual(10, pos.Right);
+        Assert.AreEqual(10, pos.Bottom);
+    }
+}

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -241,7 +241,7 @@ public partial class MonitorService {
     public MonitorPosition GetMonitorPosition(string deviceId) {
         var monitors = GetMonitors();
         foreach (var monitor in monitors) {
-            if (monitor.DeviceId == deviceId) {
+            if (string.Equals(monitor.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase)) {
                 return new MonitorPosition(monitor.Rect.Left, monitor.Rect.Top, monitor.Rect.Right, monitor.Rect.Bottom);
             }
         }


### PR DESCRIPTION
## Summary
- fix monitor device matching to use `StringComparison.OrdinalIgnoreCase`
- cover mixed case device IDs in monitor position tests

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release --no-build --framework net8.0 --logger "console;verbosity=detailed"`
- `pwsh -Command ./DesktopManager.Tests.ps1` *(fails: The term 'Save-DesktopWindowLayout' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_686d32241078832e920a962fbbe0eeb1