### PR TITLE
Fix style retrieval for 64-bit

### DIFF
--- a/Sources/DesktopManager.Tests/WindowStyleRetrievalTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStyleRetrievalTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for verifying window style retrieval on 64-bit processes.
+/// </summary>
+public class WindowStyleRetrievalTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures GetWindowPosition returns the correct state when running on 64-bit.
+    /// </summary>
+    public void GetWindowPosition_ReturnsCorrectState_On64Bit() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+        if (IntPtr.Size != 8) {
+            Assert.Inconclusive("Test requires 64-bit process");
+        }
+
+        var manager = new WindowManager();
+        var windows = manager.GetWindows();
+        if (windows.Count == 0) {
+            Assert.Inconclusive("No windows found to test");
+        }
+
+        var window = windows.First();
+        var position = manager.GetWindowPosition(window);
+        long expectedStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_STYLE).ToInt64();
+        var expectedState = WindowState.Normal;
+        if ((expectedStyle & MonitorNativeMethods.WS_MINIMIZE) != 0) {
+            expectedState = WindowState.Minimize;
+        } else if ((expectedStyle & MonitorNativeMethods.WS_MAXIMIZE) != 0) {
+            expectedState = WindowState.Maximize;
+        }
+
+        Assert.AreEqual(expectedState, position.State);
+    }
+}

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -68,7 +68,7 @@ public partial class WindowManager {
 
                             // Get window state using the IntPtr wrapper to work on x86 and x64
                             IntPtr stylePtr = MonitorNativeMethods.GetWindowLongPtr(handle, MonitorNativeMethods.GWL_STYLE);
-                            int style = unchecked((int)(long)stylePtr);
+                            long style = stylePtr.ToInt64();
                             if ((style & MonitorNativeMethods.WS_MINIMIZE) != 0) {
                                 windowInfo.State = WindowState.Minimize;
                             } else if ((style & MonitorNativeMethods.WS_MAXIMIZE) != 0) {
@@ -114,7 +114,7 @@ public partial class WindowManager {
             if (MonitorNativeMethods.GetWindowRect(windowInfo.Handle, out rect)) {
                 // Re-evaluate the current state directly from the window to avoid stale data
                 IntPtr stylePtr = MonitorNativeMethods.GetWindowLongPtr(windowInfo.Handle, MonitorNativeMethods.GWL_STYLE);
-                int style = unchecked((int)(long)stylePtr);
+                long style = stylePtr.ToInt64();
                 var state = WindowState.Normal;
                 if ((style & MonitorNativeMethods.WS_MINIMIZE) != 0) {
                     state = WindowState.Minimize;


### PR DESCRIPTION
## Summary
- handle window styles using 64-bit integers
- add tests for style retrieval on 64-bit

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68716e2e6fc0832e98c3bcf31855ed83