### PR TITLE
Add KeyDown/KeyUp support

### DIFF
--- a/Examples/InvokeDesktopKeyPress.ps1
+++ b/Examples/InvokeDesktopKeyPress.ps1
@@ -3,3 +3,8 @@ Import-Module ./DesktopManager.psd1 -Force
 # Press WIN+R to open Run dialog
 Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_LWIN, [DesktopManager.VirtualKey]::VK_R)
 
+# Press and hold WIN key then release
+Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_LWIN) -KeyDown
+Start-Sleep -Seconds 1
+Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_LWIN) -KeyUp
+

--- a/Sources/DesktopManager.Example/KeyboardInputExample.cs
+++ b/Sources/DesktopManager.Example/KeyboardInputExample.cs
@@ -16,5 +16,9 @@ internal static class KeyboardInputExample {
 
         Console.WriteLine("Pressing WIN+R to open Run dialog...");
         KeyboardInputService.PressShortcut(VirtualKey.VK_LWIN, VirtualKey.VK_R);
+
+        Console.WriteLine("Pressing and releasing F24 using KeyDown/KeyUp...");
+        KeyboardInputService.KeyDown(VirtualKey.VK_F24);
+        KeyboardInputService.KeyUp(VirtualKey.VK_F24);
     }
 }

--- a/Sources/DesktopManager.Tests/KeyboardInputServiceTests.cs
+++ b/Sources/DesktopManager.Tests/KeyboardInputServiceTests.cs
@@ -30,4 +30,28 @@ public class KeyboardInputServiceTests {
 
         KeyboardInputService.PressShortcut(VirtualKey.VK_F23, VirtualKey.VK_F24);
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for KeyDown_DoesNotThrow.
+    /// </summary>
+    public void KeyDown_DoesNotThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        KeyboardInputService.KeyDown(VirtualKey.VK_F24);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for KeyUp_DoesNotThrow.
+    /// </summary>
+    public void KeyUp_DoesNotThrow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        KeyboardInputService.KeyUp(VirtualKey.VK_F24);
+    }
 }

--- a/Sources/DesktopManager/KeyboardInputService.cs
+++ b/Sources/DesktopManager/KeyboardInputService.cs
@@ -10,28 +10,46 @@ namespace DesktopManager;
 [SupportedOSPlatform("windows")]
 public static class KeyboardInputService {
     /// <summary>
-    /// Presses a single key using SendInput.
+    /// Presses a single key by sending a down and up event.
     /// </summary>
     /// <param name="key">Key to press.</param>
     public static void PressKey(VirtualKey key) {
-        MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
-        inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-        inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+        KeyDown(key);
+        KeyUp(key);
+    }
+
+    /// <summary>
+    /// Sends a key down event for the specified key.
+    /// </summary>
+    /// <param name="key">Key to press down.</param>
+    public static void KeyDown(VirtualKey key) {
+        MonitorNativeMethods.INPUT input = new();
+        input.Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        input.Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
             Vk = (ushort)key,
             Scan = 0,
             Flags = 0,
             Time = 0,
             ExtraInfo = IntPtr.Zero
         };
-        inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-        inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+        MonitorNativeMethods.SendInput(1, [input], Marshal.SizeOf<MonitorNativeMethods.INPUT>());
+    }
+
+    /// <summary>
+    /// Sends a key up event for the specified key.
+    /// </summary>
+    /// <param name="key">Key to release.</param>
+    public static void KeyUp(VirtualKey key) {
+        MonitorNativeMethods.INPUT input = new();
+        input.Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        input.Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
             Vk = (ushort)key,
             Scan = 0,
             Flags = MonitorNativeMethods.KEYEVENTF_KEYUP,
             Time = 0,
             ExtraInfo = IntPtr.Zero
         };
-        MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
+        MonitorNativeMethods.SendInput(1, [input], Marshal.SizeOf<MonitorNativeMethods.INPUT>());
     }
 
     /// <summary>

--- a/Tests/InvokeDesktopKeyPress.Tests.ps1
+++ b/Tests/InvokeDesktopKeyPress.Tests.ps1
@@ -2,4 +2,12 @@ describe 'Invoke-DesktopKeyPress' {
     it 'supports WhatIf mode' -Skip:(-not $IsWindows) {
         { Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_F24) -WhatIf } | Should -Not -Throw
     }
+
+    it 'supports KeyDown mode' -Skip:(-not $IsWindows) {
+        { Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_F24) -KeyDown -WhatIf } | Should -Not -Throw
+    }
+
+    it 'supports KeyUp mode' -Skip:(-not $IsWindows) {
+        { Invoke-DesktopKeyPress -Keys @([DesktopManager.VirtualKey]::VK_F24) -KeyUp -WhatIf } | Should -Not -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- add `KeyDown` and `KeyUp` methods for keyboard input
- extend `Invoke-DesktopKeyPress` to support explicit key down/up
- show new functionality in examples
- test new methods and cmdlet parameters

## Testing
- `dotnet test Sources/DesktopManager.sln -f net8.0`
- `pwsh -NoLogo -NonInteractive -Command "./DesktopManager.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_6872cbe12a1c832eb5e320be64d9ce88