### PR TITLE
Ensure COM init for logon wallpaper

### DIFF
--- a/Sources/DesktopManager.Tests/ComInitializationTests.cs
+++ b/Sources/DesktopManager.Tests/ComInitializationTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for COM initialization during logon wallpaper operations.
+/// </summary>
+public class ComInitializationTests {
+    private class ComTrackingService : MonitorService {
+        public bool InitCalled;
+        public bool UninitCalled;
+        public ComTrackingService() : base(new FakeDesktopManager()) { }
+        protected override bool InitializeCom() { InitCalled = true; return true; }
+        protected override void UninitializeCom() { UninitCalled = true; }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensure SetLogonWallpaper initializes and uninitializes COM.
+    /// </summary>
+    public void SetLogonWallpaper_InitializesCom() {
+        var service = new ComTrackingService();
+        try { service.SetLogonWallpaper("path"); } catch { }
+        Assert.IsTrue(service.InitCalled);
+        Assert.IsTrue(service.UninitCalled);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensure GetLogonWallpaper initializes and uninitializes COM.
+    /// </summary>
+    public void GetLogonWallpaper_InitializesCom() {
+        var service = new ComTrackingService();
+        try { _ = service.GetLogonWallpaper(); } catch { }
+        Assert.IsTrue(service.InitCalled);
+        Assert.IsTrue(service.UninitCalled);
+    }
+}
+

--- a/Sources/DesktopManager/MonitorNativeMethods.Com.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Com.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// COM initialization related native methods.
+/// </summary>
+public static partial class MonitorNativeMethods {
+    /// <summary>Apartment threaded COM initialization flag.</summary>
+    public const uint COINIT_APARTMENTTHREADED = 0x2;
+
+    /// <summary>Initializes the COM library on the current thread.</summary>
+    /// <param name="pvReserved">Reserved, must be IntPtr.Zero.</param>
+    /// <param name="dwCoInit">Initialization options.</param>
+    /// <returns>HRESULT indicating success or failure.</returns>
+    [DllImport("ole32.dll")]
+    public static extern int CoInitializeEx(IntPtr pvReserved, uint dwCoInit);
+
+    /// <summary>Closes the COM library on the current thread.</summary>
+    [DllImport("ole32.dll")]
+    public static extern void CoUninitialize();
+}

--- a/Sources/DesktopManager/MonitorService.Com.cs
+++ b/Sources/DesktopManager/MonitorService.Com.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Provides COM initialization helpers for <see cref="MonitorService"/>.
+/// </summary>
+public partial class MonitorService {
+    /// <summary>Initializes COM on the current thread.</summary>
+    /// <returns><c>true</c> if initialization succeeded.</returns>
+    protected virtual bool InitializeCom() {
+        return MonitorNativeMethods.CoInitializeEx(IntPtr.Zero, MonitorNativeMethods.COINIT_APARTMENTTHREADED) >= 0;
+    }
+
+    /// <summary>Uninitializes COM on the current thread.</summary>
+    protected virtual void UninitializeCom() {
+        MonitorNativeMethods.CoUninitialize();
+    }
+}

--- a/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
@@ -18,6 +18,7 @@ public partial class MonitorService {
     /// <param name="imagePath">Path to the image file.</param>
     [SupportedOSPlatform("windows")]
     public void SetLogonWallpaper(string imagePath) {
+        bool comInitialized = InitializeCom();
         try {
             Type lockScreenType = Type.GetType(
                 "Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime")
@@ -48,6 +49,10 @@ public partial class MonitorService {
             throw;
         } catch {
             // ignore and use fallback
+        } finally {
+            if (comInitialized) {
+                UninitializeCom();
+            }
         }
 
         SetLogonWallpaperFallback(imagePath);
@@ -68,6 +73,7 @@ public partial class MonitorService {
     /// <returns>Path to the logon wallpaper or empty string.</returns>
     [SupportedOSPlatform("windows")]
     public string GetLogonWallpaper() {
+        bool comInitialized = InitializeCom();
         try {
             Type lockScreenType = Type.GetType(
                 "Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime")
@@ -88,6 +94,11 @@ public partial class MonitorService {
         } catch {
             // ignore and use fallback
         }
+        finally {
+            if (comInitialized) {
+                UninitializeCom();
+            }
+        }
 
         return GetLogonWallpaperFallback();
     }
@@ -104,3 +115,4 @@ public partial class MonitorService {
         return string.Empty;
     }
 }
+


### PR DESCRIPTION
## Summary
- call `CoInitializeEx`/`CoUninitialize` for logon wallpaper methods
- add COM initialization helpers and native methods
- test COM initialization via mock service

## Testing
- `dotnet test Sources/DesktopManager.sln -f net8.0 --verbosity minimal` *(fails: DllNotFoundException)*
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: COM is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_686d72dd378c832ea2fe7f17f3caeed4