### PR TITLE
Fix background control key sending

### DIFF
--- a/Sources/DesktopManager/KeyboardInputService.cs
+++ b/Sources/DesktopManager/KeyboardInputService.cs
@@ -96,9 +96,11 @@ public static class KeyboardInputService {
 
         foreach (VirtualKey key in keys) {
             MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
-            if ((key >= VirtualKey.VK_SPACE && key <= VirtualKey.VK_Z) || (key >= VirtualKey.VK_0 && key <= VirtualKey.VK_9)) {
+            if ((key >= VirtualKey.VK_SPACE && key <= VirtualKey.VK_Z) ||
+                (key >= VirtualKey.VK_0 && key <= VirtualKey.VK_9)) {
                 MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_CHAR, (uint)key, 0);
             }
+            MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYUP, (uint)key, 0);
         }
     }
 }

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -407,6 +407,11 @@ public static partial class MonitorNativeMethods
     public const uint WM_KEYDOWN = 0x0100;
 
     /// <summary>
+    /// Message used for key up events.
+    /// </summary>
+    public const uint WM_KEYUP = 0x0101;
+
+    /// <summary>
     /// Message used for character input events.
     /// </summary>
     public const uint WM_CHAR = 0x0102;


### PR DESCRIPTION
## Summary
- ensure keyup event is sent when typing to background controls
- add `WM_KEYUP` constant for window messages

## Testing
- `dotnet test Sources/DesktopManager.sln -c Release --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_6879dcf238d4832eaf57a892f820b23e