### PR TITLE
Enhance PSD1 refresh workflow

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
 
       - name: Setup PowerShell modules
         shell: pwsh
@@ -36,6 +39,17 @@ jobs:
           RefreshPSD1Only: 'true'
         run: |
           .\Build\Build-Module.ps1
+
+      - name: Commit refreshed PSD1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add DesktopManager.psd1
+          git commit -m "chore: regenerate psd1" || echo "No changes to commit"
+          git push origin HEAD:$Env:HEAD_BRANCH
 
       - name: Upload refreshed manifest
         uses: actions/upload-artifact@v4
@@ -50,6 +64,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Download manifest
         uses: actions/download-artifact@v4
@@ -85,6 +102,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Download manifest
         uses: actions/download-artifact@v4

--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
-@{
-    AliasesToExport        = @('Get-DesktopMonitors', 'Set-LockScreenWallpaper', 'Get-LockScreenWallpaper')
+﻿@{
+    AliasesToExport        = @('Get-DesktopMonitors', 'Get-LockScreenWallpaper', 'Set-LockScreenWallpaper')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWindow', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopDpiScaling', 'Set-DesktopWallpaper', 'Set-DesktopWindow', 'Set-DesktopWindowText', 'Save-DesktopWindowLayout', 'Restore-DesktopWindowLayout', 'Get-DesktopBackgroundColor', 'Set-DesktopBackgroundColor', 'Start-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Advance-DesktopSlideshow', 'Get-LogonWallpaper', 'Set-LogonWallpaper', 'Set-TaskbarPosition', 'Invoke-DesktopMouseMove', 'Invoke-DesktopMouseClick', 'Invoke-DesktopControlClick', 'Invoke-DesktopMouseScroll', 'Invoke-DesktopMouseDrag', 'Invoke-DesktopKeyPress', 'Get-DesktopWallpaperHistory', 'Set-DesktopWallpaperHistory', 'Start-DesktopWindowKeepAlive', 'Stop-DesktopWindowKeepAlive', 'Get-DesktopWindowKeepAlive', 'Wait-DesktopWindow', 'Set-DefaultAudioDevice', 'Get-DesktopBrightness', 'Set-DesktopBrightness','Get-DesktopWindowControl')
+    CmdletsToExport        = @('Advance-DesktopSlideshow', 'Get-DesktopBackgroundColor', 'Get-DesktopBrightness', 'Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWallpaperHistory', 'Get-DesktopWindow', 'Get-DesktopWindowControl', 'Get-DesktopWindowKeepAlive', 'Get-LogonWallpaper', 'Invoke-DesktopControlClick', 'Invoke-DesktopKeyPress', 'Invoke-DesktopMouseClick', 'Invoke-DesktopMouseDrag', 'Invoke-DesktopMouseMove', 'Invoke-DesktopMouseScroll', 'Invoke-DesktopScreenshot', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Restore-DesktopWindowLayout', 'Save-DesktopWindowLayout', 'Set-DefaultAudioDevice', 'Set-DesktopBackgroundColor', 'Set-DesktopBrightness', 'Set-DesktopDpiScaling', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWallpaperHistory', 'Set-DesktopWindow', 'Set-DesktopWindowSnap', 'Set-DesktopWindowText', 'Set-DesktopWindowTransparency', 'Set-LogonWallpaper', 'Set-TaskbarPosition', 'Start-DesktopSlideshow', 'Start-DesktopWindowKeepAlive', 'Stop-DesktopSlideshow', 'Stop-DesktopWindowKeepAlive', 'Wait-DesktopWindow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = '56f85fa6-c622-4204-8e97-3d99e3e06e75'
-    ModuleVersion          = '3.5.0'
+    ModuleVersion          = '3.6.0'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{


### PR DESCRIPTION
## Summary
- automatically commit regenerated PSD1
- checkout with full history in CI jobs
- make test jobs use explicit `ref`

## Testing
- `dotnet restore Sources/DesktopManager.sln`
- `dotnet build Sources/DesktopManager.sln --configuration Release --no-restore`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --configuration Release --framework net8.0 --no-build`
- `pwsh -Command './DesktopManager.Tests.ps1' | tail -n 20` *(fails: Set-DesktopWallpaperHistory not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687360ef12b8832ea69285cdf0bc3ca6