### PR TITLE
Validate wallpaper path

### DIFF
--- a/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
+++ b/Sources/DesktopManager.Tests/ErrorHandlingTests.cs
@@ -50,4 +50,20 @@ public class ErrorHandlingTests {
 
         Assert.ThrowsException<InvalidOperationException>(() => service.StartWallpaperSlideshow(new[] { invalidPath }));
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for SetSystemWallpaper_ThrowsOnNullOrEmpty.
+    /// </summary>
+    public void SetSystemWallpaper_ThrowsOnNullOrEmpty() {
+        var service = new MonitorService(new FakeDesktopManager());
+        var method = typeof(MonitorService).GetMethod("SetSystemWallpaper", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(method);
+
+        var ex1 = Assert.ThrowsException<TargetInvocationException>(() => method!.Invoke(service, new object?[] { null }));
+        Assert.IsInstanceOfType(ex1.InnerException, typeof(ArgumentNullException));
+
+        var ex2 = Assert.ThrowsException<TargetInvocationException>(() => method!.Invoke(service, new object?[] { string.Empty }));
+        Assert.IsInstanceOfType(ex2.InnerException, typeof(ArgumentNullException));
+    }
 }

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -102,7 +102,15 @@ public partial class MonitorService {
     /// </summary>
     /// <param name="path">Path to the wallpaper image.</param>
     private void SetSystemWallpaper(string path) {
-        MonitorNativeMethods.SystemParametersInfo(MonitorNativeMethods.SPI_SETDESKWALLPAPER, 0, path, MonitorNativeMethods.SPIF_UPDATEINIFILE | MonitorNativeMethods.SPIF_SENDWININICHANGE);
+        if (string.IsNullOrEmpty(path)) {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        MonitorNativeMethods.SystemParametersInfo(
+            MonitorNativeMethods.SPI_SETDESKWALLPAPER,
+            0,
+            path,
+            MonitorNativeMethods.SPIF_UPDATEINIFILE | MonitorNativeMethods.SPIF_SENDWININICHANGE);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- validate wallpaper path when calling SystemParametersInfo
- test SetSystemWallpaper path validation

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --framework net8.0 -v minimal`
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: Cannot find PowerShell module binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68716e20cf8c832eaa07898ae3b32e0b