### PR TITLE
Add privilege checker for admin operations

### DIFF
--- a/Sources/DesktopManager.PowerShell/CmdletSetLogonWallpaper.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetLogonWallpaper.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Management.Automation;
+using DesktopManager;
 
 namespace DesktopManager.PowerShell;
 
@@ -23,6 +24,7 @@ public sealed class CmdletSetLogonWallpaper : PSCmdlet {
         }
 
         if (ShouldProcess("System", $"Set logon wallpaper to '{ImagePath}'")) {
+            PrivilegeChecker.EnsureElevated();
             Monitors monitors = new Monitors();
             monitors.SetLogonWallpaper(ImagePath);
         }

--- a/Sources/DesktopManager.Tests/PrivilegeCheckerTests.cs
+++ b/Sources/DesktopManager.Tests/PrivilegeCheckerTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DesktopManager;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class PrivilegeCheckerTests {
+    [TestMethod]
+    public void EnsureElevated_ThrowsWhenNotElevated() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.ThrowsException<PlatformNotSupportedException>(() => PrivilegeChecker.EnsureElevated());
+        } else {
+            if (PrivilegeChecker.IsElevated) {
+                Assert.Inconclusive("Test requires non-elevated context");
+            }
+
+            Assert.ThrowsException<InvalidOperationException>(() => PrivilegeChecker.EnsureElevated());
+        }
+    }
+}

--- a/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
@@ -18,6 +18,7 @@ public partial class MonitorService {
     /// <param name="imagePath">Path to the image file.</param>
     [SupportedOSPlatform("windows")]
     public void SetLogonWallpaper(string imagePath) {
+        PrivilegeChecker.EnsureElevated();
         try {
             Type lockScreenType = Type.GetType(
                 "Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime")
@@ -54,6 +55,7 @@ public partial class MonitorService {
     }
 
     private static void SetLogonWallpaperFallback(string imagePath) {
+        PrivilegeChecker.EnsureElevated();
         try {
             using RegistryKey? key = Registry.LocalMachine.CreateSubKey(RegistryPath);
             key?.SetValue(RegistryValue, imagePath, RegistryValueKind.String);

--- a/Sources/DesktopManager/PrivilegeChecker.cs
+++ b/Sources/DesktopManager/PrivilegeChecker.cs
@@ -1,0 +1,30 @@
+using System.Runtime.Versioning;
+using System.Security.Principal;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Helper for checking if the current process is running with administrative privileges.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public static class PrivilegeChecker {
+    /// <summary>
+    /// Returns true if the current process is elevated.
+    /// </summary>
+    public static bool IsElevated {
+        get {
+            using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            WindowsPrincipal principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> if the current process is not elevated.
+    /// </summary>
+    public static void EnsureElevated() {
+        if (!IsElevated) {
+            throw new InvalidOperationException("Operation requires administrative privileges.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PrivilegeChecker` helper
- enforce admin check for logon wallpaper operations
- update PowerShell cmdlet to verify admin rights
- cover new logic with unit tests

## Testing
- `dotnet test Sources/DesktopManager.sln --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_686d72bd4a68832eb4791ded3149f82f