### PR TITLE
Implement shared MonitorWatcher subscription

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
@@ -31,4 +31,24 @@ public class MonitorWatcherSubscriptionTests {
         Assert.AreEqual(1, c1);
         Assert.AreEqual(1, c2);
     }
+
+    [TestMethod]
+    public void DisplaySettingsChanged_NotRaised_WhenAllWatchersDisposed() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        var watcher = new MonitorWatcher();
+        int count = 0;
+        watcher.DisplaySettingsChanged += (_, _) => count++;
+        watcher.Dispose();
+        var method = typeof(MonitorWatcher).GetMethod("OnDisplaySettingsChangedStatic", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        method.Invoke(null, new object?[] { null, EventArgs.Empty });
+        Assert.AreEqual(0, count);
+    }
 }

--- a/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+[SupportedOSPlatform("windows")]
+public class MonitorWatcherSubscriptionTests {
+    [TestMethod]
+    public void DisplaySettingsChanged_NotDuplicated_ForMultipleWatchers() {
+#if NET5_0_OR_GREATER
+        if (!OperatingSystem.IsWindows()) {
+#else
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+#endif
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        using var w1 = new MonitorWatcher();
+        using var w2 = new MonitorWatcher();
+        int c1 = 0;
+        int c2 = 0;
+        w1.DisplaySettingsChanged += (_, _) => c1++;
+        w2.DisplaySettingsChanged += (_, _) => c2++;
+        var method = typeof(MonitorWatcher).GetMethod("OnDisplaySettingsChangedStatic", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        method.Invoke(null, new object?[] { null, EventArgs.Empty });
+        Assert.AreEqual(1, c1);
+        Assert.AreEqual(1, c2);
+    }
+}

--- a/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorWatcherSubscriptionTests.cs
@@ -8,8 +8,10 @@ namespace DesktopManager.Tests;
 
 [TestClass]
 [SupportedOSPlatform("windows")]
+/// <summary>Tests for event subscriptions across multiple watchers.</summary>
 public class MonitorWatcherSubscriptionTests {
     [TestMethod]
+    /// <summary>Verify events fire only once when multiple watchers exist.</summary>
     public void DisplaySettingsChanged_NotDuplicated_ForMultipleWatchers() {
 #if NET5_0_OR_GREATER
         if (!OperatingSystem.IsWindows()) {
@@ -33,6 +35,7 @@ public class MonitorWatcherSubscriptionTests {
     }
 
     [TestMethod]
+    /// <summary>Ensure events stop after all watchers are disposed.</summary>
     public void DisplaySettingsChanged_NotRaised_WhenAllWatchersDisposed() {
 #if NET5_0_OR_GREATER
         if (!OperatingSystem.IsWindows()) {

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -94,10 +94,12 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private static void OnDisplaySettingsChangedStatic(object sender, EventArgs e) {
+        MonitorWatcher[] watchers;
         lock (_syncRoot) {
-            foreach (var watcher in _instances.ToArray()) {
-                watcher.OnDisplaySettingsChanged(sender, e);
-            }
+            watchers = _instances.ToArray();
+        }
+        foreach (var watcher in watchers) {
+            watcher.OnDisplaySettingsChanged(sender, e);
         }
     }
 
@@ -146,10 +148,12 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private static void StaticProcessPowerBroadcast(int state) {
+        MonitorWatcher[] watchers;
         lock (_syncRoot) {
-            foreach (var watcher in _instances.ToArray()) {
-                watcher.ProcessPowerBroadcast(state);
-            }
+            watchers = _instances.ToArray();
+        }
+        foreach (var watcher in watchers) {
+            watcher.ProcessPowerBroadcast(state);
         }
     }
 
@@ -168,10 +172,12 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private static void StaticProcessDeviceChange(IntPtr lParam, bool connected) {
+        MonitorWatcher[] watchers;
         lock (_syncRoot) {
-            foreach (var watcher in _instances.ToArray()) {
-                watcher.ProcessDeviceChange(lParam, connected);
-            }
+            watchers = _instances.ToArray();
+        }
+        foreach (var watcher in watchers) {
+            watcher.ProcessDeviceChange(lParam, connected);
         }
     }
 

--- a/Sources/DesktopManager/MonitorWatcher.cs
+++ b/Sources/DesktopManager/MonitorWatcher.cs
@@ -53,8 +53,11 @@ public sealed class MonitorWatcher : IDisposable {
     private Dictionary<string, MonitorState> _state = new();
     internal Func<Dictionary<string, MonitorState>> StateProvider { get; set; }
     private bool _disposed;
-    private PowerBroadcastWindow? _powerWindow;
-    private DeviceChangeWindow? _deviceWindow;
+    private static int _subscriptionCount;
+    private static readonly object _syncRoot = new();
+    private static PowerBroadcastWindow? _powerWindow;
+    private static DeviceChangeWindow? _deviceWindow;
+    private static readonly List<MonitorWatcher> _instances = new();
 
     private static readonly Guid GUID_MONITOR_POWER_ON = new("02731015-4510-4526-99E6-E5A17EBD1AEA");
 
@@ -80,9 +83,22 @@ public sealed class MonitorWatcher : IDisposable {
 
         StateProvider = GetCurrentStates;
         _state = StateProvider();
-        SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
-        _powerWindow = new PowerBroadcastWindow(this);
-        _deviceWindow = new DeviceChangeWindow(this);
+        lock (_syncRoot) {
+            _instances.Add(this);
+            if (Interlocked.Increment(ref _subscriptionCount) == 1) {
+                SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChangedStatic;
+                _powerWindow = new PowerBroadcastWindow(StaticProcessPowerBroadcast);
+                _deviceWindow = new DeviceChangeWindow(StaticProcessDeviceChange);
+            }
+        }
+    }
+
+    private static void OnDisplaySettingsChangedStatic(object sender, EventArgs e) {
+        lock (_syncRoot) {
+            foreach (var watcher in _instances.ToArray()) {
+                watcher.OnDisplaySettingsChanged(sender, e);
+            }
+        }
     }
 
     private void OnDisplaySettingsChanged(object sender, EventArgs e) {
@@ -129,6 +145,14 @@ public sealed class MonitorWatcher : IDisposable {
         }
     }
 
+    private static void StaticProcessPowerBroadcast(int state) {
+        lock (_syncRoot) {
+            foreach (var watcher in _instances.ToArray()) {
+                watcher.ProcessPowerBroadcast(state);
+            }
+        }
+    }
+
     internal void ProcessDeviceChange(IntPtr lParam, bool connected) {
         var hdr = Marshal.PtrToStructure<MonitorNativeMethods.DEV_BROADCAST_HDR>(lParam);
         if (hdr.dbch_devicetype == MonitorNativeMethods.DBT_DEVTYP_DEVICEINTERFACE) {
@@ -139,6 +163,14 @@ public sealed class MonitorWatcher : IDisposable {
                 } else {
                     MonitorDisconnected?.Invoke(this, EventArgs.Empty);
                 }
+            }
+        }
+    }
+
+    private static void StaticProcessDeviceChange(IntPtr lParam, bool connected) {
+        lock (_syncRoot) {
+            foreach (var watcher in _instances.ToArray()) {
+                watcher.ProcessDeviceChange(lParam, connected);
             }
         }
     }
@@ -184,10 +216,21 @@ public sealed class MonitorWatcher : IDisposable {
             return;
         }
 
-        if (disposing) {
-            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+        bool last;
+        lock (_syncRoot) {
+            _instances.Remove(this);
+            last = Interlocked.Decrement(ref _subscriptionCount) == 0;
+        }
+
+        if (last) {
+            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChangedStatic;
             _powerWindow?.Dispose();
             _deviceWindow?.Dispose();
+            _powerWindow = null;
+            _deviceWindow = null;
+        }
+
+        if (disposing) {
             GC.SuppressFinalize(this);
         }
 
@@ -195,15 +238,15 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private sealed class PowerBroadcastWindow : IDisposable {
-        private readonly MonitorWatcher _parent;
+        private readonly Action<int> _callback;
         private IntPtr _hwnd;
         private IntPtr _notificationHandle;
         private Thread _thread;
         private MonitorNativeMethods.WndProc? _wndProc;
         private readonly ManualResetEventSlim _ready = new(false);
 
-        public PowerBroadcastWindow(MonitorWatcher parent) {
-            _parent = parent;
+        public PowerBroadcastWindow(Action<int> callback) {
+            _callback = callback;
             _thread = new Thread(MessageLoop) { IsBackground = true };
             _thread.Start();
             _ready.Wait();
@@ -253,7 +296,7 @@ public sealed class MonitorWatcher : IDisposable {
             if (msg == (uint)WindowMessage.WM_POWERBROADCAST && wParam.ToInt32() == MonitorNativeMethods.PBT_POWERSETTINGCHANGE) {
                 var setting = Marshal.PtrToStructure<MonitorNativeMethods.POWERBROADCAST_SETTING>(lParam);
                 if (setting.PowerSetting == GUID_MONITOR_POWER_ON) {
-                    _parent.ProcessPowerBroadcast(setting.Data);
+                    _callback(setting.Data);
                 }
             }
             return MonitorNativeMethods.DefWindowProcW(hWnd, msg, wParam, lParam);
@@ -269,15 +312,15 @@ public sealed class MonitorWatcher : IDisposable {
     }
 
     private sealed class DeviceChangeWindow : IDisposable {
-        private readonly MonitorWatcher _parent;
+        private readonly Action<IntPtr, bool> _callback;
         private IntPtr _hwnd;
         private IntPtr _notificationHandle;
         private Thread _thread;
         private MonitorNativeMethods.WndProc? _wndProc;
         private readonly ManualResetEventSlim _ready = new(false);
 
-        public DeviceChangeWindow(MonitorWatcher parent) {
-            _parent = parent;
+        public DeviceChangeWindow(Action<IntPtr, bool> callback) {
+            _callback = callback;
             _thread = new Thread(MessageLoop) { IsBackground = true };
             _thread.Start();
             _ready.Wait();
@@ -333,9 +376,9 @@ public sealed class MonitorWatcher : IDisposable {
         private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam) {
             if (msg == (uint)WindowMessage.WM_DEVICECHANGE) {
                 if (wParam.ToInt32() == MonitorNativeMethods.DBT_DEVICEARRIVAL) {
-                    _parent.ProcessDeviceChange(lParam, true);
+                    _callback(lParam, true);
                 } else if (wParam.ToInt32() == MonitorNativeMethods.DBT_DEVICEREMOVECOMPLETE) {
-                    _parent.ProcessDeviceChange(lParam, false);
+                    _callback(lParam, false);
                 }
             }
             return MonitorNativeMethods.DefWindowProcW(hWnd, msg, wParam, lParam);


### PR DESCRIPTION
## Summary
- only subscribe `MonitorWatcher` once across instances
- add static windows for power and device notifications
- test that events fire once per watcher

## Testing
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Debug -f net8.0 --no-build`
- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -c Debug -f net472 --no-build` *(fails: SetLogonWallpaper_ThrowsOnMissingRuntime, EnsureElevated_ThrowsWhenNotElevated)*

------
https://chatgpt.com/codex/tasks/task_e_6873772a0c14832eaf197efe53d18f17