### PR TITLE
Add keyboard actions example

### DIFF
--- a/Examples/KeyboardActions.ps1
+++ b/Examples/KeyboardActions.ps1
@@ -1,0 +1,30 @@
+Import-Module ./DesktopManager.psd1 -Force
+
+# Launch Notepad and wait until it starts
+$proc = Start-Process -FilePath notepad -PassThru
+Start-Sleep -Seconds 1
+
+# Get the Notepad window and bring it to the foreground
+$window = Get-DesktopWindow -Name '*Notepad*'
+
+# Type "HELLO WORLD" into Notepad
+Invoke-DesktopKeyPress -Window $window -Keys @(
+    [DesktopManager.VirtualKey]::VK_H,
+    [DesktopManager.VirtualKey]::VK_E,
+    [DesktopManager.VirtualKey]::VK_L,
+    [DesktopManager.VirtualKey]::VK_L,
+    [DesktopManager.VirtualKey]::VK_O,
+    [DesktopManager.VirtualKey]::VK_SPACE,
+    [DesktopManager.VirtualKey]::VK_W,
+    [DesktopManager.VirtualKey]::VK_O,
+    [DesktopManager.VirtualKey]::VK_R,
+    [DesktopManager.VirtualKey]::VK_L,
+    [DesktopManager.VirtualKey]::VK_D
+)
+
+# Press Ctrl+S to open the Save dialog
+Invoke-DesktopKeyPress -Window $window -Keys @(
+    [DesktopManager.VirtualKey]::VK_CONTROL,
+    [DesktopManager.VirtualKey]::VK_S
+)
+

--- a/README.MD
+++ b/README.MD
@@ -296,6 +296,16 @@ Set-DesktopWindow -Name '*Zadanie - Notepad' -State Maximize
 Set-DesktopWindowText -Name '*Notepad*' -Text 'Hello world'
 ```
 
+```powershell
+# Send Ctrl+S to Notepad
+$notepad = Get-DesktopWindow -Name '*Notepad*'
+Invoke-DesktopKeyPress -Window $notepad -Keys @(
+    [DesktopManager.VirtualKey]::VK_CONTROL,
+    [DesktopManager.VirtualKey]::VK_S
+)
+# See Examples/KeyboardActions.ps1
+```
+
 ### Example in PowerShell - Activating and Setting Window Top-Most
 
 ```powershell


### PR DESCRIPTION
## Summary
- add `KeyboardActions.ps1` demonstrating `Invoke-DesktopKeyPress`
- document keyboard action snippet in README

## Testing
- `pwsh -NoLogo -NoProfile -Command ./DesktopManager.Tests.ps1` *(fails: `Set-DesktopWallpaperHistory` not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6872c92b9494832e954959aa4a758852