### PR TITLE
Add monitor hotplug events

### DIFF
--- a/Sources/DesktopManager.Example/MonitorWatcherExample.cs
+++ b/Sources/DesktopManager.Example/MonitorWatcherExample.cs
@@ -20,6 +20,10 @@ internal static class MonitorWatcherExample {
         using var watcher = new MonitorWatcher();
         watcher.DisplaySettingsChanged += (_, _) =>
             Helpers.AddLine("MonitorWatcher", "Display settings changed");
+        watcher.MonitorConnected += (_, _) =>
+            Helpers.AddLine("MonitorWatcher", "Monitor connected");
+        watcher.MonitorDisconnected += (_, _) =>
+            Helpers.AddLine("MonitorWatcher", "Monitor disconnected");
         Console.WriteLine($"Monitoring display changes for {duration.TotalSeconds} seconds...");
         await Task.Delay(duration);
     }

--- a/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherTests.cs
@@ -1,5 +1,7 @@
 using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using DesktopManager;
 
 namespace DesktopManager.Tests;
 
@@ -46,5 +48,86 @@ public class MonitorWatcherTests {
         GC.WaitForPendingFinalizers();
         GC.Collect();
         Assert.IsTrue(true);
+    }
+
+    private class TestWatcher : MonitorWatcher {
+        private Queue<Dictionary<string, MonitorWatcher.MonitorState>> _states;
+
+        public TestWatcher(params Dictionary<string, MonitorWatcher.MonitorState>[] states) : base(false) {
+            _states = new Queue<Dictionary<string, MonitorWatcher.MonitorState>>(states);
+        }
+
+        protected override Dictionary<string, MonitorWatcher.MonitorState> GetCurrentStates() {
+            return _states.Peek();
+        }
+
+        public void SetState(Dictionary<string, MonitorWatcher.MonitorState> state) {
+            _states.Clear();
+            _states.Enqueue(state);
+        }
+
+        public void Trigger() {
+            CheckForChanges();
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Simulates monitor connection event.
+    /// </summary>
+    public void MonitorWatcher_RaisesConnectEvent() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var initial = new Dictionary<string, MonitorWatcher.MonitorState> {
+            {"DISPLAY1", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }}
+        };
+        var changed = new Dictionary<string, MonitorWatcher.MonitorState> {
+            {"DISPLAY1", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }},
+            {"DISPLAY2", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }}
+        };
+
+        var watcher = new TestWatcher(initial);
+        bool raised = false;
+        watcher.MonitorConnected += (_, _) => raised = true;
+        watcher.SetState(changed);
+        watcher.Trigger();
+
+        Assert.IsTrue(raised);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Simulates monitor disconnection event.
+    /// </summary>
+    public void MonitorWatcher_RaisesDisconnectEvent() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var initial = new Dictionary<string, MonitorWatcher.MonitorState> {
+            {"DISPLAY1", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }},
+            {"DISPLAY2", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }}
+        };
+        var changed = new Dictionary<string, MonitorWatcher.MonitorState> {
+            {"DISPLAY1", new MonitorWatcher.MonitorState { Width = 10, Height = 10, Orientation = 0 }}
+        };
+
+        var watcher = new TestWatcher(initial);
+        bool raised = false;
+        watcher.MonitorDisconnected += (_, _) => raised = true;
+        watcher.SetState(changed);
+        watcher.Trigger();
+
+        Assert.IsTrue(raised);
     }
 }

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -50,6 +50,15 @@
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
+  <!-- Required for WMI-based monitor detection -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="System.Management" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+      <Reference Include="System.Management" />
+  </ItemGroup>
+
   <ItemGroup>
       <Compile Include="..\Shared\SupportedOSPlatformAttribute.cs" />
   </ItemGroup>
@@ -69,6 +78,7 @@
         <Using Include="System.Runtime.InteropServices" />
         <Using Include="System" />
         <Using Include="System.Collections.Generic" />
+        <Using Include="System.Management" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
 using System.Collections.Generic;
+using System.Management;
 
 namespace DesktopManager;
 
@@ -11,7 +12,7 @@ namespace DesktopManager;
 /// Monitors display change notifications using <c>WM_DISPLAYCHANGE</c>.
 /// </summary>
 [SupportedOSPlatform("windows")]
