### PR TITLE
Refactor MonitorService file utilities

### DIFF
--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -117,25 +117,6 @@ public partial class MonitorService {
         return string.Empty;
     }
 
-    private static string WriteStreamToTempFile(Stream stream) {
-        string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        try {
-            using FileStream fs = File.Create(path);
-            stream.CopyTo(fs);
-            return path;
-        } catch {
-            DeleteTempFile(path);
-            throw;
-        }
-    }
-
-    private static void DeleteTempFile(string path) {
-        try {
-            File.Delete(path);
-        } catch (Exception ex) {
-            Console.WriteLine($"DeleteTempFile failed: {ex.Message}");
-        }
-    }
 
     private DesktopWallpaperPosition GetWallpaperPositionFallback() {
         try {

--- a/Sources/DesktopManager/MonitorService.FileUtilities.cs
+++ b/Sources/DesktopManager/MonitorService.FileUtilities.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+
+namespace DesktopManager;
+
+public partial class MonitorService {
+    private static string WriteStreamToTempFile(Stream stream) {
+        string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try {
+            using FileStream fs = File.Create(path);
+            stream.CopyTo(fs);
+            return path;
+        } catch {
+            DeleteTempFile(path);
+            throw;
+        }
+    }
+
+    private static void DeleteTempFile(string path) {
+        try {
+            File.Delete(path);
+        } catch (Exception ex) {
+            Console.WriteLine($"DeleteTempFile failed: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract temporary file helpers into `MonitorService.FileUtilities`
- trim `MonitorService.Display` accordingly

## Testing
- `dotnet test Sources/DesktopManager.sln --no-build --framework net8.0` *(fails: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_687020a52910832e822885d0ad484505