### PR TITLE
Handle state retrieval errors in MonitorWatcher

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorWatcherStateFailureTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherStateFailureTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Reflection;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+[SupportedOSPlatform("windows")]
+public class MonitorWatcherStateFailureTests {
+    [TestMethod]
+    public void OnDisplaySettingsChanged_DoesNotUpdateState_WhenProviderFails() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var watcher = new MonitorWatcher();
+        var field = typeof(MonitorWatcher).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field);
+        var before = field.GetValue(watcher);
+
+        watcher.StateProvider = () => throw new InvalidOperationException("fail");
+
+        using var sw = new System.IO.StringWriter();
+        var original = Console.Out;
+        Console.SetOut(sw);
+        var method = typeof(MonitorWatcher).GetMethod("OnDisplaySettingsChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(method);
+        method.Invoke(watcher, new object?[] { null, EventArgs.Empty });
+        Console.SetOut(original);
+
+        var after = field.GetValue(watcher);
+        Assert.AreSame(before, after);
+        StringAssert.Contains(sw.ToString(), "GetCurrentStates failed");
+    }
+}


### PR DESCRIPTION
## Summary
- add injection point for monitor state provider
- guard state retrieval in `MonitorWatcher` against exceptions
- test that state isn't updated when provider fails

## Testing
- `dotnet test Sources/DesktopManager.sln -f net8.0` *(fails: 2, passed: 37, skipped: 51)*

------
https://chatgpt.com/codex/tasks/task_e_68700aac2e98832eb0b7b10724160a48