### PR TITLE
Handle cleanup for physical monitors

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorHandleCleanupTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorHandleCleanupTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for handle tracking and cleanup in MonitorService.
+/// </summary>
+public class MonitorHandleCleanupTests {
+    [TestMethod]
+    /// <summary>
+    /// GetMonitorBrightness releases monitor handles when completed.
+    /// </summary>
+    public void GetMonitorBrightness_ReleasesHandles() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var service = new MonitorService(new FakeDesktopManager());
+        var monitors = service.GetMonitorsConnected();
+        if (monitors.Count == 0) {
+            Assert.Inconclusive("No monitors found");
+        }
+
+        var field = typeof(MonitorService).GetField("_monitorHandles", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field);
+        var list = (List<PHYSICAL_MONITOR>)field!.GetValue(service)!;
+
+        string deviceId = monitors[0].DeviceId;
+        try {
+            service.GetMonitorBrightness(deviceId);
+        } catch (Exception ex) {
+            Console.WriteLine($"GetMonitorBrightness threw: {ex.Message}");
+        }
+
+        Assert.AreEqual(0, list.Count);
+    }
+}

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -12,6 +12,7 @@ namespace DesktopManager;
 /// Provides methods for managing display-related monitor settings.
 /// </summary>
 public partial class MonitorService {
+    private readonly List<PHYSICAL_MONITOR> _monitorHandles = new();
     /// <summary>
     /// Gets the desktop background color.
     /// </summary>
@@ -417,8 +418,13 @@ public partial class MonitorService {
         }
         PHYSICAL_MONITOR[] monitors = new PHYSICAL_MONITOR[count];
         if (!MonitorNativeMethods.GetPhysicalMonitorsFromHMONITOR(found, count, monitors)) {
+            uint released = (uint)monitors.Count(m => m.hPhysicalMonitor != IntPtr.Zero);
+            if (released > 0) {
+                MonitorNativeMethods.DestroyPhysicalMonitors(released, monitors);
+            }
             return Array.Empty<PHYSICAL_MONITOR>();
         }
+        _monitorHandles.AddRange(monitors);
         return monitors;
     }
 
@@ -441,6 +447,9 @@ public partial class MonitorService {
             if (!MonitorNativeMethods.DestroyPhysicalMonitors((uint)monitors.Length, monitors)) {
                 Console.WriteLine("DestroyPhysicalMonitors failed");
             }
+            foreach (var m in monitors) {
+                _monitorHandles.Remove(m);
+            }
         }
     }
 
@@ -461,6 +470,9 @@ public partial class MonitorService {
         } finally {
             if (!MonitorNativeMethods.DestroyPhysicalMonitors((uint)monitors.Length, monitors)) {
                 Console.WriteLine("DestroyPhysicalMonitors failed");
+            }
+            foreach (var m in monitors) {
+                _monitorHandles.Remove(m);
             }
         }
     }


### PR DESCRIPTION
## Summary
- track monitor handles in `GetPhysicalMonitors`
- ensure handles are released on enumeration failure
- remove tracked handles after destroying
- test monitor handle cleanup

## Testing
- `dotnet test Sources/DesktopManager.sln` *(fails: FileNotFoundException - could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68700ab66808832ebf4f6cd970b43d5d