### PR TITLE
Validate slideshow paths

### DIFF
--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace DesktopManager.Tests;
 
@@ -60,6 +61,36 @@ public class WallpaperHistoryTests
             if (File.Exists(temp))
             {
                 File.Delete(temp);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Test for StartWallpaperSlideshow_IgnoresInvalidPaths.
+    /// </summary>
+    public void StartWallpaperSlideshow_IgnoresInvalidPaths()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var fake = new FakeDesktopManager();
+        var service = new MonitorService(fake);
+
+        string valid = Path.GetTempFileName();
+        try
+        {
+            string invalid = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.jpg");
+            service.StartWallpaperSlideshow(new[] { invalid, valid });
+            Assert.AreEqual(1, fake.SetSlideshowCalls.Count);
+        }
+        finally
+        {
+            if (File.Exists(valid))
+            {
+                File.Delete(valid);
             }
         }
     }

--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -79,9 +79,14 @@ public class WallpaperHistoryTests
         var fake = new FakeDesktopManager();
         var service = new MonitorService(fake);
 
-        string valid = Path.GetTempFileName();
+        string valid = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".bmp");
         try
         {
+            using (var bmp = new System.Drawing.Bitmap(1, 1))
+            {
+                bmp.Save(valid, System.Drawing.Imaging.ImageFormat.Bmp);
+            }
+
             string invalid = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.jpg");
             service.StartWallpaperSlideshow(new[] { invalid, valid });
             Assert.AreEqual(1, fake.SetSlideshowCalls.Count);

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -475,6 +475,10 @@ public partial class MonitorService {
             throw new ArgumentNullException(nameof(wallpaperPaths));
         }
 
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            throw new PlatformNotSupportedException("Wallpaper slideshow is only supported on Windows.");
+        }
+
         List<string> valid = new();
         foreach (var path in wallpaperPaths) {
             if (string.IsNullOrEmpty(path)) {
@@ -536,6 +540,7 @@ public partial class MonitorService {
                 }
                 object obj = Marshal.GetObjectForIUnknown(item);
                 collection.AddObject(obj);
+                Marshal.ReleaseComObject(obj);
                 Marshal.Release(item);
             }
 

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -475,9 +475,24 @@ public partial class MonitorService {
             throw new ArgumentNullException(nameof(wallpaperPaths));
         }
 
+        List<string> valid = new();
+        foreach (var path in wallpaperPaths) {
+            if (string.IsNullOrEmpty(path)) {
+                continue;
+            }
+
+            if (File.Exists(path)) {
+                valid.Add(path);
+            }
+        }
+
+        if (valid.Count == 0) {
+            throw new InvalidOperationException("No valid wallpaper paths were provided.");
+        }
+
         IntPtr arrayPtr = IntPtr.Zero;
         try {
-            arrayPtr = CreateShellItemArray(wallpaperPaths);
+            arrayPtr = CreateShellItemArray(valid);
             Execute(() => _desktopManager.SetSlideshow(arrayPtr), nameof(IDesktopManager.SetSlideshow));
         } finally {
             if (arrayPtr != IntPtr.Zero) {

--- a/Sources/DesktopManager/PrivilegeChecker.cs
+++ b/Sources/DesktopManager/PrivilegeChecker.cs
@@ -23,6 +23,10 @@ public static class PrivilegeChecker {
     /// Throws <see cref="InvalidOperationException"/> if the current process is not elevated.
     /// </summary>
     public static void EnsureElevated() {
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+            throw new PlatformNotSupportedException("Elevated privilege checks are only supported on Windows.");
+        }
+
         if (!IsElevated) {
             throw new InvalidOperationException("Operation requires administrative privileges.");
         }


### PR DESCRIPTION
## Summary
- ensure `StartWallpaperSlideshow` ignores invalid paths
- test slideshow path validation

## Testing
- `dotnet build Sources/DesktopManager/DesktopManager.csproj -c Release`
- `dotnet build Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Release -f net8.0 --no-build`
- `dotnet build Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj -c Debug`
- `pwsh -NoProfile -Command ./DesktopManager.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_687377241994832e8bc6bbef0be85c37