-public sealed class MonitorWatcher : IDisposable {
+public class MonitorWatcher : IDisposable {
     /// <summary>
     /// Raised when display settings change.
     /// </summary>
@@ -27,12 +28,24 @@ public sealed class MonitorWatcher : IDisposable {
     /// </summary>
     public event EventHandler ResolutionChanged;
 
+    /// <summary>
+    /// Raised when monitor is connected.
+    /// </summary>
+    public event EventHandler MonitorConnected;
+
+    /// <summary>
+    /// Raised when monitor is disconnected.
+    /// </summary>
+    public event EventHandler MonitorDisconnected;
+
     private const int ENUM_CURRENT_SETTINGS = -1;
 
     private Dictionary<string, MonitorState> _state = new();
     private bool _disposed;
+    private ManagementEventWatcher? _connectWatcher;
+    private ManagementEventWatcher? _disconnectWatcher;
 
-    private struct MonitorState {
+    public struct MonitorState {
         /// <summary>Current width of the monitor.</summary>
         public int Width;
 
@@ -47,46 +60,25 @@ public sealed class MonitorWatcher : IDisposable {
     /// Initializes a new instance of the <see cref="MonitorWatcher"/> class.
     /// </summary>
     /// <exception cref="PlatformNotSupportedException">Thrown when not running on Windows.</exception>
-    public MonitorWatcher() {
+    public MonitorWatcher() : this(true) { }
+
+    protected MonitorWatcher(bool enableDeviceWatchers) {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             throw new PlatformNotSupportedException("MonitorWatcher is supported only on Windows.");
         }
 
         _state = GetCurrentStates();
         SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
+        if (enableDeviceWatchers) {
+            InitializeDeviceWatchers();
+        }
     }
 
     private void OnDisplaySettingsChanged(object sender, EventArgs e) {
-        var current = GetCurrentStates();
-        bool orientationChanged = false;
-        bool resolutionChanged = false;
-
-        foreach (var item in current) {
-            if (_state.TryGetValue(item.Key, out var prev)) {
-                if (prev.Orientation != item.Value.Orientation) {
-                    orientationChanged = true;
-                }
-                if (prev.Width != item.Value.Width || prev.Height != item.Value.Height) {
-                    resolutionChanged = true;
-                }
-            } else {
-                orientationChanged = true;
-                resolutionChanged = true;
-            }
-        }
-
-        _state = current;
-
-        DisplaySettingsChanged?.Invoke(this, EventArgs.Empty);
-        if (orientationChanged) {
-            OrientationChanged?.Invoke(this, EventArgs.Empty);
-        }
-        if (resolutionChanged) {
-            ResolutionChanged?.Invoke(this, EventArgs.Empty);
-        }
+        CheckForChanges();
     }
 
-    private Dictionary<string, MonitorState> GetCurrentStates() {
+    protected virtual Dictionary<string, MonitorState> GetCurrentStates() {
         Dictionary<string, MonitorState> states = new();
         DISPLAY_DEVICE device = new();
         device.cb = Marshal.SizeOf(device);
@@ -107,6 +99,68 @@ public sealed class MonitorWatcher : IDisposable {
         }
         return states;
     }
+
+    protected void CheckForChanges() {
+        var current = GetCurrentStates();
+        bool orientationChanged = false;
+        bool resolutionChanged = false;
+        bool connected = false;
+        bool disconnected = false;
+
+        foreach (var item in current) {
+            if (_state.TryGetValue(item.Key, out var prev)) {
+                if (prev.Orientation != item.Value.Orientation) {
+                    orientationChanged = true;
+                }
+                if (prev.Width != item.Value.Width || prev.Height != item.Value.Height) {
+                    resolutionChanged = true;
+                }
+            } else {
+                orientationChanged = true;
+                resolutionChanged = true;
+                connected = true;
+            }
+        }
+
+        foreach (var item in _state.Keys) {
+            if (!current.ContainsKey(item)) {
+                disconnected = true;
+            }
+        }
+
+        _state = current;
+
+        DisplaySettingsChanged?.Invoke(this, EventArgs.Empty);
+        if (orientationChanged) {
+            OrientationChanged?.Invoke(this, EventArgs.Empty);
+        }
+        if (resolutionChanged) {
+            ResolutionChanged?.Invoke(this, EventArgs.Empty);
+        }
+        if (connected) {
+            MonitorConnected?.Invoke(this, EventArgs.Empty);
+        }
+        if (disconnected) {
+            MonitorDisconnected?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private void InitializeDeviceWatchers() {
+        try {
+            var connectQuery = new WqlEventQuery("__InstanceCreationEvent", new TimeSpan(0, 0, 1), "TargetInstance ISA 'Win32_PnPEntity' AND TargetInstance.PNPClass = 'Monitor'");
+            _connectWatcher = new ManagementEventWatcher(connectQuery);
+            _connectWatcher.EventArrived += (_, _) => CheckForChanges();
+            _connectWatcher.Start();
+
+            var disconnectQuery = new WqlEventQuery("__InstanceDeletionEvent", new TimeSpan(0, 0, 1), "TargetInstance ISA 'Win32_PnPEntity' AND TargetInstance.PNPClass = 'Monitor'");
+            _disconnectWatcher = new ManagementEventWatcher(disconnectQuery);
+            _disconnectWatcher.EventArrived += (_, _) => CheckForChanges();
+            _disconnectWatcher.Start();
+        } catch (ManagementException) {
+            // WMI might not be available
+        }
+    }
+
 
     /// <summary>
     /// Unsubscribes from system events.
@@ -129,6 +183,10 @@ public sealed class MonitorWatcher : IDisposable {
 
         if (disposing) {
             SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+            _connectWatcher?.Stop();
+            _connectWatcher?.Dispose();
+            _disconnectWatcher?.Stop();
+            _disconnectWatcher?.Dispose();
             GC.SuppressFinalize(this);
         }
 


### PR DESCRIPTION
## Summary
- expand MonitorWatcher with MonitorConnected/MonitorDisconnected events using WMI
- show new events in example
- add unit tests simulating monitor connection and disconnection
- document System.Management requirement in project file

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release -f net8.0 --no-build`
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: module cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d72983d8c832eb745e18a25c3fd0c