### PR TITLE
Add window edge snap

### DIFF
--- a/Sources/DesktopManager.Example/Program.cs
+++ b/Sources/DesktopManager.Example/Program.cs
@@ -75,6 +75,9 @@ namespace DesktopManager.Example {
             // Demonstrate window management features
             WindowExamples.Run();
 
+            // Demonstrate automatic window snapping
+            WindowSnapExample.Run();
+
             // Demonstrate window keep-alive features
             WindowKeepAliveExample.Run();
 

--- a/Sources/DesktopManager.Example/WindowSnapExample.cs
+++ b/Sources/DesktopManager.Example/WindowSnapExample.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Example;
+
+/// <summary>
+/// Demonstrates automatic snapping when moving windows near monitor edges.
+/// </summary>
+internal static class WindowSnapExample {
+    /// <summary>Runs the edge snapping example.</summary>
+    public static void Run() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Console.WriteLine("Window snapping requires Windows.");
+            return;
+        }
+
+        var manager = new WindowManager(new WindowSnapOptions { SnapThreshold = 30 });
+        manager.StartAutoSnap();
+        Console.WriteLine("Move a window near the edge to snap. Press Enter to stop...");
+        Console.ReadLine();
+        manager.StopAutoSnap();
+    }
+}

--- a/Sources/DesktopManager.Tests/EdgeSnapTests.cs
+++ b/Sources/DesktopManager.Tests/EdgeSnapTests.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for edge snapping logic.
+/// </summary>
+public class EdgeSnapTests {
+    [TestMethod]
+    /// <summary>
+    /// GetSnapPosition detects left edge.
+    /// </summary>
+    public void GetSnapPosition_LeftEdge() {
+        var bounds = new RECT { Left = 0, Top = 0, Right = 1000, Bottom = 1000 };
+        var pos = new WindowPosition { Left = 5, Top = 100, Right = 305, Bottom = 400 };
+        var snap = WindowManager.GetSnapPosition(pos, bounds, 10);
+        Assert.AreEqual(SnapPosition.Left, snap);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// GetSnapPosition detects top-right corner.
+    /// </summary>
+    public void GetSnapPosition_TopRight() {
+        var bounds = new RECT { Left = 0, Top = 0, Right = 800, Bottom = 600 };
+        var pos = new WindowPosition { Left = 790, Top = 5, Right = 810, Bottom = 305 };
+        var snap = WindowManager.GetSnapPosition(pos, bounds, 15);
+        Assert.AreEqual(SnapPosition.TopRight, snap);
+    }
+}

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -443,4 +443,25 @@ public static partial class MonitorNativeMethods
         /// <summary>Additional information associated with the keystroke.</summary>
         public IntPtr ExtraInfo;
     }
+
+    /// <summary>
+    /// Delegate for WinEvent callbacks.
+    /// </summary>
+    public delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
+        int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+    /// <summary>Hook flag to receive events out of context.</summary>
+    public const uint WINEVENT_OUTOFCONTEXT = 0;
+
+    /// <summary>Event fired when a window move/size operation ends.</summary>
+    public const uint EVENT_SYSTEM_MOVESIZEEND = 0x000B;
+
+    /// <summary>Installs an event hook.</summary>
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc,
+        WinEventDelegate lpfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+
+    /// <summary>Removes an event hook.</summary>
+    [DllImport("user32.dll")]
+    public static extern bool UnhookWinEvent(IntPtr hWinEventHook);
 }

