### PR TITLE
Fix background keyboard input for controls

### DIFF
--- a/Sources/DesktopManager/KeyboardInputService.cs
+++ b/Sources/DesktopManager/KeyboardInputService.cs
@@ -95,16 +95,19 @@ public static class KeyboardInputService {
         }
 
         foreach (VirtualKey key in keys) {
-            MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
             bool printable =
                 (key >= VirtualKey.VK_SPACE && key <= VirtualKey.VK_Z) ||
                 (key >= VirtualKey.VK_0 && key <= VirtualKey.VK_9);
 
             if (printable) {
-                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_CHAR, (uint)key, 0);
+                uint end = unchecked((uint)0xFFFFFFFF);
+                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.EM_SETSEL, end, end);
+                string text = ((char)key).ToString();
+                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.EM_REPLACESEL, new IntPtr(1), text);
+            } else {
+                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
+                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYUP, (uint)key, 0);
             }
-
-            MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYUP, (uint)key, 0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- improve `KeyboardInputService.SendToControl` so printable characters insert correctly

## Testing
- `dotnet build Sources/DesktopManager.sln -c Release -p:XmlDoc2CmdletDocStrict=false`
- `dotnet test Sources/DesktopManager.sln -c Release --framework net8.0 -p:XmlDoc2CmdletDocStrict=false`


------
https://chatgpt.com/codex/tasks/task_e_687ea51366e8832ea8242699379a2655