### PR TITLE
Fix background control typing

### DIFF
--- a/Sources/DesktopManager/KeyboardInputService.cs
+++ b/Sources/DesktopManager/KeyboardInputService.cs
@@ -102,8 +102,7 @@ public static class KeyboardInputService {
             if (printable) {
                 uint end = unchecked((uint)0xFFFFFFFF);
                 MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.EM_SETSEL, end, end);
-                string text = ((char)key).ToString();
-                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.EM_REPLACESEL, new IntPtr(1), text);
+                MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_CHAR, (uint)key, 0);
             } else {
                 MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
                 MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_KEYUP, (uint)key, 0);


### PR DESCRIPTION
## Summary
- fix `SendToControl` to use `WM_CHAR` for printable keys

## Testing
- `dotnet build Sources/DesktopManager.sln --no-restore --verbosity minimal -p:XmlDoc2CmdletDocStrict=false`
- `dotnet test Sources/DesktopManager.sln --no-build --verbosity normal -p:XmlDoc2CmdletDocStrict=false` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_688146e60ee8832ebb3c469f50e64453