--- a/Sources/DesktopManager/WindowManager.Snap.cs
+++ b/Sources/DesktopManager/WindowManager.Snap.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+public partial class WindowManager {
+    private MonitorNativeMethods.WinEventDelegate? _moveDelegate;
+    private IntPtr _moveHook;
+
+    /// <summary>
+    /// Gets options for window snapping.
+    /// </summary>
+    public WindowSnapOptions SnapOptions { get; }
+
+    /// <summary>
+    /// Initializes snapping options.
+    /// </summary>
+    /// <param name="options">Snap options instance.</param>
+    public WindowManager(WindowSnapOptions? options) : this() {
+        SnapOptions = options ?? new WindowSnapOptions();
+    }
+
+    /// <summary>
+    /// Starts automatic snapping when windows are moved near edges.
+    /// </summary>
+    public void StartAutoSnap() {
+        if (_moveHook != IntPtr.Zero) {
+            return;
+        }
+
+        _moveDelegate = OnMoveEnd;
+        _moveHook = MonitorNativeMethods.SetWinEventHook(
+            MonitorNativeMethods.EVENT_SYSTEM_MOVESIZEEND,
+            MonitorNativeMethods.EVENT_SYSTEM_MOVESIZEEND,
+            IntPtr.Zero,
+            _moveDelegate,
+            0,
+            0,
+            MonitorNativeMethods.WINEVENT_OUTOFCONTEXT);
+    }
+
+    /// <summary>
+    /// Stops automatic snapping.
+    /// </summary>
+    public void StopAutoSnap() {
+        if (_moveHook != IntPtr.Zero) {
+            MonitorNativeMethods.UnhookWinEvent(_moveHook);
+            _moveHook = IntPtr.Zero;
+        }
+    }
+
+    private void OnMoveEnd(IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime) {
+        if (hwnd == IntPtr.Zero) {
+            return;
+        }
+
+        var window = new WindowInfo { Handle = hwnd };
+        var position = GetWindowPosition(window);
+        var monitor = _monitors.GetMonitors().FirstOrDefault(m => {
+            var b = m.GetMonitorBounds();
+            return position.Left >= b.Left && position.Left < b.Right && position.Top >= b.Top && position.Top < b.Bottom;
+        });
+        if (monitor == null) {
+            return;
+        }
+
+        var bounds = monitor.GetMonitorBounds();
+        var snap = GetSnapPosition(position, bounds, SnapOptions.SnapThreshold);
+        if (snap.HasValue) {
+            SnapWindow(window, snap.Value);
+        }
+    }
+
+    internal static SnapPosition? GetSnapPosition(WindowPosition pos, RECT bounds, int threshold) {
+        bool left = Math.Abs(pos.Left - bounds.Left) <= threshold;
+        bool right = Math.Abs(pos.Right - bounds.Right) <= threshold;
+        bool top = Math.Abs(pos.Top - bounds.Top) <= threshold;
+        bool bottom = Math.Abs(pos.Bottom - bounds.Bottom) <= threshold;
+
+        if (left && top) {
+            return SnapPosition.TopLeft;
+        }
+        if (left && bottom) {
+            return SnapPosition.BottomLeft;
+        }
+        if (right && top) {
+            return SnapPosition.TopRight;
+        }
+        if (right && bottom) {
+            return SnapPosition.BottomRight;
+        }
+        if (left) {
+            return SnapPosition.Left;
+        }
+        if (right) {
+            return SnapPosition.Right;
+        }
+        return null;
+    }
+}

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -19,6 +19,7 @@ public partial class WindowManager {
         /// </summary>
         public WindowManager() {
             _monitors = new Monitors();
+            SnapOptions = new WindowSnapOptions();
         }
 
         /// <summary>

--- a/Sources/DesktopManager/WindowSnapOptions.cs
+++ b/Sources/DesktopManager/WindowSnapOptions.cs
@@ -1,0 +1,11 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Options controlling automatic window snapping behavior.
+/// </summary>
+public class WindowSnapOptions {
+    /// <summary>
+    /// Threshold in pixels for snapping windows to monitor edges.
+    /// </summary>
+    public int SnapThreshold { get; set; } = 20;
+}


### PR DESCRIPTION
## Summary
- hook into window move events via WinEvent API
- add snapping configuration options
- implement auto-snapping logic
- include example usage
- cover edge snap detection with tests

## Testing
- `dotnet build Sources/DesktopManager.sln`
- `dotnet test Sources/DesktopManager.sln --no-build` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_68716d945040832e8aa10afb33f03e8c