### PR TITLE
Add process ID filtering to GetWindows

### DIFF
--- a/Examples/GetWindow.ps1
+++ b/Examples/GetWindow.ps1
@@ -5,6 +5,12 @@ Get-DesktopWindow | Format-Table *
 # Filter windows by process name
 Get-DesktopWindow -ProcessName 'notepad'
 
+# Filter windows by process ID
+$notepad = Get-Process -Name notepad -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($notepad) {
+    Get-DesktopWindow -ProcessId $notepad.Id
+}
+
 # Filter by class name
 Get-DesktopWindow -ClassName 'Notepad'
 

--- a/README.MD
+++ b/README.MD
@@ -124,7 +124,7 @@ The table below shows the most relevant API methods behind each PowerShell cmdle
 | Invoke-DesktopMouseClick | `WindowManager.ClickMouse` |
 | Invoke-DesktopMouseScroll | `WindowManager.ScrollMouse` |
 | Invoke-DesktopScreenshot | `ScreenshotService.CaptureScreen`, `ScreenshotService.CaptureRegion` |
-| Get-DesktopWindow | `WindowManager.GetWindows` |
+| Get-DesktopWindow | `WindowManager.GetWindows` / `GetWindowsForProcess` |
 | Set-DesktopWindow | `WindowManager.SetWindowPosition`, `MoveWindowToMonitor`, etc. |
 | Set-DesktopWindowSnap | `WindowManager.SnapWindow` |
 | Set-DesktopWindowText | `WindowInputService` |
@@ -282,6 +282,12 @@ Set-DesktopPosition -Index 1 -Left 0 -Top 0 -Right 3840 -Bottom 2160 -WhatIf
 
 ```powershell
 Get-DesktopWindow | Format-Table *
+```
+
+```powershell
+$np = Start-Process notepad -PassThru
+Get-DesktopWindow -ProcessId $np.Id
+$np | Stop-Process
 ```
 
 ![image](https://github.com/user-attachments/assets/e4d026f7-2035-4a45-9779-a85423acdb21)

--- a/Sources/DesktopManager.PowerShell/CmdletGetDesktopWindow.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetDesktopWindow.cs
@@ -40,11 +40,17 @@ namespace DesktopManager.PowerShell {
         public Regex Regex { get; set; }
 
         /// <summary>
+        /// <para type="description">Filter windows by process ID.</para>
+        /// </summary>
+        [Parameter]
+        public int ProcessId { get; set; } = 0;
+
+        /// <summary>
         /// Retrieves and outputs matching windows.
         /// </summary>
         protected override void BeginProcessing() {
             var manager = new WindowManager();
-            var windows = manager.GetWindows(Name, ProcessName, ClassName, Regex);
+            var windows = manager.GetWindows(Name, ProcessName, ClassName, Regex, ProcessId);
             WriteObject(windows, true);
         }
     }

--- a/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
@@ -35,6 +35,39 @@ public class WindowManagerFilterTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures filtering by process ID returns matching window.
+    /// </summary>
+    public void GetWindows_ProcessIdFilter_ReturnsWindow() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var proc = Process.Start(new ProcessStartInfo("notepad.exe") {
+            WindowStyle = ProcessWindowStyle.Normal
+        });
+        if (proc == null) {
+            Assert.Inconclusive("Failed to start notepad");
+        }
+
+        proc.WaitForInputIdle(2000);
+
+        try {
+            var manager = new WindowManager();
+            var windows = manager.GetWindows(processId: proc.Id);
+            Assert.IsTrue(windows.Any());
+
+            var windows2 = manager.GetWindowsForProcess(proc);
+            Assert.IsTrue(windows2.Any());
+        } finally {
+            if (!proc.HasExited) {
+                proc.Kill();
+                proc.WaitForExit();
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures filtering by class name returns matching window.
     /// </summary>
     public void GetWindows_ClassNameFilter_ReturnsWindow() {

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -24,14 +24,16 @@ public partial class WindowManager {
         }
 
         /// <summary>
-        /// Gets all visible windows.
+        /// Gets all visible windows, optionally filtered by title, process name,
+        /// class name, regular expression or process ID.
         /// </summary>
         /// <param name="name">Optional window title filter. Supports wildcards.</param>
         /// <param name="processName">Optional process name filter. Supports wildcards.</param>
         /// <param name="className">Optional window class name filter. Supports wildcards.</param>
         /// <param name="regex">Optional regular expression to match the window title.</param>
+        /// <param name="processId">Optional process ID filter.</param>
         /// <returns>A list of WindowInfo objects.</returns>
-        public List<WindowInfo> GetWindows(string name = "*", string processName = "*", string className = "*", Regex regex = null) {
+        public List<WindowInfo> GetWindows(string name = "*", string processName = "*", string className = "*", Regex regex = null, int processId = 0) {
             var handles = new List<IntPtr>();
             var shellWindowhWnd = MonitorNativeMethods.GetShellWindow();
 
@@ -58,12 +60,12 @@ public partial class WindowManager {
                         continue;
                     }
 
-                    uint processId = 0;
-                    MonitorNativeMethods.GetWindowThreadProcessId(handle, out processId);
+                    uint windowProcessId = 0;
+                    MonitorNativeMethods.GetWindowThreadProcessId(handle, out windowProcessId);
 
                     if (!string.IsNullOrEmpty(processName) && processName != "*") {
                         try {
-                            var process = Process.GetProcessById((int)processId);
+                            var process = Process.GetProcessById((int)windowProcessId);
                             if (!MatchesWildcard(process.ProcessName, processName)) {
                                 continue;
                             }
@@ -80,10 +82,14 @@ public partial class WindowManager {
                         }
                     }
 
+                    if (processId > 0 && windowProcessId != processId) {
+                        continue;
+                    }
+
                     var windowInfo = new WindowInfo {
                         Title = title,
                         Handle = handle,
-                        ProcessId = processId
+                        ProcessId = windowProcessId
                     };
 
                         // Get window position and state
@@ -129,6 +135,19 @@ public partial class WindowManager {
                 }
 
             return windows;
+        }
+
+        /// <summary>
+        /// Gets windows belonging to the specified process.
+        /// </summary>
+        /// <param name="process">Process whose windows to retrieve.</param>
+        /// <returns>List of windows owned by the process.</returns>
+        public List<WindowInfo> GetWindowsForProcess(Process process) {
+            if (process == null) {
+                throw new ArgumentNullException(nameof(process));
+            }
+
+            return GetWindows(processId: process.Id);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- extend `WindowManager.GetWindows` with optional `processId` parameter
- add `GetWindowsForProcess` helper method
- expose `-ProcessId` parameter in `Get-DesktopWindow`
- update README and example script
- test filtering using a sample Notepad process

## Testing
- `dotnet test Sources/DesktopManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_6872d872c5a0832ebbd0561af890c86f