### PR TITLE
fix(build): 🐛 update target frameworks and module exports

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet build Sources/DesktopManager.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
       - name: Run tests
-        run: dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows10.0.19041.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        run: dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0-windows --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-Import-Module PSPublishModule -Force
+Import-Module PSPublishModule -Force -RequiredVersion 2.0.27
 
 Build-Module -ModuleName 'DesktopManager' {
     # Usual defaults as per standard module
@@ -27,9 +27,9 @@ Build-Module -ModuleName 'DesktopManager' {
         IconUri                = 'https://evotec.xyz/wp-content/uploads/2022/12/DesktopManager.png'
 
         DotNetFrameworkVersion = '4.7.2'
-        AliasesToExport        = '*'
-        CmdletsToExport        = '*'
-        FunctionsToExport      = '*'
+        #AliasesToExport        = '*'
+        #CmdletsToExport        = '*'
+        #FunctionsToExport      = '*'
 
         #PreReleaseTag          = 'Preview3'
     }
@@ -88,7 +88,7 @@ Build-Module -ModuleName 'DesktopManager' {
         ResolveBinaryConflictsName        = 'DesktopManager.PowerShell'
         NETProjectName                    = 'DesktopManager.PowerShell'
         NETConfiguration                  = 'Release'
-        NETFramework                      = 'net8.0', 'net472'
+        NETFramework                      = 'net8.0-windows', 'net472'
         NETSearchClass                    = "DesktopManager.PowerShell.CmdletSetDesktopWallpaper"
         NETHandleAssemblyWithSameName     = $true
         NETBinaryModuleDocumenation       = $true
@@ -96,7 +96,7 @@ Build-Module -ModuleName 'DesktopManager' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = $false
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -96,7 +96,7 @@ Build-Module -ModuleName 'DesktopManager' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $false
+        RefreshPSD1Only                   = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,15 +1,15 @@
-@{
-    AliasesToExport        = @('*')
+﻿@{
+    AliasesToExport        = @('Get-DesktopMonitors', 'Get-LockScreenWallpaper', 'Set-LockScreenWallpaper')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('*')
+    CmdletsToExport        = @('Advance-DesktopSlideshow', 'Get-DesktopBackgroundColor', 'Get-DesktopBrightness', 'Get-DesktopControlCheck', 'Get-DesktopMonitor', 'Get-DesktopWallpaper', 'Get-DesktopWallpaperHistory', 'Get-DesktopWindow', 'Get-DesktopWindowControl', 'Get-DesktopWindowKeepAlive', 'Get-DesktopWindowProcessInfo', 'Get-LogonWallpaper', 'Invoke-DesktopControlClick', 'Invoke-DesktopKeyPress', 'Invoke-DesktopMouseClick', 'Invoke-DesktopMouseDrag', 'Invoke-DesktopMouseMove', 'Invoke-DesktopMouseScroll', 'Invoke-DesktopScreenshot', 'Invoke-DesktopWindowScreenshot', 'Register-DesktopHotkey', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Restore-DesktopWindowLayout', 'Save-DesktopWindowLayout', 'Send-DesktopControlKey', 'Set-DefaultAudioDevice', 'Set-DesktopBackgroundColor', 'Set-DesktopBrightness', 'Set-DesktopControlCheck', 'Set-DesktopDpiScaling', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopWallpaper', 'Set-DesktopWallpaperHistory', 'Set-DesktopWindow', 'Set-DesktopWindowSnap', 'Set-DesktopWindowStyle', 'Set-DesktopWindowText', 'Set-DesktopWindowTransparency', 'Set-DesktopWindowVisibility', 'Set-LogonWallpaper', 'Set-TaskbarPosition', 'Start-DesktopSlideshow', 'Start-DesktopWindowKeepAlive', 'Stop-DesktopSlideshow', 'Stop-DesktopWindowKeepAlive', 'Unregister-DesktopHotkey', 'Wait-DesktopWindow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description            = 'Desktop Manager is a PowerShell module that allows easy way to change wallpaper on multiple screens/monitors.'
     DotNetFrameworkVersion = '4.7.2'
-    FunctionsToExport      = @('*')
+    FunctionsToExport      = @()
     GUID                   = '56f85fa6-c622-4204-8e97-3d99e3e06e75'
-    ModuleVersion        = '3.6.0'
+    ModuleVersion          = '3.6.0'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/DesktopManager.psm1
+++ b/DesktopManager.psm1
@@ -13,7 +13,7 @@ if ($DevelopmentEnv) {
     $Development = $DevelopmentEnv.ToString().ToLowerInvariant() -in @('1', 'true', 'yes', 'on')
 }
 $DevelopmentPath = "$PSScriptRoot\Sources\DesktopManager.PowerShell\bin\Debug"
-$DevelopmentFolderCore = "net8.0-windows10.0.19041.0"
+$DevelopmentFolderCore = "net8.0-windows"
 $DevelopmentFolderDefault = "net472"
 $DevelopmentCoreFolder = Get-ChildItem -Path $DevelopmentPath -Directory -Filter 'net8.0-windows*' -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $DevelopmentCoreFolder) {

--- a/Sources/DesktopManager.Example/DesktopManager.Example.csproj
+++ b/Sources/DesktopManager.Example/DesktopManager.Example.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
+++ b/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net472;net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
         <Description>PowerShell Module for working Windows Desktop</Description>
         <AssemblyName>DesktopManager.PowerShell</AssemblyName>
         <AssemblyTitle>DesktopManager.PowerShell</AssemblyTitle>

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>DesktopManager</AssemblyName>
         <AssemblyTitle>DesktopManager</AssemblyTitle>
 
-        <TargetFrameworks>netstandard2.0;net472;net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
@@ -34,7 +34,7 @@
         <PackageId>DesktopManager</PackageId>
         <PackageIcon>DesktopManager.png</PackageIcon>
         <PackageTags>
-            desktop;net472;net48;netstandard;netstandard2.0,netstandard2.1;net80
+            desktop;net472;net48;net80
         </PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/DesktopManager</PackageProjectUrl>
         <PackageReadmeFile>README.MD</PackageReadmeFile>

--- a/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.LogonWallpaper.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
-#if NET8_0_OR_GREATER && WINDOWS
+#if NET8_0_OR_GREATER && WINDOWS && WINDOWS10_0_19041_0
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Storage;
 using Windows.System.UserProfile;
@@ -35,7 +35,7 @@ public partial class MonitorService {
             PrivilegeChecker.EnsureElevated();
         
             try {
-#if NET8_0_OR_GREATER && WINDOWS
+#if NET8_0_OR_GREATER && WINDOWS && WINDOWS10_0_19041_0
                 try {
                     var file = StorageFile.GetFileFromPathAsync(imagePath).AsTask().GetAwaiter().GetResult();
                     LockScreen.SetImageFileAsync(file).AsTask().GetAwaiter().GetResult();
@@ -119,7 +119,7 @@ public partial class MonitorService {
     public string GetLogonWallpaper() {
         bool comInitialized = InitializeCom();
         try {
-#if NET8_0_OR_GREATER && WINDOWS
+#if NET8_0_OR_GREATER && WINDOWS && WINDOWS10_0_19041_0
             try {
                 using var inputStream = LockScreen.GetImageStream();
                 using var stream = inputStream.AsStreamForRead();

--- a/Sources/WindowTextHelper32/WindowTextHelper32.csproj
+++ b/Sources/WindowTextHelper32/WindowTextHelper32.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>latest</LangVersion>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">win-x86</RuntimeIdentifier>
-    <SelfContained Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">true</SelfContained>
-    <PublishSingleFile Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">true</PublishSingleFile>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net8.0-windows'">win-x86</RuntimeIdentifier>
+    <SelfContained Condition="'$(TargetFramework)' == 'net8.0-windows'">true</SelfContained>
+    <PublishSingleFile Condition="'$(TargetFramework)' == 'net8.0-windows'">true</PublishSingleFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />


### PR DESCRIPTION
* Changed target frameworks from `net8.0-windows10.0.19041.0` to `net8.0-windows` across multiple projects.
* Updated `DesktopManager.psd1` to specify explicit cmdlets and aliases for export.
* Adjusted `Build-Module.ps1` to reflect the new framework and export settings.
* Ensured compatibility with the latest .NET SDK.