### PR TITLE
Add default audio device cmdlet

### DIFF
--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 @{
     AliasesToExport        = @('Get-DesktopMonitors', 'Set-LockScreenWallpaper', 'Get-LockScreenWallpaper')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow', 'Get-LogonWallpaper', 'Set-LogonWallpaper')
+    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DefaultAudioDevice', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow', 'Get-LogonWallpaper', 'Set-LogonWallpaper')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Examples/SetDefaultAudioDevice.ps1
+++ b/Examples/SetDefaultAudioDevice.ps1
@@ -1,0 +1,4 @@
+Import-Module .\DesktopManager.psd1 -Force
+
+# Change the default playback device (preview with WhatIf)
+Set-DefaultAudioDevice -DeviceId 'DEVICE_ID' -WhatIf

--- a/Sources/DesktopManager.PowerShell/CmdletSetDefaultAudioDevice.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDefaultAudioDevice.cs
@@ -1,0 +1,25 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Sets the default audio device.</summary>
+/// <para type="synopsis">Sets the default audio device.</para>
+/// <para type="description">Sets the system default audio playback device using Core Audio APIs.</para>
+[Cmdlet(VerbsCommon.Set, "DefaultAudioDevice", SupportsShouldProcess = true)]
+public sealed class CmdletSetDefaultAudioDevice : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Identifier of the audio device.</para>
+    /// </summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    public string DeviceId;
+
+    /// <summary>
+    /// Begin processing the cmdlet.
+    /// </summary>
+    protected override void BeginProcessing() {
+        if (ShouldProcess($"Audio device {DeviceId}", "Set as default")) {
+            AudioService service = new AudioService();
+            service.SetDefaultAudioDevice(DeviceId);
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/AudioServiceTests.cs
+++ b/Sources/DesktopManager.Tests/AudioServiceTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for the <see cref="AudioService"/> class.
+/// </summary>
+public class AudioServiceTests {
+    private sealed class FakePolicyConfig : IPolicyConfigClient {
+        public readonly List<(string id, ERole role)> Calls = new();
+        public void SetDefaultEndpoint(string devID, ERole role) => Calls.Add((devID, role));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Verify that setting the default device calls the policy client for all roles.
+    /// </summary>
+    public void SetDefaultAudioDevice_CallsPolicyForAllRoles() {
+        var fake = new FakePolicyConfig();
+        var service = new AudioService(fake);
+        service.SetDefaultAudioDevice("device1");
+
+        Assert.AreEqual(3, fake.Calls.Count);
+        Assert.AreEqual(("device1", ERole.eConsole), fake.Calls[0]);
+        Assert.AreEqual(("device1", ERole.eMultimedia), fake.Calls[1]);
+        Assert.AreEqual(("device1", ERole.eCommunications), fake.Calls[2]);
+    }
+}

--- a/Sources/DesktopManager/AudioService.cs
+++ b/Sources/DesktopManager/AudioService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.Versioning;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Service to manage system audio devices.
+/// </summary>
+public class AudioService {
+    private readonly IPolicyConfigClient _policy;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioService"/> class.
+    /// </summary>
+    /// <param name="policy">Optional policy configuration client.</param>
+    public AudioService(IPolicyConfigClient? policy = null) {
+        _policy = policy ?? new PolicyConfigClient();
+    }
+
+    /// <summary>
+    /// Sets the default audio device for all roles.
+    /// </summary>
+    /// <param name="deviceId">Identifier of the device.</param>
+    [SupportedOSPlatform("windows")]
+    public void SetDefaultAudioDevice(string deviceId) {
+        if (deviceId == null) {
+            throw new ArgumentNullException(nameof(deviceId));
+        }
+
+        _policy.SetDefaultEndpoint(deviceId, ERole.eConsole);
+        _policy.SetDefaultEndpoint(deviceId, ERole.eMultimedia);
+        _policy.SetDefaultEndpoint(deviceId, ERole.eCommunications);
+    }
+}

--- a/Sources/DesktopManager/ERole.cs
+++ b/Sources/DesktopManager/ERole.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Roles supported when setting default audio device.
+/// </summary>
+public enum ERole {
+    /// <summary>Console audio stream.</summary>
+    eConsole = 0,
+    /// <summary>Multimedia audio stream.</summary>
+    eMultimedia = 1,
+    /// <summary>Communications audio stream.</summary>
+    eCommunications = 2,
+    /// <summary>Number of roles.</summary>
+    ERole_enum_count = 3
+}

--- a/Sources/DesktopManager/IPolicyConfig.cs
+++ b/Sources/DesktopManager/IPolicyConfig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// COM interface for configuring audio endpoint policies.
+/// </summary>
+[ComImport]
+[Guid("f8679f50-850a-41cf-9c72-430f290290c8")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IPolicyConfig {
+    int GetMixFormat(string pszDeviceName, IntPtr ppFormat);
+    int GetDeviceFormat(string pszDeviceName, bool bDefault, IntPtr ppFormat);
+    int ResetDeviceFormat(string pszDeviceName);
+    int SetDeviceFormat(string pszDeviceName, IntPtr pEndpointFormat, IntPtr MixFormat);
+    int GetProcessingPeriod(string pszDeviceName, bool bDefault, IntPtr pmftDefaultPeriod, IntPtr pmftMinimumPeriod);
+    int SetProcessingPeriod(string pszDeviceName, IntPtr pmftPeriod);
+    int GetShareMode(string pszDeviceName, IntPtr pMode);
+    int SetShareMode(string pszDeviceName, IntPtr mode);
+    int GetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetDefaultEndpoint(string pszDeviceName, ERole role);
+    int SetEndpointVisibility(string pszDeviceName, bool bVisible);
+}

--- a/Sources/DesktopManager/IPolicyConfig10.cs
+++ b/Sources/DesktopManager/IPolicyConfig10.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// COM interface for configuring audio endpoint policies on Windows 10.
+/// </summary>
+[ComImport]
+[Guid("00000000-0000-0000-C000-000000000046")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IPolicyConfig10 {
+    int GetMixFormat(string pszDeviceName, IntPtr ppFormat);
+    int GetDeviceFormat(string pszDeviceName, bool bDefault, IntPtr ppFormat);
+    int ResetDeviceFormat(string pszDeviceName);
+    int SetDeviceFormat(string pszDeviceName, IntPtr pEndpointFormat, IntPtr MixFormat);
+    int GetProcessingPeriod(string pszDeviceName, bool bDefault, IntPtr pmftDefaultPeriod, IntPtr pmftMinimumPeriod);
+    int SetProcessingPeriod(string pszDeviceName, IntPtr pmftPeriod);
+    int GetShareMode(string pszDeviceName, IntPtr pMode);
+    int SetShareMode(string pszDeviceName, IntPtr mode);
+    int GetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetDefaultEndpoint(string pszDeviceName, ERole role);
+    int SetEndpointVisibility(string pszDeviceName, bool bVisible);
+}

--- a/Sources/DesktopManager/IPolicyConfigVista.cs
+++ b/Sources/DesktopManager/IPolicyConfigVista.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Older COM interface for configuring audio endpoint policies on Windows Vista.
+/// </summary>
+[ComImport]
+[Guid("568B9108-44BF-40B4-9006-86AFE5B5A620")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IPolicyConfigVista {
+    int GetMixFormat(string pszDeviceName, IntPtr ppFormat);
+    int GetDeviceFormat(string pszDeviceName, bool bDefault, IntPtr ppFormat);
+    int ResetDeviceFormat(string pszDeviceName);
+    int SetDeviceFormat(string pszDeviceName, IntPtr pEndpointFormat, IntPtr MixFormat);
+    int GetProcessingPeriod(string pszDeviceName, bool bDefault, IntPtr pmftDefaultPeriod, IntPtr pmftMinimumPeriod);
+    int SetProcessingPeriod(string pszDeviceName, IntPtr pmftPeriod);
+    int GetShareMode(string pszDeviceName, IntPtr pMode);
+    int SetShareMode(string pszDeviceName, IntPtr mode);
+    int GetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetPropertyValue(string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+    int SetDefaultEndpoint(string pszDeviceName, ERole role);
+    int SetEndpointVisibility(string pszDeviceName, bool bVisible);
+}

--- a/Sources/DesktopManager/PolicyConfigClient.cs
+++ b/Sources/DesktopManager/PolicyConfigClient.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Wrapper around Core Audio policy configuration COM interfaces.
+/// </summary>
+public interface IPolicyConfigClient {
+    /// <summary>Sets the default audio endpoint for the specified role.</summary>
+    /// <param name="devID">Device identifier.</param>
+    /// <param name="role">Audio role.</param>
+    void SetDefaultEndpoint(string devID, ERole role);
+}
+
+[ComImport]
+[Guid("870af99c-171d-4f9e-af0d-e63df40c2bc9")]
+internal class _PolicyConfigClient {
+}
+
+/// <summary>
+/// Implementation using the native policy configuration interfaces.
+/// </summary>
+public class PolicyConfigClient : IPolicyConfigClient {
+    private readonly IPolicyConfig? _policyConfig;
+    private readonly IPolicyConfigVista? _policyConfigVista;
+    private readonly IPolicyConfig10? _policyConfig10;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolicyConfigClient"/> class.
+    /// </summary>
+    public PolicyConfigClient() {
+        _policyConfig = new _PolicyConfigClient() as IPolicyConfig;
+        if (_policyConfig != null) {
+            return;
+        }
+
+        _policyConfigVista = new _PolicyConfigClient() as IPolicyConfigVista;
+        if (_policyConfigVista != null) {
+            return;
+        }
+
+        _policyConfig10 = new _PolicyConfigClient() as IPolicyConfig10;
+    }
+
+    /// <inheritdoc/>
+    public void SetDefaultEndpoint(string devID, ERole role) {
+        if (_policyConfig != null) {
+            Marshal.ThrowExceptionForHR(_policyConfig.SetDefaultEndpoint(devID, role));
+            return;
+        }
+        if (_policyConfigVista != null) {
+            Marshal.ThrowExceptionForHR(_policyConfigVista.SetDefaultEndpoint(devID, role));
+            return;
+        }
+        if (_policyConfig10 != null) {
+            Marshal.ThrowExceptionForHR(_policyConfig10.SetDefaultEndpoint(devID, role));
+        }
+    }
+}

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -48,6 +48,10 @@ Describe 'DesktopManager basic tests' {
     It 'Exports Get-DesktopWindowKeepAlive' {
         Get-Command Get-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
     }
+    It 'Exports Set-DefaultAudioDevice' {
+        Get-Command Set-DefaultAudioDevice | Should -Not -BeNullOrEmpty
+    }
+
 
     It 'Exports Set-DesktopWindowText' {
         Get-Command Set-DesktopWindowText | Should -Not -BeNullOrEmpty

--- a/Tests/SetDefaultAudioDevice.Tests.ps1
+++ b/Tests/SetDefaultAudioDevice.Tests.ps1
@@ -1,0 +1,8 @@
+describe 'Default audio device cmdlet' {
+    it 'exports Set-DefaultAudioDevice' {
+        Get-Command Set-DefaultAudioDevice | Should -Not -BeNullOrEmpty
+    }
+    it 'supports WhatIf' -Skip:(-not $IsWindows) {
+        { Set-DefaultAudioDevice -DeviceId 'test' -WhatIf } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add CoreAudio wrappers and `AudioService`
- implement `Set-DefaultAudioDevice` cmdlet
- add example script
- add unit and pester tests
- expose new cmdlet in module manifest

## Testing
- `dotnet build Sources/DesktopManager.sln -c Debug`
- `pwsh DesktopManager.Tests.ps1` *(fails: COM is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686d449f77fc832eb7cb7e7c0c48f07e