### PR TITLE
Add EDID parsing support

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorEdidParsingTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorEdidParsingTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorEdidParsingTests {
+    [TestMethod]
+    public void ParseManufacturerFromEdid_ReturnsCorrectCode() {
+        byte[] edid = new byte[128];
+        edid[8] = 0x04;
+        edid[9] = 0x72;
+
+        var method = typeof(Monitor).GetMethod("ParseManufacturerFromEdid", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        string manufacturer = (string)method!.Invoke(null, new object[] { edid })!;
+
+        Assert.AreEqual("ACR", manufacturer);
+    }
+
+    [TestMethod]
+    public void ParseSerialNumberFromEdid_ReturnsCorrectValue() {
+        byte[] edid = new byte[128];
+        edid[12] = 0x4D;
+        edid[13] = 0x3C;
+        edid[14] = 0x2B;
+        edid[15] = 0x1A;
+
+        var method = typeof(Monitor).GetMethod("ParseSerialNumberFromEdid", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        string serial = (string)method!.Invoke(null, new object[] { edid })!;
+
+        Assert.AreEqual("439041101", serial);
+    }
+}

--- a/Sources/DesktopManager/MonitorService.Core.cs
+++ b/Sources/DesktopManager/MonitorService.Core.cs
@@ -87,6 +87,7 @@ public partial class MonitorService {
                         monitor.StateFlags = d.StateFlags;
                         monitor.DeviceKey = d.DeviceKey;
                     }
+                    monitor.LoadEdidInfo();
                 }
                 list.Add(monitor);
             }
@@ -118,6 +119,7 @@ public partial class MonitorService {
                         DeviceKey = device.DeviceKey,
                         Rect = info.rcMonitor
                     };
+                    monitor.LoadEdidInfo();
                     monitors.Add(monitor);
                 }
             }


### PR DESCRIPTION
## Summary
- parse EDID manufacturer and serial in `Monitor`
- expose new data via `Get-DesktopMonitor`
- test EDID parsing logic

## Testing
- `dotnet test Sources/DesktopManager.sln -c Release --no-build`
- `dotnet build Sources/DesktopManager.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d72d354c0832ea3005f1d2226fb3b