### PR TITLE
Add monitor connection events

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorWatcherDeviceChangeTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherDeviceChangeTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+[SupportedOSPlatform("windows")]
+/// <summary>Tests for monitor connection events.</summary>
+public class MonitorWatcherDeviceChangeTests {
+    [TestMethod]
+    /// <summary>Verify MonitorConnected is raised.</summary>
+    public void MonitorConnected_EventRaised() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var watcher = new MonitorWatcher();
+        bool raised = false;
+        watcher.MonitorConnected += (_, _) => raised = true;
+        MonitorNativeMethods.DEV_BROADCAST_DEVICEINTERFACE data = new() {
+            dbcc_size = (uint)Marshal.SizeOf<MonitorNativeMethods.DEV_BROADCAST_DEVICEINTERFACE>(),
+            dbcc_devicetype = MonitorNativeMethods.DBT_DEVTYP_DEVICEINTERFACE,
+            dbcc_classguid = MonitorNativeMethods.GUID_DEVINTERFACE_MONITOR
+        };
+        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(data));
+        try {
+            Marshal.StructureToPtr(data, ptr, false);
+            watcher.ProcessDeviceChange(ptr, true);
+        } finally {
+            Marshal.FreeHGlobal(ptr);
+        }
+        Assert.IsTrue(raised);
+    }
+
+    [TestMethod]
+    /// <summary>Verify MonitorDisconnected is raised.</summary>
+    public void MonitorDisconnected_EventRaised() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var watcher = new MonitorWatcher();
+        bool raised = false;
+        watcher.MonitorDisconnected += (_, _) => raised = true;
+        MonitorNativeMethods.DEV_BROADCAST_DEVICEINTERFACE data = new() {
+            dbcc_size = (uint)Marshal.SizeOf<MonitorNativeMethods.DEV_BROADCAST_DEVICEINTERFACE>(),
+            dbcc_devicetype = MonitorNativeMethods.DBT_DEVTYP_DEVICEINTERFACE,
+            dbcc_classguid = MonitorNativeMethods.GUID_DEVINTERFACE_MONITOR
+        };
+        IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(data));
+        try {
+            Marshal.StructureToPtr(data, ptr, false);
+            watcher.ProcessDeviceChange(ptr, false);
+        } finally {
+            Marshal.FreeHGlobal(ptr);
+        }
+        Assert.IsTrue(raised);
+    }
+}

--- a/Sources/DesktopManager/MonitorNativeMethods.Device.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Device.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+/// <summary>
+/// Native device notification related platform invocations.
+/// </summary>
+public static partial class MonitorNativeMethods {
+    /// <summary>Message indicating a device change.</summary>
+    public const uint WM_DEVICECHANGE = 0x0219;
+
+    /// <summary>Device arrival event.</summary>
+    public const int DBT_DEVICEARRIVAL = 0x8000;
+
+    /// <summary>Device removal event.</summary>
+    public const int DBT_DEVICEREMOVECOMPLETE = 0x8004;
+
+    /// <summary>Device interface class type.</summary>
+    public const int DBT_DEVTYP_DEVICEINTERFACE = 0x00000005;
+
+    /// <summary>GUID for monitor device interface notifications.</summary>
+    public static readonly Guid GUID_DEVINTERFACE_MONITOR = new("E6F07B5F-EE97-4a90-B076-33F57BF4EAA7");
+
+    /// <summary>
+    /// Header for device broadcast messages.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DEV_BROADCAST_HDR {
+        /// <summary>Structure size.</summary>
+        public uint dbch_size;
+        /// <summary>Device type.</summary>
+        public uint dbch_devicetype;
+        /// <summary>Reserved.</summary>
+        public uint dbch_reserved;
+    }
+
+    /// <summary>
+    /// Device interface notification structure.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct DEV_BROADCAST_DEVICEINTERFACE {
+        /// <summary>Structure size.</summary>
+        public uint dbcc_size;
+        /// <summary>Device type.</summary>
+        public uint dbcc_devicetype;
+        /// <summary>Reserved.</summary>
+        public uint dbcc_reserved;
+        /// <summary>Class GUID.</summary>
+        public Guid dbcc_classguid;
+        /// <summary>Device name.</summary>
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string dbcc_name;
+    }
+
+    /// <summary>Registers for device notifications.</summary>
+    /// <param name="hRecipient">Window handle.</param>
+    /// <param name="notificationFilter">Filter structure pointer.</param>
+    /// <param name="flags">Notification flags.</param>
+    /// <returns>Registration handle.</returns>
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern IntPtr RegisterDeviceNotification(IntPtr hRecipient, IntPtr notificationFilter, uint flags);
+
+    /// <summary>Unregisters device notifications.</summary>
+    /// <param name="handle">Registration handle.</param>
+    /// <returns>True if successful.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool UnregisterDeviceNotification(IntPtr handle);
+}

--- a/Sources/DesktopManager/WindowMessage.cs
+++ b/Sources/DesktopManager/WindowMessage.cs
@@ -12,6 +12,11 @@ public enum WindowMessage {
     /// <summary>
     /// Broadcast of power-management events.
     /// </summary>
-    WM_POWERBROADCAST = 0x0218
+    WM_POWERBROADCAST = 0x0218,
+
+    /// <summary>
+    /// Broadcast of device add or remove events.
+    /// </summary>
+    WM_DEVICECHANGE = 0x0219
 }
 


### PR DESCRIPTION
## Summary
- extend `MonitorWatcher` with `MonitorConnected` and `MonitorDisconnected`
- use WM_DEVICECHANGE notifications via new `DeviceChangeWindow`
- expose native device change constants
- test monitor connection and disconnection handling

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_686d81246e8c832e9eab4c94717cded0