### PR TITLE
feat(mcp): harden desktop workflows and live validation

### DIFF
--- a/.agents/skills/desktopmanager-build/SKILL.md
+++ b/.agents/skills/desktopmanager-build/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: desktopmanager-build
+description: Build, package, and verify DesktopManager NuGet, PowerShell module, and CLI/MCP artefacts through the repo-standard PowerForge entrypoints. Use when changing Build/Build-Project.ps1, Build/Build-Module.ps1, Build/project.build.json, powerforge.dotnetpublish.json, module packaging, CLI publish outputs, release assets, or build/operator documentation.
+---
+
+# DesktopManager Build
+
+Use this skill when the task touches how DesktopManager is built, packaged, or published.
+
+## Golden Path
+
+1. Use the repo entrypoint first:
+   `.\Build\Build-Project.ps1`
+2. Prefer plan mode before changing packaging behavior:
+   `.\Build\Build-Project.ps1 -Plan`
+3. For PowerShell module-only work, use:
+   `.\Build\Build-Module.ps1 -SkipInstall`
+4. For CLI-only publish verification, use:
+   `.\Build\Build-Project.ps1 -Build:$false -BuildModule:$false`
+5. When checking a specific runtime publish, pass:
+   `-Runtimes win-x64`
+
+## Decision Rules
+
+- Treat `Build/Build-Project.ps1` as the primary repo build and release entrypoint.
+- Prefer changing `Build/project.build.json` and `powerforge.dotnetpublish.json` over hardcoding publish behavior in ad-hoc scripts.
+- Prefer `Build/Build-Module.ps1` for PowerShell packaging behavior instead of editing checked-in artefacts by hand.
+- Verify the resulting behaviour from the real surfaces:
+  NuGet/library, PowerShell import, CLI help, and `desktopmanager mcp serve`.
+- Keep docs aligned with the actual build flow:
+  `Docs/Build.Runbook.md`, `README.MD`, and repo-local skills.
+- When packaging or publish output changes, check the expected output locations before concluding:
+  `Artefacts/ProjectBuild`, `Artefacts/Unpacked`, `Artefacts/Packed`, and `Artefacts/PowerForge/DesktopManager`.
+
+## Reference Files
+
+- `Build/Build-Project.ps1`
+- `Build/Build-Module.ps1`
+- `Build/project.build.json`
+- `powerforge.dotnetpublish.json`
+- `Docs/Build.Runbook.md`
+- `README.MD`

--- a/.agents/skills/desktopmanager-build/agents/openai.yaml
+++ b/.agents/skills/desktopmanager-build/agents/openai.yaml
@@ -1,0 +1,8 @@
+display_name: DesktopManager Build
+short_description: Build and verify DesktopManager package, module, CLI, and MCP outputs through the repo-standard PowerForge entrypoints.
+default_prompt: >-
+  Use the DesktopManager repo build flow. Prefer Build/Build-Project.ps1 first,
+  use plan mode before changing packaging behavior, keep Build/project.build.json
+  and powerforge.dotnetpublish.json as the source of truth, verify PowerShell
+  import plus CLI and MCP behaviour after changes, and keep build docs aligned
+  with the real outputs.

--- a/.agents/skills/desktopmanager-operator/SKILL.md
+++ b/.agents/skills/desktopmanager-operator/SKILL.md
@@ -11,6 +11,10 @@ Use this skill to operate the Windows desktop through DesktopManager.
 
 1. Prefer MCP first:
    `desktopmanager mcp serve`
+   - Add `--allow-mutations` only when the session really needs desktop or saved-state changes.
+   - Add `--allow-process <pattern>` or `--deny-process <pattern>` when the session should stay scoped to specific desktop apps.
+   - Add `--allow-foreground-input` only for sacrificial or tightly controlled sessions that may need focused fallback on zero-handle UIA text or key actions.
+   - Add `--dry-run` when you want to preview mutating MCP calls without changing the desktop.
 2. Start with inspection, not mutation.
    - Read resources first:
      `desktop://windows/active`
@@ -23,6 +27,7 @@ Use this skill to operate the Windows desktop through DesktopManager.
    - When more than one window matches, switch to an exact handle before mutating anything.
 3. Launch and wait when the target app is not ready yet.
    - Use `launch_process` to start the app.
+   - Prefer `launch_and_wait_for_window` when the next step depends on a real launched window instead of a best-effort process start.
    - If launch correlation matters, set a short launch-time window wait instead of assuming the first matching app window is the new one.
    - If you know the expected launched window, pass a title or class filter and require a real match.
    - Use `wait_for_window` before moving, focusing, or capturing it.
@@ -34,18 +39,23 @@ Use this skill to operate the Windows desktop through DesktopManager.
 - The control diagnostics payload now includes elapsed times, so you can compare cold versus warm-cache behavior directly instead of inferring it only from cache flags.
    - Use UIA-oriented selectors when modern apps do not expose useful child-window controls.
    - Use `control_exists` or `wait_for_control` when the control can appear asynchronously or when you want an explicit precondition before clicking.
+   - Use `assert_control_value` when the workflow depends on the field content itself, not merely the presence of a matching control.
    - When available, prefer value, enabled, or focusable checks over brittle text-only guesses.
    - If UIA discovery is flaky on a background window, retry with the shared foreground hint before inventing wrapper-specific workarounds.
    - If the app still stays structurally opaque, switch to the shared coordinate-based fallback: capture the window, inspect its geometry, then use `click_window_point`, `drag_window_points`, or `scroll_window_point`.
+   - When the same visual region matters across runs, save it as a named target area and reuse it from `screenshot_window` with `targetName` or `screenshot target`.
    - Prefer ratio-based client-area targeting when the same workflow must survive different window sizes.
    - If you will reuse the same fallback point more than once, save it as a named target instead of repeating raw ratios or pixels.
    - Use `type_window_text` for whole-window entry.
+   - Use `send_window_keys` for whole-window Enter, Escape, or accelerator follow-up actions when the window is reliable but a modern control is not.
    - Use `click_control`, `set_control_text`, or `send_control_keys` for control-level work.
    - For classic handle-backed controls, prefer `set_control_text` or `send_control_keys` over foreground-dependent hacks because they now route directly to the control.
    - For zero-handle UIA controls in modern apps, foreground-based text or key fallback exists in the shared library too, but treat it as an explicit opt-in for sacrificial or tightly controlled windows.
+   - When you do opt into foreground text fallback, assume the shared library will try a focused select-all-and-paste flow before raw typed input. That is usually the safer first bet for Chromium-style editable controls.
 5. Prefer named state over one-off moves.
    - Use `list_named_layouts` before manually moving windows.
    - Use `apply_named_layout` or `restore_saved_snapshot` when the desired setup already exists.
+   - Use `assert_window_layout` when the next step depends on the saved layout actually being satisfied, not just available.
 6. Make the smallest safe change.
    - Prefer `focus_window`, `snap_window`, or `minimize_windows`.
    - Save the current state before larger changes:
@@ -53,6 +63,11 @@ Use this skill to operate the Windows desktop through DesktopManager.
      `save_current_snapshot`
 7. Explain what changed after mutating actions.
 8. Use CLI only as fallback or verification.
+9. When a mutation matters, ask for evidence.
+   - Mutating MCP tools now accept `captureBefore`, `captureAfter`, and `artifactDirectory`.
+   - Their structured results include `success`, `elapsedMilliseconds`, `safetyMode`, optional target name/kind, best-effort before/after screenshots, and artifact warnings.
+   - Prefer `captureAfter` by default and add `captureBefore` when you need a stronger audit trail.
+   - Remember that the MCP server is now read-only by default, so a failed mutating tool call may be a policy block rather than a selector failure.
 
 ## MCP Surface
 
@@ -67,12 +82,14 @@ Tools:
 - `list_window_controls`
 - `diagnose_window_controls`
 - `control_exists`
+- `assert_control_value`
 - `wait_for_control`
 - `move_window`
 - `click_window_point`
 - `drag_window_points`
 - `scroll_window_point`
 - `type_window_text`
+- `send_window_keys`
 - `focus_window`
 - `minimize_windows`
 - `snap_window`
@@ -80,19 +97,28 @@ Tools:
 - `screenshot_desktop`
 - `screenshot_window`
 - `launch_process`
+- `launch_and_wait_for_window`
 - `list_named_targets`
 - `get_named_target`
 - `save_window_target`
 - `resolve_window_target`
+- `list_named_control_targets`
+- `get_named_control_target`
+- `save_control_target`
+- `resolve_control_target`
 - `click_control`
 - `set_control_text`
 - `send_control_keys`
 - `list_named_layouts`
 - `save_current_layout`
 - `apply_named_layout`
+- `assert_window_layout`
 - `list_named_snapshots`
 - `save_current_snapshot`
 - `restore_saved_snapshot`
+- `prepare_for_coding`
+- `prepare_for_screen_sharing`
+- `clean_up_distractions`
 
 Resources:
 
@@ -132,6 +158,7 @@ desktopmanager window scroll --handle 0xFF1802 --x 200 --y 200 --delta -120 --cl
 desktopmanager window scroll --handle 0xFF1802 --x-ratio 0.5 --y-ratio 0.5 --delta -120 --client-area
 desktopmanager window scroll --handle 0xFF1802 --target editor-center --delta -120
 desktopmanager window type --process notepad --text "Hello world"
+desktopmanager window keys --process msedge --keys VK_RETURN
 desktopmanager control list --window-process notepad
 desktopmanager control diagnose --window-title "*Codex*" --uia --ensure-foreground --sample-limit 5 --json
 desktopmanager control diagnose --window-title "Codex" --target codex-sidebar-toggle --sample-limit 5 --json
@@ -148,8 +175,10 @@ desktopmanager control click --window-process notepad --class RichEditD2DPT
 desktopmanager control set-text --window-process notepad --class RichEditD2DPT --text "Hello world"
 desktopmanager control send-keys --window-process notepad --class RichEditD2DPT --keys VK_CONTROL,VK_A
 desktopmanager process start notepad.exe --wait-for-input-idle-ms 1000
+desktopmanager process start-and-wait notepad.exe --window-title "*Notepad*" --timeout-ms 5000 --json
 desktopmanager screenshot desktop
 desktopmanager screenshot window --process notepad
+desktopmanager screenshot target edge-editor-pane --process msedge --json
 desktopmanager window move --title "Visual Studio Code" --x 0 --y 0 --width 1920 --height 1400
 desktopmanager window focus --process code
 desktopmanager window snap --title "Visual Studio Code" --position left
@@ -157,6 +186,7 @@ desktopmanager monitor list
 desktopmanager layout list
 desktopmanager layout save coding
 desktopmanager layout apply coding
+desktopmanager layout assert coding --position-tolerance-px 50 --size-tolerance-px 50 --json
 desktopmanager snapshot save before-meeting
 desktopmanager snapshot restore before-meeting
 ```
@@ -166,14 +196,19 @@ desktopmanager snapshot restore before-meeting
 - Prefer reading resources before calling mutating tools.
 - Prefer screenshot tools when the task needs visual validation rather than only structural window data.
 - Prefer `launch_process` plus `wait_for_window` over blind retries.
+- Prefer `launch_and_wait_for_window` when a workflow needs one shared launch result, one shared waited-window result, and optional mutation evidence.
+- Remember that `--dry-run` is the safest way to validate mutating MCP payloads and orchestration without touching the desktop.
+- Remember that process allow/deny filters only work reliably when the mutating tool declares an explicit process scope, so prefer `processName` over title-only selectors when those filters are active.
 - Prefer `list_window_controls` before guessing a control handle.
 - Prefer `diagnose_window_controls` when Chromium-style apps or background windows are not returning expected controls, because it now shows per-root UIA probe results instead of only aggregate counts.
 - Remember that `diagnose_window_controls` now also shows whether a preferred UIA root was reused inside the current process, which is most useful in MCP sessions or in-process waits.
 - Remember that `diagnose_window_controls` now also shows whether cached UIA root controls were reused, which helps explain why repeated MCP reads can speed up after the first heavy Chromium-style pass.
 - Prefer `click_window_point`, `drag_window_points`, or `scroll_window_point` over inventing wrapper-specific mouse hacks when screenshots give you a reliable target and the app exposes no usable controls.
+- Prefer `send_window_keys` over ad-hoc foreground hacks when the whole window is the stable target and you only need a commit or accelerator key.
 - Prefer client-area coordinates for browser/editor content, and outer-window coordinates when you intentionally want chrome like tabs, sidebars, or title-bar buttons.
 - Prefer ratio-based coordinates when you expect the target window size to vary between runs or machines.
 - Prefer named targets when the same coordinate fallback will be reused across multiple actions or sessions.
+- Remember that named targets can now also describe reusable areas, so prefer them for screenshot-assisted visual verification instead of hand-rolled crop coordinates.
 - Prefer named control targets when the same control selector or capability profile will be reused across multiple modern-app interactions.
 - Remember that saved control targets improve consistency, but the underlying UIA discovery cost is still real on Chromium-style apps, so `wait` may not return instantly even when the control already exists.
 - Remember that preferred-root reuse is process-local. A long-running MCP server can benefit from it, while separate one-shot CLI invocations start fresh.
@@ -182,7 +217,9 @@ desktopmanager snapshot restore before-meeting
 - Remember that shared control waits now prefer already-seen matching window handles inside the same process before broad rediscovery, so long-lived MCP sessions should behave better on stable modern-app windows.
 - Prefer window-level typing when control-level targeting is uncertain.
 - Prefer named layouts and snapshots over repeated manual window placement.
+- Prefer `assert_window_layout` before multi-step workflows when layout correctness is a precondition, especially after a best-effort apply or a manual rearrangement.
 - Prefer minimizing distracting windows over closing them.
+- Remember that broad layout, snapshot-restore, and workflow mutations are intentionally blocked when MCP process filters are active, because their target app set is wider than one declared process.
 - Use specific selectors when possible:
   title, process, class, pid, or handle.
 - Prefer `handle` over `process` when multiple windows from the same app are open.
@@ -192,8 +229,12 @@ desktopmanager snapshot restore before-meeting
 - Remember that whole-window typing now falls back away from raw `SendInput` when the target window does not actually own foreground focus.
 - Remember that handle-backed control text and key actions now use shared direct-to-control routing, so they are a better background-safe option than trying to focus the app first.
 - Remember that control listings now include shared capability flags for background-safe click, text, keys, and foreground fallback, so inspect those before enabling risky focused-input behavior.
+- Remember that explicit foreground fallback now also requires MCP server opt-in through `--allow-foreground-input`, not only per-tool request opt-in.
 - Remember that UIA control actions now reuse the same shared fallback-root search strategy as UIA discovery, so a discovered modern-app control is less likely to fail later due to a different action search path.
 - Remember that UIA selectors and actions now run through the shared library, but verifying selectors in the current host is still smart before relying on them unattended.
+- Remember that mutating MCP tools can now return best-effort before/after screenshot artifacts and safety metadata, so prefer that shared evidence path over inventing wrapper-specific verification blobs.
+- Prefer the shared workflow tools for coding prep, screen-sharing prep, and cleanup when they fit, because they now return structured results and keep orchestration inside DesktopManager instead of one-off prompts.
+- When a workflow uses an explicit window selector, treat `ResolvedWindow` and `FocusedWindow` as best-effort evidence rather than guaranteed output, and fall back to the workflow `Notes` plus screenshot artifacts when Windows blocks the normal focus path.
 
 ## Reference Files
 

--- a/Docs/Build.Runbook.md
+++ b/Docs/Build.Runbook.md
@@ -86,4 +86,30 @@ Publish a specific CLI runtime:
 
 ```powershell
 desktopmanager mcp serve
+desktopmanager mcp serve --allow-mutations
+desktopmanager mcp serve --allow-mutations --allow-process notepad
 ```
+
+- Fast MCP contract verification lives in `McpServerTests`.
+- The disposable live-app MCP harness lives in `McpServerEndToEndTests` and is gated by:
+
+```powershell
+$env:RUN_UI_TESTS = "true"
+$env:RUN_DESTRUCTIVE_UI_TESTS = "true"
+$env:RUN_EXPERIMENTAL_UI_TESTS = "true"
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadRoundTrip
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadTargetAreaRoundTrip
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWindowMutationRoundTrip
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWorkflowRoundTrip
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadAllowedProcessPolicy
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDeniedProcessPolicy
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDryRunPolicy
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_NotepadRoundTrip|McpServer_NotepadTargetAreaRoundTrip|McpServer_NotepadWindowMutationRoundTrip|McpServer_NotepadWorkflowRoundTrip|McpServer_NotepadAllowedProcessPolicy|McpServer_NotepadDeniedProcessPolicy|McpServer_NotepadDryRunPolicy"
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn
+```
+
+- Those live MCP desktop tests intentionally run under `net8.0-windows` only because they all drive the shared `DesktopManager.Cli.exe` host and the same real desktop session.
+- The safety-policy harness now covers one allowed scoped mutation, one denied scoped mutation, and one dry-run scoped mutation preview against a disposable Notepad window.
+- The stable live MCP desktop pack now stays on the Notepad-backed flows, while both Chromium-style foreground-input harnesses live behind `RUN_EXPERIMENTAL_UI_TESTS=true` so they can be exercised manually without destabilizing regular regression runs.
+- When the experimental Chromium opt-in harness goes inconclusive, it now keeps a screenshot plus control-diagnostic bundle under `%TEMP%\DesktopManager.Tests\McpE2E\Experimental`, exercises temporary named window/control targets so the fallback path stays aligned with the shared targeting workflow, and writes `decision-trace.txt` plus `comparison.txt` for follow-up analysis.

--- a/Docs/DesktopManager.Cli.md
+++ b/Docs/DesktopManager.Cli.md
@@ -17,6 +17,7 @@ desktopmanager window exists
 desktopmanager window active-matches
 desktopmanager window wait
 desktopmanager window type
+desktopmanager window keys
 desktopmanager window move
 desktopmanager window click
 desktopmanager window drag
@@ -36,9 +37,11 @@ desktopmanager control send-keys
 desktopmanager monitor list
 
 desktopmanager process start
+desktopmanager process start-and-wait
 
 desktopmanager screenshot desktop
 desktopmanager screenshot window
+desktopmanager screenshot target
 
 desktopmanager target save
 desktopmanager target get
@@ -52,13 +55,21 @@ desktopmanager control-target resolve
 
 desktopmanager layout save
 desktopmanager layout apply
+desktopmanager layout assert
 desktopmanager layout list
 
 desktopmanager snapshot save
 desktopmanager snapshot restore
 desktopmanager snapshot list
 
+desktopmanager workflow prepare-coding
+desktopmanager workflow prepare-screen-sharing
+desktopmanager workflow clean-up-distractions
+
 desktopmanager mcp serve
+desktopmanager mcp serve --allow-mutations
+desktopmanager mcp serve --allow-mutations --allow-process notepad
+desktopmanager mcp serve --dry-run
 ```
 
 ## Current behavior
@@ -72,9 +83,11 @@ desktopmanager mcp serve
 - snapshots currently reuse the window layout format and are therefore windows-only for now.
 - `process start` launches a desktop application and can optionally wait for input idle and for a launched window to appear.
 - `process start` can now also validate the launched window by title or class and optionally require that a real matching window be found before returning.
+- `process start-and-wait` now packages the safer unattended launch flow: start the app, bind the follow-up wait to the launched process, return the resolved window result, and optionally capture before/after evidence.
 - `window wait` polls for a matching window and returns when one appears.
 - `window exists` and `window active-matches` provide non-mutating verification commands.
 - `control exists` and `control wait` provide the same inspect-first verification model for controls.
+- `control assert-value` adds a stronger reusable assertion when a workflow depends on the resolved field content, not just control presence.
 - `control diagnose` explains which discovery path was used, how many Win32 and UIA controls were actually found, and what each probed UIA root returned.
 - `control diagnose` can now also take `--target <name>`, so saved control targets and ad-hoc selectors share the same diagnostics path.
 - `control diagnose --action-probe` adds a read-only UIA action-resolution probe for the first matched UIA control, so you can verify cached action-match reuse without clicking anything.
@@ -88,13 +101,24 @@ desktopmanager mcp serve
 - `control set-text` and handle-backed `control send-keys` now use shared direct-to-control message routing instead of relying on foreground focus.
 - UIA control actions now reuse the same shared fallback-root search strategy as UIA discovery, which reduces “listed but not actionable” mismatches when modern apps expose controls under Chromium-style child roots.
 - zero-handle UIA text and key fallback paths are now shared too, but they are intentionally opt-in because they rely on focused foreground input for modern apps.
+- when zero-handle UIA text fallback is enabled, the shared library now prefers a focused replace-and-paste flow with verification before it falls back to raw typed input, which is notably more reliable for Chromium-style edit fields.
 - `window type` sends text to the target window, either by simulated typing or clipboard paste.
+- `window keys` sends key chords or single keys to the target window after activating it, which is the safer shared follow-up path for Enter, Escape, and similar actions when modern controls stop being structurally reusable after text entry.
+- mutating `window` and `control` commands can now return shared verification metadata: `success`, `elapsedMilliseconds`, `safetyMode`, optional target name/kind, best-effort before/after screenshots, and artifact warnings.
+- those mutating commands now also accept `--capture-before`, `--capture-after`, and `--artifact-directory` so CLI, MCP, and agent workflows can ask for evidence without changing the core action logic.
+- `workflow prepare-coding` can optionally apply a named layout and then focus a likely editor or terminal window.
+- `workflow prepare-screen-sharing` can optionally apply a named layout, minimize common distractions, and then focus a likely sharing window.
+- `workflow clean-up-distractions` exposes the same shared distraction-minimizing logic as a standalone structured step.
+- workflow results can include `resolvedWindow` for the explicit target window when the workflow can resolve it, but callers should still treat focus and target resolution as best-effort and rely on `Notes` when Windows blocks the normal path.
+- `layout assert` now verifies that the current desktop satisfies a saved named layout within configurable geometry tolerances and optional state matching, which makes saved layouts reusable as assertions instead of restore-only state.
 - `window click`, `window drag`, and `window scroll` provide shared window-relative fallbacks for modern apps when structural control discovery is unavailable.
 - `window` commands support exact handle targeting and active-window targeting for safer selection when multiple windows match.
 - `window geometry` returns both outer-window and client-area bounds, which makes screenshot-assisted targeting much easier.
 - `window click`, `window drag`, and `window scroll` now also support normalized ratios from `0` to `1` for less brittle targeting.
 - `target save` lets you persist a reusable client-area or window-relative point once and reuse it from `window click`, `window drag`, and `window scroll`.
+- `target save` can now also persist a reusable target area via `width`/`height` or `widthRatio`/`heightRatio`, which makes screenshot-assisted visual targeting much more reusable.
 - `target resolve` shows the exact screen-space point a named target maps to for a live window.
+- `screenshot target` and `screenshot window --target <name>` can now capture a resolved named target area directly.
 - `control-target save` lets you persist a reusable control selector and capability profile once, then resolve it later against live windows.
 - `control-target resolve` shows which live control a saved target matches, including its current capabilities and parent window.
 - `control click`, `control set-text`, and `control send-keys` can now reuse a saved control target via `--target`.
@@ -108,15 +132,26 @@ desktopmanager mcp serve
 - `process start` now prefers windows from the launched process and then newer post-launch window handles for the target app, which is safer than binding to any older matching window.
 - `process start --require-window` is now a useful shared primitive for unattended workflows that need a validated target window instead of a best-effort launcher result.
 - `mcp serve` hosts a stdio MCP server.
+- `mcp serve` now defaults to read-only inspection so agents can connect safely before any mutation is enabled.
+- `mcp serve --allow-mutations` enables mutating MCP tools for an intentional session.
+- `mcp serve --allow-process <pattern>` and `--deny-process <pattern>` constrain live desktop mutations to specific process patterns.
+- `mcp serve --allow-foreground-input` is a second explicit opt-in for zero-handle UIA text/key fallback that may need focused foreground input.
+- `mcp serve --dry-run` previews mutating tool calls without changing desktop or saved state.
+- when process filters are active, broad layout/snapshot/workflow mutations that cannot be scoped to one process are intentionally blocked.
 
 ## Why this shape
 
 - `window`, `monitor`, `layout`, and `snapshot` scale better than flat verbs.
 - `process` and `screenshot` add the first inspect-launch-wait loop needed for desktop automation.
+- `process start-and-wait` turns that inspect-launch-wait loop into one shared structured result instead of leaving the correlation logic to every caller.
 - `control` and `window type` add the first direct interaction layer for classic desktop controls.
+- `window keys` rounds out the shared whole-window input path for accelerators and commit keys without forcing agents back into ad-hoc foreground hacks.
 - `window click`, `window drag`, and `window scroll` give CLI, MCP, and PowerShell the same coordinate-based fallback path when UIA-heavy apps stay opaque.
 - `target` turns screenshot-assisted coordinate fallback into reusable state instead of one-off manual ratios.
+- area-capable `target` definitions now let the shared core reuse visual regions, not just click points.
 - `control-target` turns modern-app control discovery into reusable state instead of repeating long UIA selector sets each time.
+- `workflow` packages a few multi-step desktop routines into shared structured results instead of leaving them as prompts or one-off agent logic.
+- `layout assert` turns named layouts into reusable verification assets, not just restore assets.
 - when a saved control target points at a modern Chromium-style app, the first resolution can still take a couple of seconds because shared UIA discovery is the expensive part of the workflow.
 - those fallbacks now also support client-area coordinates, which are usually a better fit for browser and editor content than raw outer-window coordinates.
 - screenshot JSON now includes window geometry metadata for window captures, so agents can map screenshots to client-area coordinates without extra probing.
@@ -132,3 +167,24 @@ desktopmanager mcp serve
 - preferred UIA root reuse only helps inside a long-lived process like MCP or an in-process wait loop. Separate one-shot CLI invocations still start fresh.
 - the short-lived UIA control cache is also process-local, so it mainly helps MCP, in-process waits, and repeated diagnostics inside the same host session.
 - For opaque modern apps, the most reliable fallback flow is now: `screenshot window --json`, inspect `Geometry`, then use ratio-based `window click`, `window drag`, or `window scroll` with `--client-area`.
+
+## Screenshot-Assisted Target Flow
+
+When a modern app exposes unstable structure, prefer this repeatable flow:
+
+```text
+desktopmanager screenshot window --process msedge --json
+desktopmanager target save edge-editor-pane --x-ratio 0.1 --y-ratio 0.15 --width-ratio 0.8 --height-ratio 0.7 --client-area
+desktopmanager target resolve edge-editor-pane --process msedge --json
+desktopmanager screenshot target edge-editor-pane --process msedge --json
+desktopmanager window click --process msedge --target edge-editor-pane
+```
+
+For reusable drags or scrolling, save more than one target and then reuse them from `window drag` or `window scroll` instead of repeating raw coordinates.
+
+When you want mutation evidence too, add artifact flags to the action step:
+
+```text
+desktopmanager control set-text --window-process msedge --target edge-address --text "https://evotec.xyz" --allow-foreground-input --capture-before --capture-after --json
+desktopmanager window click --process msedge --target edge-editor-center --capture-before --capture-after --artifact-directory .\artifacts --json
+```

--- a/Docs/DesktopManager.Mcp.md
+++ b/Docs/DesktopManager.Mcp.md
@@ -9,6 +9,8 @@ DesktopManager exposes two automation surfaces:
 
 For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
 
+The MCP server now starts in read-only inspection mode by default. Use `desktopmanager mcp serve --allow-mutations` when you intentionally want mutating tools, add `--allow-process <pattern>` or `--deny-process <pattern>` when the session should be constrained to specific apps, add `--allow-foreground-input` only for sessions that may need focused foreground fallback on zero-handle UIA text or key actions, and use `--dry-run` when you want mutation previews without changing the desktop.
+
 ## Current MCP Tools
 
 - `get_active_window`
@@ -20,12 +22,14 @@ For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
 - `list_window_controls`
 - `diagnose_window_controls`
 - `control_exists`
+- `assert_control_value`
 - `wait_for_control`
 - `move_window`
 - `click_window_point`
 - `drag_window_points`
 - `scroll_window_point`
 - `type_window_text`
+- `send_window_keys`
 - `focus_window`
 - `minimize_windows`
 - `snap_window`
@@ -33,6 +37,7 @@ For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
 - `screenshot_desktop`
 - `screenshot_window`
 - `launch_process`
+- `launch_and_wait_for_window`
 - `list_named_targets`
 - `get_named_target`
 - `save_window_target`
@@ -47,9 +52,13 @@ For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
 - `list_named_layouts`
 - `save_current_layout`
 - `apply_named_layout`
+- `assert_window_layout`
 - `list_named_snapshots`
 - `save_current_snapshot`
 - `restore_saved_snapshot`
+- `prepare_for_coding`
+- `prepare_for_screen_sharing`
+- `clean_up_distractions`
 
 ## Current MCP Resources
 
@@ -69,25 +78,33 @@ For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
 
 ## Recommended Agent Workflow
 
-1. Inspect first.
+1. Start the server in the safest useful mode.
+   - use plain `desktopmanager mcp serve` for inspection-only sessions
+   - add `--allow-mutations` only when the workflow really needs state changes
+   - add `--allow-process` and `--deny-process` when the workflow should be limited to specific desktop apps
+   - add `--allow-foreground-input` only for sacrificial or tightly controlled sessions that may need focused fallback in modern apps
+   - add `--dry-run` when you want a preview of mutating requests without side effects
+2. Inspect first.
    - Read `desktop://windows/visible`, `desktop://windows/active`, and `desktop://monitors`.
    - Use `get_active_window` when focus matters.
    - Use `window_exists` or `active_window_matches` when you want a structured assertion before acting.
    - Use `screenshot_desktop` or `screenshot_window` when visual confirmation is needed.
    - Use `get_window_geometry` when you need outer-window and client-area bounds before a coordinate-based action.
    - When multiple windows match, prefer an exact `handle` over a broad process selector.
-2. Launch when needed.
+3. Launch when needed.
    - Use `launch_process` for the app under test.
+   - Prefer `launch_and_wait_for_window` when the next step depends on a real launched window, because it binds the wait to the launched process and returns both launch and wait results together.
    - Use `waitForWindowMs` when you want launch to spend a short time correlating the real app window before returning.
    - When you know what kind of window should appear, pass `windowTitle` or `windowClassName` and set `requireWindow=true`.
    - Use `wait_for_window` before trying to move, focus, or capture the window.
-3. Inspect controls before trying to interact.
+4. Inspect controls before trying to interact.
    - Use `list_window_controls` to discover target handles, classes, visible text, automation ids, control types, and control bounds.
    - Use `diagnose_window_controls` when a modern app is not exposing the controls you expect. It will tell you whether Win32 or UIA discovery produced results, whether foreground preparation succeeded, and what each probed UIA root returned.
 - `diagnose_window_controls` also accepts a saved `targetName`, so reusable control targets and one-off selectors share the same diagnostic path.
 - `diagnose_window_controls` also accepts `includeActionProbe`, which adds a read-only UIA action-resolution probe for the first matched UIA control.
 - Diagnostic results now include elapsed times for the overall pass, and the optional action probe includes its own elapsed time too.
    - Use `control_exists` or `wait_for_control` when the target control can appear asynchronously or when you want a structured assertion before clicking.
+   - Use `assert_control_value` when you need to prove that a field really contains the expected value, not just that a matching control exists.
    - When modern controls expose state through UI Automation, filter by current value, enabled state, or keyboard focusability instead of guessing from text alone.
    - If a UIA-heavy query is host-sensitive, opt into foreground assistance before falling back to brittle retries.
    - If structure discovery still fails, use `screenshot_window` plus `get_window_geometry`, then target `click_window_point`, `drag_window_points`, or `scroll_window_point`.
@@ -95,23 +112,34 @@ For agent-driven desktop automation, prefer MCP first and use CLI as fallback.
    - When the same coordinate fallback will be reused, save it once with `save_window_target` and resolve or reuse it by name.
    - When the same control selector will be reused, save it once with `save_control_target` and resolve or reuse it by name.
    - Prefer `type_window_text` for whole-window text entry.
+   - Prefer `send_window_keys` for whole-window Enter, Escape, or accelerator follow-up actions when a modern control becomes unreliable after text entry.
    - Prefer `click_control`, `set_control_text`, and `send_control_keys` for control-level interactions.
 - Saved control targets are especially useful for modern Chromium-style apps because they preserve the same capability-aware selector profile across runs.
 - The same saved control target can now drive read-only discovery too, not just actions, so agents can `list`, `exists`, and `wait` against one reusable selector profile.
    - For classic handle-backed controls, `set_control_text` and `send_control_keys` now route directly to the target control instead of depending on foreground focus.
    - For zero-handle UIA controls in modern apps, foreground-based text or key fallback is now shared too, but should be treated as an explicit opt-in because it can affect the live focused app.
-4. Prefer named state when available.
+   - When foreground text fallback is enabled for those controls, the shared library now prefers a focused select-all-and-paste path with verification before it falls back to raw typed characters, which is usually more reliable for Chromium-style editors and address bars.
+5. Prefer named state when available.
    - Use `list_named_layouts` before moving windows one by one.
    - Use `apply_named_layout` or `restore_saved_snapshot` when a saved state exists.
-5. Make reversible changes.
+   - Use `assert_window_layout` when the workflow depends on the layout being correct before continuing, not just on a layout name existing.
+6. Make reversible changes.
    - Prefer `focus_window`, `snap_window`, and `minimize_windows` over destructive actions.
    - Save the current layout or snapshot before larger rearrangements.
-6. Explain intent.
+7. Explain intent.
    - Say what will change before applying a layout or minimizing multiple windows.
-7. Avoid assumptions.
+8. Avoid assumptions.
    - Match windows by title, process, class, pid, or handle.
    - Start with specific selectors when possible.
    - Remember that `activeWindow` means the current foreground window, which may be the agent host if it has focus.
+9. Ask mutating tools for evidence when it matters.
+   - mutating MCP tools now accept `captureBefore`, `captureAfter`, and `artifactDirectory`.
+   - their structured results now include `success`, `elapsedMilliseconds`, `safetyMode`, optional resolved target name/kind, best-effort before/after screenshots, and artifact warnings.
+   - prefer `captureAfter=true` for lightweight confirmation and add `captureBefore=true` when you need a stronger audit trail.
+10. Prefer shared workflows over prompt-only orchestration when they fit.
+   - `prepare_for_coding`, `prepare_for_screen_sharing`, and `clean_up_distractions` now exist as MCP tools, not only as prompts.
+   - use them when you want a structured result with layout/focus/minimize details instead of free-form narration.
+   - when a workflow is given an explicit window selector, its structured result can include `ResolvedWindow`, but focus and target resolution are still best-effort and may fall back to explanatory `Notes`.
 
 ## CLI Fallback Patterns
 
@@ -142,6 +170,7 @@ desktopmanager window scroll --handle 0xFF1802 --x-ratio 0.5 --y-ratio 0.5 --del
 desktopmanager window scroll --handle 0xFF1802 --target editor-center --delta -120
 desktopmanager window type --handle 0x30A263C --text "Hello world"
 desktopmanager window type --process notepad --text "Hello world"
+desktopmanager window keys --process msedge --keys VK_RETURN
 desktopmanager control list --window-process notepad
 desktopmanager control diagnose --window-title "*Codex*" --uia --ensure-foreground --sample-limit 5 --json
 desktopmanager control diagnose --window-title "Codex" --target codex-sidebar-toggle --sample-limit 5 --json
@@ -155,6 +184,7 @@ desktopmanager control click --window-process notepad --class RichEditD2DPT
 desktopmanager control set-text --window-process notepad --class RichEditD2DPT --text "Hello world"
 desktopmanager control send-keys --window-process notepad --class RichEditD2DPT --keys VK_CONTROL,VK_A
 desktopmanager process start notepad.exe --wait-for-input-idle-ms 1000
+desktopmanager process start-and-wait notepad.exe --window-title "*Notepad*" --timeout-ms 5000 --json
 desktopmanager screenshot desktop
 desktopmanager screenshot window --process notepad
 desktopmanager window move --title "Visual Studio Code" --x 0 --y 0 --width 1920 --height 1400
@@ -164,10 +194,27 @@ desktopmanager monitor list
 desktopmanager layout list
 desktopmanager layout save coding
 desktopmanager layout apply coding
+desktopmanager layout assert coding --position-tolerance-px 50 --size-tolerance-px 50 --json
 desktopmanager snapshot save before-meeting
 desktopmanager snapshot restore before-meeting
 desktopmanager mcp serve
+desktopmanager mcp serve --allow-mutations
+desktopmanager mcp serve --allow-mutations --allow-process notepad
+desktopmanager mcp serve --allow-mutations --deny-process teams
+desktopmanager mcp serve --allow-mutations --allow-foreground-input
+desktopmanager mcp serve --dry-run
 ```
+
+## Screenshot-Assisted Target Flow
+
+When control structure is flaky, prefer this flow:
+
+1. Capture the target window with `screenshot_window`.
+2. Read `get_window_geometry` if you need exact client-area bounds.
+3. Save a reusable point or area with `save_window_target`.
+4. Reuse it from `resolve_window_target`, `screenshot_window` with `targetName`, `click_window_point`, `drag_window_points`, or `scroll_window_point`.
+
+That keeps screenshot-assisted targeting in the shared core instead of forcing the agent to re-invent one-off coordinates every run.
 
 ## Safety Notes
 
@@ -177,6 +224,7 @@ desktopmanager mcp serve
 - Snapshots are windows-only for now.
 - Control discovery supports both child-window selectors and UIA-oriented selectors.
 - Control assertions and waits are available on the same shared selector model as list/click/set-text.
+- Saved layouts now also support structured assertion through `assert_window_layout`, so agents can verify geometry/state expectations before assuming the desktop is ready.
 - Control diagnostics are available on the same shared selector model and help explain Win32 versus UIA discovery gaps.
 - Control diagnostics now include per-root UIA probe details, which makes Chromium-style discovery failures much easier to explain and debug.
 - Control diagnostics now also show whether a preferred UIA root was learned and reused inside the current long-lived process, which is most relevant for MCP sessions and in-process waits.
@@ -186,16 +234,24 @@ desktopmanager mcp serve
 - Coordinate fallbacks can target the client area, which is usually more reliable for browser/editor content than raw outer-window coordinates.
 - Ratio-based coordinate fallbacks are available, which makes screenshot-assisted targeting more portable across different window sizes.
 - Named window targets are available on the same shared geometry model, which makes repeated coordinate fallbacks much less brittle.
+- Named window targets can now also describe reusable areas, not just points, so agents can capture and verify stable visual regions through the shared core.
 - Window screenshots now return geometry metadata in JSON so agents can align the image with client-area coordinates.
 - Window typing now avoids raw `SendInput` when Windows refuses to foreground the target window, which reduces the chance of text leaking into whatever app currently owns focus.
+- Window-level key sending is available as a shared MCP tool, which gives agents a cleaner way to commit or dismiss modern UI flows after whole-window text entry.
 - Process launch can now wait for a launched window and prefers windows from the launched process or newer post-launch handles instead of blindly reusing an older matching window.
 - Process launch can also validate the launched window by title/class and require a real match before returning.
+- `launch_and_wait_for_window` adds a higher-level shared result for unattended launch flows, so MCP callers do not need to stitch `launch_process` and `wait_for_window` together by hand.
 - The shared control selector model now supports value, enabled, and keyboard-focusable checks.
 - The shared control selector model now also exposes background-safe capability metadata for click, text, keys, and explicit foreground fallback.
 - The shared control selector model also supports an opt-in foreground hint for UIA discovery when a target window needs focus.
 - Handle-backed control text and key actions now use shared direct message routing, which is safer for background automation than stealing focus first.
 - UIA control actions now reuse the same shared fallback-root search strategy as UIA discovery, which reduces action mismatches when controls live under Chromium-style child roots.
 - Zero-handle UIA controls now also support shared foreground-based text and key fallback paths, but they should only be enabled intentionally for sacrificial or tightly controlled windows.
+- Shared zero-handle UIA text fallback now prefers focused paste-with-verification before raw typed characters, which should improve reliability for modern edit fields without changing the explicit opt-in safety boundary.
+- Mutating MCP tools can now return best-effort before/after screenshot artifacts plus safety/timing metadata, which makes it easier to verify what actually happened without building custom wrappers around each action.
+- The MCP server now enforces its safety posture instead of documenting it only: default read-only inspection, explicit mutation opt-in through `--allow-mutations`, explicit risky foreground-input opt-in through `--allow-foreground-input`, and side-effect-free mutation previews through `--dry-run`.
+- MCP process filters now let you constrain live desktop mutations to allowed or denied process patterns, and they intentionally block broader layout/workflow mutations when the target app set cannot be scoped safely.
+- Higher-level workflow tools now exist for coding prep, screen-sharing prep, and distraction cleanup, so agents do not have to reassemble those routines from prompts alone.
 - Saved control targets still pay the underlying UIA discovery cost on modern apps, so target-based `wait` is reusable and safer, but not necessarily cheap.
 - Preferred-root reuse is process-local. It helps a long-running MCP server more than separate one-shot CLI invocations.
 - The short-lived shared UIA control cache is also process-local, so long-running MCP sessions benefit far more than one-shot CLI calls.

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -10,6 +10,12 @@ Locale: en-US
 ## Description
 The **DesktopManager** module exposes cmdlets for reading and changing desktop settings such as monitor information, wallpapers and brightness levels.
 
+For the newer window/control automation, target-management, CLI, and MCP surfaces, use the repo-level guides too:
+
+- `README.MD`
+- `Docs/DesktopManager.Cli.md`
+- `Docs/DesktopManager.Mcp.md`
+
 ## DesktopManager Cmdlets
 ### [Get-DesktopMonitors](Get-DesktopMonitors.md)
 List information about the monitors connected to the system.

--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,8 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 
 - [Docs/DesktopManager.Cli.md](Docs/DesktopManager.Cli.md)
 - [Docs/DesktopManager.Mcp.md](Docs/DesktopManager.Mcp.md)
+- [.agents/skills/desktopmanager-operator/SKILL.md](.agents/skills/desktopmanager-operator/SKILL.md)
+- [.agents/skills/desktopmanager-build/SKILL.md](.agents/skills/desktopmanager-build/SKILL.md)
 
 
 ### Available PowerShell Cmdlets
@@ -89,10 +91,22 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 | Invoke-DesktopMouseScroll | Scroll the mouse wheel |
 | Invoke-DesktopScreenshot | Capture monitor or region screenshots |
 | Get-DesktopWindow | Enumerate visible windows |
+| Get-DesktopWindowGeometry | Return outer-window and client-area geometry for matched windows |
 | Get-DesktopWindowControl | Enumerate Win32 or UIA window controls |
+| Get-DesktopWindowControlDiagnostic | Explain Win32 vs UIA control discovery and actionability |
+| Get-DesktopWindowProcessInfo | Return process details for matched windows |
+| Get-DesktopWindowTarget | List saved window-relative targets or resolve one against live windows |
+| Get-DesktopControlTarget | List saved control targets or resolve one against live windows |
+| Invoke-DesktopControlClick | Click a matched control using shared control action routing |
+| Invoke-DesktopWindowClick | Click a window-relative point or saved window target |
+| Invoke-DesktopWindowDrag | Drag between window-relative points or saved targets |
+| Invoke-DesktopWindowScroll | Scroll at a window-relative point or saved target |
+| Send-DesktopControlKey | Send keys to a matched control without reimplementing key routing |
+| Set-DesktopControlTarget | Save a reusable control selector profile |
 | Set-DesktopControlText | Write text directly to a specific control |
 | Set-DesktopWindow | Move, resize or control windows |
 | Set-DesktopWindowSnap | Snap window to common positions |
+| Set-DesktopWindowTarget | Save a reusable window-relative point target |
 | Set-DesktopWindowText | Paste or type text into a window |
 | Wait-DesktopWindow | Wait for a window to appear |
 | Wait-DesktopWindowControl | Wait for a control to appear |
@@ -137,11 +151,23 @@ The table below shows the most relevant API methods behind each PowerShell cmdle
 | Invoke-DesktopMouseScroll | `WindowManager.ScrollMouse` |
 | Invoke-DesktopScreenshot | `ScreenshotService.CaptureScreen`, `ScreenshotService.CaptureRegion` |
 | Get-DesktopWindow | `WindowManager.GetWindows` / `GetWindowsForProcess` |
+| Get-DesktopWindowGeometry | `DesktopAutomationService.GetWindowGeometry` |
 | Get-DesktopWindowControl | `DesktopAutomationService.GetControls` |
-| Set-DesktopControlText | `WindowManager.SetControlText` |
+| Get-DesktopWindowControlDiagnostic | `DesktopAutomationService.GetControlDiagnostics` / `GetControlTargetDiagnostics` |
+| Get-DesktopWindowProcessInfo | `WindowManager.GetWindowProcessInfo` |
+| Get-DesktopWindowTarget | `DesktopAutomationService.ListWindowTargets`, `GetWindowTarget`, `ResolveWindowTargets` |
+| Get-DesktopControlTarget | `DesktopAutomationService.ListControlTargets`, `GetControlTarget`, `ResolveControlTargets` |
+| Invoke-DesktopControlClick | `DesktopAutomationService.ClickControls` / `ClickControlTarget` |
+| Invoke-DesktopWindowClick | `DesktopAutomationService.ClickWindowPoint` / `ClickWindowTarget` |
+| Invoke-DesktopWindowDrag | `DesktopAutomationService.DragWindowPoints` / `DragWindowTargets` |
+| Invoke-DesktopWindowScroll | `DesktopAutomationService.ScrollWindowPoint` / `ScrollWindowTarget` |
+| Send-DesktopControlKey | `DesktopAutomationService.SendControlKeys` / `SendControlTargetKeys` |
+| Set-DesktopControlTarget | `DesktopAutomationService.SaveControlTarget` |
+| Set-DesktopControlText | `DesktopAutomationService.SetControlText` |
 | Set-DesktopWindow | `WindowManager.SetWindowPosition`, `MoveWindowToMonitor`, etc. |
 | Set-DesktopWindowSnap | `WindowManager.SnapWindow` |
-| Set-DesktopWindowText | `WindowInputService` |
+| Set-DesktopWindowTarget | `DesktopAutomationService.SaveWindowTarget` |
+| Set-DesktopWindowText | `WindowManager.TypeText`, `WindowManager.PasteText`, `WindowInputService` |
 | Wait-DesktopWindow | `DesktopAutomationService.WaitForWindows` |
 | Wait-DesktopWindowControl | `DesktopAutomationService.WaitForControls` |
 | Test-DesktopWindow | `DesktopAutomationService.WindowExists` / `ActiveWindowMatches` |
@@ -168,7 +194,8 @@ Install-Module DesktopManager -Force -Verbose
 UI-impacting tests are opt-in to avoid opening windows or changing the desktop during local development. Use the environment variables below to control behavior:
 
 - `RUN_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_UI_TESTS=true`) enables UI tests.
-- `RUN_DESTRUCTIVE_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true`) enables tests that change wallpapers, brightness, or resolution.
+- `RUN_DESTRUCTIVE_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true`) enables tests that change desktop state, including the live MCP Notepad round-trip harness and tests that change wallpapers, brightness, or resolution.
+- `RUN_EXPERIMENTAL_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_EXPERIMENTAL_UI_TESTS=true`) enables experimental live UI harnesses that are useful for manual validation but are not part of the stable regression pack.
 - `SKIP_UI_TESTS=true` (or `DESKTOPMANAGER_SKIP_UI_TESTS=true`) forces UI tests to skip, even if enabled elsewhere.
 
 ```powershell
@@ -178,9 +205,44 @@ $env:RUN_UI_TESTS = "true"
 # Run tests that change desktop settings
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
 
+# Run experimental live UI harnesses
+$env:RUN_EXPERIMENTAL_UI_TESTS = "true"
+
 # Force skip
 $env:SKIP_UI_TESTS = "true"
+
+# Run the live MCP Notepad end-to-end harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadRoundTrip
+
+# Run the live MCP target-area capture harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadTargetAreaRoundTrip
+
+# Run the live MCP window-move and geometry verification harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWindowMutationRoundTrip
+
+# Run the live MCP workflow harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWorkflowRoundTrip
+
+# Run the live MCP allowlisted process-policy harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadAllowedProcessPolicy
+
+# Run the live MCP denied-process policy harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDeniedProcessPolicy
+
+# Run the live MCP dry-run policy harness (net8 only)
+dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDryRunPolicy
+
+# Run the stable live MCP desktop pack (net8 only)
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_NotepadRoundTrip|McpServer_NotepadTargetAreaRoundTrip|McpServer_NotepadWindowMutationRoundTrip|McpServer_NotepadWorkflowRoundTrip|McpServer_NotepadAllowedProcessPolicy|McpServer_NotepadDeniedProcessPolicy|McpServer_NotepadDryRunPolicy"
+
+# Run the experimental live MCP blocked foreground-input Edge harness (net8 only)
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn
+
+# Run the experimental live MCP foreground-input opt-in Edge harness (net8 only)
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn
 ```
+
+When the experimental Chromium opt-in harness skips because the omnibox never becomes reliably discoverable, it now leaves a screenshot plus control-diagnostic bundle under `%TEMP%\DesktopManager.Tests\McpE2E\Experimental` and uses temporary named window/control targets so the fallback path matches the shared targeting model. Each bundle now also includes `decision-trace.txt` and `comparison.txt`.
 
 ### Usage
 

--- a/Sources/DesktopManager.Cli/CliApplication.cs
+++ b/Sources/DesktopManager.Cli/CliApplication.cs
@@ -24,6 +24,7 @@ internal static class CliApplication {
                 "control-target" => ControlTargetCommands.Run(action, parsed),
                 "layout" => LayoutCommands.Run(action, parsed),
                 "snapshot" => SnapshotCommands.Run(action, parsed),
+                "workflow" => WorkflowCommands.Run(action, parsed),
                 "mcp" => McpCommands.Run(action, parsed),
                 "help" => ShowGroupHelp(parsed),
                 _ => throw new CommandLineException($"Unknown command group '{group}'.")
@@ -51,6 +52,7 @@ internal static class CliApplication {
             "control-target" => HelpText.GetControlTargetHelp(),
             "layout" => HelpText.GetLayoutHelp(),
             "snapshot" => HelpText.GetSnapshotHelp(),
+            "workflow" => HelpText.GetWorkflowHelp(),
             "mcp" => HelpText.GetMcpHelp(),
             _ => HelpText.GetGeneralHelp()
         };

--- a/Sources/DesktopManager.Cli/ControlCommands.cs
+++ b/Sources/DesktopManager.Cli/ControlCommands.cs
@@ -10,6 +10,7 @@ internal static class ControlCommands {
             "list" => List(arguments),
             "diagnose" => Diagnose(arguments),
             "exists" => Exists(arguments),
+            "assert-value" => AssertValue(arguments),
             "wait" => Wait(arguments),
             "click" => Click(arguments),
             "set-text" => SetText(arguments),
@@ -166,6 +167,43 @@ internal static class ControlCommands {
         return 0;
     }
 
+    private static int AssertValue(CommandLineArguments arguments) {
+        bool contains = arguments.GetBoolFlag("contains");
+        string? expected = arguments.GetOption("expected-value") ?? arguments.GetOption("expected");
+        if (string.IsNullOrWhiteSpace(expected)) {
+            throw new CommandLineException("Missing required option '--expected-value'.");
+        }
+
+        string? targetName = arguments.GetOption("target");
+        ControlValueAssertionResult result = !string.IsNullOrWhiteSpace(targetName)
+            ? DesktopOperations.AssertControlTargetValue(
+                CreateWindowCriteria(arguments),
+                targetName,
+                expected,
+                contains,
+                arguments.GetBoolFlag("all-windows"),
+                arguments.GetBoolFlag("all"))
+            : DesktopOperations.AssertControlValue(
+                CreateWindowCriteria(arguments),
+                CreateControlCriteria(arguments),
+                expected,
+                contains,
+                arguments.GetBoolFlag("all-windows"));
+
+        if (arguments.GetBoolFlag("json")) {
+            OutputFormatter.WriteJson(result);
+        } else {
+            Console.WriteLine(result.Matched ? "Control value assertion passed." : "Control value assertion failed.");
+            Console.WriteLine($"assertion: {result.PropertyName} {result.MatchMode} \"{result.Expected}\"");
+            Console.WriteLine($"matched: {result.MatchedCount}/{result.Count}");
+            foreach (ControlResult control in result.Controls) {
+                Console.WriteLine($"- {control.ControlType} value=\"{control.Value}\" text=\"{control.Text}\" in {control.ParentWindow.Title}");
+            }
+        }
+
+        return result.Matched ? 0 : 2;
+    }
+
     private static int Click(CommandLineArguments arguments) {
         string? targetName = arguments.GetOption("target");
         ControlActionResult result;
@@ -175,7 +213,8 @@ internal static class ControlCommands {
                 targetName,
                 arguments.GetOption("button") ?? "left",
                 arguments.GetBoolFlag("all-windows"),
-                arguments.GetBoolFlag("all"));
+                arguments.GetBoolFlag("all"),
+                CreateArtifactOptions(arguments));
             return WriteAction(arguments, result);
         }
 
@@ -183,7 +222,8 @@ internal static class ControlCommands {
             CreateWindowCriteria(arguments),
             CreateControlCriteria(arguments),
             arguments.GetOption("button") ?? "left",
-            arguments.GetBoolFlag("all-windows"));
+            arguments.GetBoolFlag("all-windows"),
+            CreateArtifactOptions(arguments));
         return WriteAction(arguments, result);
     }
 
@@ -197,12 +237,14 @@ internal static class ControlCommands {
                 arguments.GetBoolFlag("ensure-foreground"),
                 arguments.GetBoolFlag("allow-foreground-input"),
                 arguments.GetBoolFlag("all-windows"),
-                arguments.GetBoolFlag("all"))
+                arguments.GetBoolFlag("all"),
+                CreateArtifactOptions(arguments))
             : DesktopOperations.SetControlText(
                 CreateWindowCriteria(arguments),
                 CreateControlCriteria(arguments),
                 arguments.GetRequiredOption("text"),
-                arguments.GetBoolFlag("all-windows"));
+                arguments.GetBoolFlag("all-windows"),
+                CreateArtifactOptions(arguments));
         return WriteAction(arguments, result);
     }
 
@@ -222,12 +264,14 @@ internal static class ControlCommands {
                 arguments.GetBoolFlag("ensure-foreground"),
                 arguments.GetBoolFlag("allow-foreground-input"),
                 arguments.GetBoolFlag("all-windows"),
-                arguments.GetBoolFlag("all"))
+                arguments.GetBoolFlag("all"),
+                CreateArtifactOptions(arguments))
             : DesktopOperations.SendControlKeys(
                 CreateWindowCriteria(arguments),
                 CreateControlCriteria(arguments),
                 keys,
-                arguments.GetBoolFlag("all-windows"));
+                arguments.GetBoolFlag("all-windows"),
+                CreateArtifactOptions(arguments));
         return WriteAction(arguments, result);
     }
 
@@ -237,11 +281,38 @@ internal static class ControlCommands {
             return 0;
         }
 
-        Console.WriteLine($"{result.Action}: {result.Count} control(s)");
+        Console.WriteLine($"{result.Action}: {result.Count} control(s) success={result.Success} safety={result.SafetyMode} elapsed-ms={result.ElapsedMilliseconds}");
+        if (!string.IsNullOrWhiteSpace(result.TargetName)) {
+            Console.WriteLine($"target: {result.TargetKind ?? "selector"} {result.TargetName}");
+        }
+
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            Console.WriteLine($"warning: {warning}");
+        }
+
         foreach (ControlResult control in result.Controls) {
             Console.WriteLine($"- {control.ClassName} [{control.Id}] in {control.ParentWindow.Title}");
         }
         return 0;
+    }
+
+    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+        bool captureBefore = arguments.GetBoolFlag("capture-before");
+        bool captureAfter = arguments.GetBoolFlag("capture-after");
+        string? artifactDirectory = arguments.GetOption("artifact-directory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
     }
 
     private static int WriteAssertion(CommandLineArguments arguments, ControlAssertionResult result, string successText, string failureText) {

--- a/Sources/DesktopManager.Cli/DesktopModels.cs
+++ b/Sources/DesktopManager.Cli/DesktopModels.cs
@@ -56,7 +56,15 @@ internal sealed class WindowResult {
 
 internal sealed class WindowChangeResult {
     public string Action { get; set; } = string.Empty;
+    public bool Success { get; set; }
     public int Count { get; set; }
+    public int ElapsedMilliseconds { get; set; }
+    public string SafetyMode { get; set; } = string.Empty;
+    public string? TargetName { get; set; }
+    public string? TargetKind { get; set; }
+    public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
     public IReadOnlyList<WindowResult> Windows { get; set; } = new List<WindowResult>();
 }
 
@@ -100,7 +108,15 @@ internal sealed class ControlResult {
 
 internal sealed class ControlActionResult {
     public string Action { get; set; } = string.Empty;
+    public bool Success { get; set; }
     public int Count { get; set; }
+    public int ElapsedMilliseconds { get; set; }
+    public string SafetyMode { get; set; } = string.Empty;
+    public string? TargetName { get; set; }
+    public string? TargetKind { get; set; }
+    public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
     public IReadOnlyList<ControlResult> Controls { get; set; } = new List<ControlResult>();
 }
 
@@ -108,6 +124,18 @@ internal sealed class ControlAssertionResult {
     public bool Matched { get; set; }
     public string Assertion { get; set; } = string.Empty;
     public int Count { get; set; }
+    public IReadOnlyList<ControlResult> Controls { get; set; } = new List<ControlResult>();
+}
+
+internal sealed class ControlValueAssertionResult {
+    public bool Matched { get; set; }
+    public string Assertion { get; set; } = string.Empty;
+    public string Expected { get; set; } = string.Empty;
+    public string MatchMode { get; set; } = string.Empty;
+    public string PropertyName { get; set; } = string.Empty;
+    public int Count { get; set; }
+    public int MatchedCount { get; set; }
+    public string? TargetName { get; set; }
     public IReadOnlyList<ControlResult> Controls { get; set; } = new List<ControlResult>();
 }
 
@@ -183,12 +211,55 @@ internal sealed class NamedStateResult {
     public string? Scope { get; set; }
 }
 
+internal sealed class SavedWindowLayoutEntryResult {
+    public string Title { get; set; } = string.Empty;
+    public uint ProcessId { get; set; }
+    public int Left { get; set; }
+    public int Top { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public string? State { get; set; }
+}
+
+internal sealed class WindowLayoutMismatchResult {
+    public SavedWindowLayoutEntryResult Expected { get; set; } = new();
+    public WindowResult Current { get; set; } = new();
+    public int LeftDelta { get; set; }
+    public int TopDelta { get; set; }
+    public int WidthDelta { get; set; }
+    public int HeightDelta { get; set; }
+    public bool StateMatched { get; set; }
+}
+
+internal sealed class WindowLayoutAssertionResult {
+    public bool Matched { get; set; }
+    public string Assertion { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public int ExpectedCount { get; set; }
+    public int MatchedCount { get; set; }
+    public int MissingCount { get; set; }
+    public int MismatchCount { get; set; }
+    public int PositionTolerancePixels { get; set; }
+    public int SizeTolerancePixels { get; set; }
+    public bool CheckState { get; set; }
+    public IReadOnlyList<SavedWindowLayoutEntryResult> MissingWindows { get; set; } = new List<SavedWindowLayoutEntryResult>();
+    public IReadOnlyList<WindowLayoutMismatchResult> MismatchedWindows { get; set; } = new List<WindowLayoutMismatchResult>();
+    public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
+}
+
 internal sealed class WindowTargetDefinitionResult {
     public string? Description { get; set; }
     public int? X { get; set; }
     public int? Y { get; set; }
     public double? XRatio { get; set; }
     public double? YRatio { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+    public double? WidthRatio { get; set; }
+    public double? HeightRatio { get; set; }
     public bool ClientArea { get; set; }
 }
 
@@ -232,8 +303,12 @@ internal sealed class ResolvedWindowTargetResult {
     public WindowGeometryResult Geometry { get; set; } = new();
     public int RelativeX { get; set; }
     public int RelativeY { get; set; }
+    public int? RelativeWidth { get; set; }
+    public int? RelativeHeight { get; set; }
     public int ScreenX { get; set; }
     public int ScreenY { get; set; }
+    public int? ScreenWidth { get; set; }
+    public int? ScreenHeight { get; set; }
 }
 
 internal sealed class ResolvedControlTargetResult {
@@ -264,6 +339,20 @@ internal sealed class ProcessLaunchResult {
     public WindowResult? MainWindow { get; set; }
 }
 
+internal sealed class LaunchAndWaitResult {
+    public string Action { get; set; } = string.Empty;
+    public bool Success { get; set; }
+    public int ElapsedMilliseconds { get; set; }
+    public int WaitTimeoutMilliseconds { get; set; }
+    public int WaitIntervalMilliseconds { get; set; }
+    public ProcessLaunchResult Launch { get; set; } = new();
+    public WaitForWindowResult WindowWait { get; set; } = new();
+    public IReadOnlyList<string> Notes { get; set; } = new List<string>();
+    public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
+}
+
 internal sealed class WaitForWindowResult {
     public int ElapsedMilliseconds { get; set; }
     public int Count { get; set; }
@@ -282,4 +371,26 @@ internal sealed class WindowAssertionResult {
     public int Count { get; set; }
     public IReadOnlyList<WindowResult> Windows { get; set; } = new List<WindowResult>();
     public WindowResult? ActiveWindow { get; set; }
+}
+
+internal sealed class MutationArtifactOptions {
+    public bool CaptureBefore { get; set; }
+    public bool CaptureAfter { get; set; }
+    public string? ArtifactDirectory { get; set; }
+}
+
+internal sealed class WorkflowResult {
+    public string Action { get; set; } = string.Empty;
+    public bool Success { get; set; }
+    public int ElapsedMilliseconds { get; set; }
+    public string? LayoutName { get; set; }
+    public bool LayoutApplied { get; set; }
+    public int MinimizedCount { get; set; }
+    public IReadOnlyList<WindowResult> MinimizedWindows { get; set; } = new List<WindowResult>();
+    public WindowResult? ResolvedWindow { get; set; }
+    public WindowResult? FocusedWindow { get; set; }
+    public IReadOnlyList<string> Notes { get; set; } = new List<string>();
+    public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
+    public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
 }

--- a/Sources/DesktopManager.Cli/DesktopOperations.LayoutAssertions.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.LayoutAssertions.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace DesktopManager.Cli;
+
+internal static partial class DesktopOperations {
+    public static WindowLayoutAssertionResult AssertWindowLayout(string name, int positionTolerancePixels, int sizeTolerancePixels, bool includeHidden, bool includeEmpty, bool checkState, MutationArtifactOptions? artifactOptions = null) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            throw new CommandLineException("Layout name is required.");
+        }
+
+        if (positionTolerancePixels < 0) {
+            throw new CommandLineException("Position tolerance must be zero or greater.");
+        }
+
+        if (sizeTolerancePixels < 0) {
+            throw new CommandLineException("Size tolerance must be zero or greater.");
+        }
+
+        return ExecuteCore(() => {
+            string path = DesktopStateStore.GetLayoutPath(name);
+            if (!File.Exists(path)) {
+                throw new InvalidOperationException($"Named layout '{name}' was not found.");
+            }
+
+            WindowLayout layout = ReadWindowLayout(path);
+            var warnings = new List<string>();
+            MutationArtifactOptions options = artifactOptions ?? new MutationArtifactOptions();
+            IReadOnlyList<ScreenshotResult> beforeScreenshots = options.CaptureBefore
+                ? CaptureDesktopArtifacts("assert-window-layout", "before", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            DesktopAutomationService automation = new DesktopAutomationService();
+            IReadOnlyList<WindowInfo> currentWindows = automation.GetWindows(new WindowQueryOptions {
+                TitlePattern = "*",
+                ProcessNamePattern = "*",
+                ClassNamePattern = "*",
+                IncludeHidden = includeHidden,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = includeEmpty
+            });
+
+            var missingWindows = new List<SavedWindowLayoutEntryResult>();
+            var mismatchedWindows = new List<WindowLayoutMismatchResult>();
+            var usedHandles = new HashSet<IntPtr>();
+            int matchedCount = 0;
+
+            foreach (WindowPosition expected in layout.Windows) {
+                WindowInfo? current = FindMatchingWindow(expected, currentWindows, usedHandles);
+                SavedWindowLayoutEntryResult expectedResult = MapSavedWindowLayoutEntry(expected);
+                if (current == null) {
+                    missingWindows.Add(expectedResult);
+                    continue;
+                }
+
+                int leftDelta = Math.Abs(expected.Left - current.Left);
+                int topDelta = Math.Abs(expected.Top - current.Top);
+                int widthDelta = Math.Abs(expected.Width - current.Width);
+                int heightDelta = Math.Abs(expected.Height - current.Height);
+                bool geometryMatched = leftDelta <= positionTolerancePixels &&
+                    topDelta <= positionTolerancePixels &&
+                    widthDelta <= sizeTolerancePixels &&
+                    heightDelta <= sizeTolerancePixels;
+                bool stateMatched = !checkState || !expected.State.HasValue || expected.State == current.State;
+
+                if (geometryMatched && stateMatched) {
+                    matchedCount++;
+                    continue;
+                }
+
+                mismatchedWindows.Add(new WindowLayoutMismatchResult {
+                    Expected = expectedResult,
+                    Current = MapWindow(current),
+                    LeftDelta = leftDelta,
+                    TopDelta = topDelta,
+                    WidthDelta = widthDelta,
+                    HeightDelta = heightDelta,
+                    StateMatched = stateMatched
+                });
+            }
+
+            IReadOnlyList<ScreenshotResult> afterScreenshots = options.CaptureAfter
+                ? CaptureDesktopArtifacts("assert-window-layout", "after", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            return new WindowLayoutAssertionResult {
+                Matched = missingWindows.Count == 0 && mismatchedWindows.Count == 0 && matchedCount == layout.Windows.Count,
+                Assertion = "window-layout",
+                Name = name,
+                Path = path,
+                ExpectedCount = layout.Windows.Count,
+                MatchedCount = matchedCount,
+                MissingCount = missingWindows.Count,
+                MismatchCount = mismatchedWindows.Count,
+                PositionTolerancePixels = positionTolerancePixels,
+                SizeTolerancePixels = sizeTolerancePixels,
+                CheckState = checkState,
+                MissingWindows = missingWindows,
+                MismatchedWindows = mismatchedWindows,
+                BeforeScreenshots = beforeScreenshots,
+                AfterScreenshots = afterScreenshots,
+                ArtifactWarnings = warnings
+            };
+        });
+    }
+
+    private static WindowLayout ReadWindowLayout(string path) {
+        string json = File.ReadAllText(path);
+        WindowLayout? layout;
+        try {
+            layout = JsonSerializer.Deserialize<WindowLayout>(json);
+        } catch (JsonException ex) {
+            throw new InvalidOperationException($"Invalid layout file: {ex.Message}", ex);
+        }
+
+        if (layout?.Windows == null) {
+            throw new InvalidDataException("Layout does not contain any windows.");
+        }
+
+        return layout;
+    }
+
+    private static WindowInfo? FindMatchingWindow(WindowPosition expected, IReadOnlyList<WindowInfo> currentWindows, HashSet<IntPtr> usedHandles) {
+        WindowInfo? exact = currentWindows.FirstOrDefault(window =>
+            window.Handle != IntPtr.Zero &&
+            !usedHandles.Contains(window.Handle) &&
+            window.ProcessId == expected.ProcessId &&
+            string.Equals(window.Title, expected.Title, StringComparison.Ordinal));
+        if (exact != null) {
+            usedHandles.Add(exact.Handle);
+            return exact;
+        }
+
+        WindowInfo? byTitle = currentWindows.FirstOrDefault(window =>
+            window.Handle != IntPtr.Zero &&
+            !usedHandles.Contains(window.Handle) &&
+            string.Equals(window.Title, expected.Title, StringComparison.Ordinal));
+        if (byTitle != null) {
+            usedHandles.Add(byTitle.Handle);
+            return byTitle;
+        }
+
+        WindowInfo? byProcessId = currentWindows.FirstOrDefault(window =>
+            window.Handle != IntPtr.Zero &&
+            !usedHandles.Contains(window.Handle) &&
+            window.ProcessId == expected.ProcessId);
+        if (byProcessId != null) {
+            usedHandles.Add(byProcessId.Handle);
+            return byProcessId;
+        }
+
+        return null;
+    }
+
+    private static SavedWindowLayoutEntryResult MapSavedWindowLayoutEntry(WindowPosition window) {
+        return new SavedWindowLayoutEntryResult {
+            Title = window.Title,
+            ProcessId = window.ProcessId,
+            Left = window.Left,
+            Top = window.Top,
+            Width = window.Width,
+            Height = window.Height,
+            State = window.State?.ToString()
+        };
+    }
+}

--- a/Sources/DesktopManager.Cli/DesktopOperations.Mutations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.Mutations.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace DesktopManager.Cli;
+
+internal static partial class DesktopOperations {
+    private static WindowChangeResult ExecuteWindowMutation(string action, WindowSelectionCriteria criteria, string safetyMode, MutationArtifactOptions? artifactOptions, Func<DesktopAutomationService, IReadOnlyList<WindowInfo>> mutation, string? targetName = null, string? targetKind = null) {
+        return ExecuteCore(() => {
+            var automation = new DesktopAutomationService();
+            var warnings = new List<string>();
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            MutationArtifactOptions options = artifactOptions ?? new MutationArtifactOptions();
+
+            IReadOnlyList<ScreenshotResult> beforeScreenshots = options.CaptureBefore
+                ? CaptureWindowArtifacts(automation, ResolveWindowsForMutation(automation, criteria), action, "before", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            IReadOnlyList<WindowInfo> windows = mutation(automation);
+
+            IReadOnlyList<ScreenshotResult> afterScreenshots = options.CaptureAfter
+                ? CaptureWindowArtifacts(automation, windows, action, "after", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            stopwatch.Stop();
+            return BuildWindowChangeResult(action, windows, (int)stopwatch.ElapsedMilliseconds, safetyMode, targetName, targetKind, beforeScreenshots, afterScreenshots, warnings);
+        });
+    }
+
+    private static ControlActionResult ExecuteControlMutation(string action, WindowSelectionCriteria windowCriteria, bool allWindows, bool allControls, MutationArtifactOptions? artifactOptions, Func<DesktopAutomationService, IReadOnlyList<WindowControlTargetInfo>> resolveControls, Func<IReadOnlyList<WindowControlTargetInfo>, string> determineSafetyMode, Func<DesktopAutomationService, IReadOnlyList<WindowControlTargetInfo>> mutation, string? targetName = null, string? targetKind = null) {
+        return ExecuteCore(() => {
+            var automation = new DesktopAutomationService();
+            var warnings = new List<string>();
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            MutationArtifactOptions options = artifactOptions ?? new MutationArtifactOptions();
+
+            IReadOnlyList<WindowControlTargetInfo> resolvedControls = options.CaptureBefore
+                ? resolveControls(automation)
+                : Array.Empty<WindowControlTargetInfo>();
+            IReadOnlyList<ScreenshotResult> beforeScreenshots = options.CaptureBefore
+                ? CaptureControlArtifacts(automation, LimitControlsForMutation(resolvedControls, allWindows, allControls), action, "before", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            IReadOnlyList<WindowControlTargetInfo> controls = mutation(automation);
+            IReadOnlyList<WindowControlTargetInfo> safetyControls = resolvedControls.Count > 0 ? resolvedControls : controls;
+            string safetyMode = determineSafetyMode(safetyControls);
+
+            IReadOnlyList<ScreenshotResult> afterScreenshots = options.CaptureAfter
+                ? CaptureControlArtifacts(automation, controls, action, "after", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            stopwatch.Stop();
+            return BuildControlActionResult(action, controls, (int)stopwatch.ElapsedMilliseconds, safetyMode, targetName, targetKind, beforeScreenshots, afterScreenshots, warnings);
+        });
+    }
+
+    private static IReadOnlyList<WindowInfo> ResolveWindowsForMutation(DesktopAutomationService automation, WindowSelectionCriteria criteria) {
+        IReadOnlyList<WindowInfo> windows = automation.GetWindows(CreateWindowQuery(criteria));
+        if (criteria.All || windows.Count <= 1) {
+            return windows;
+        }
+
+        return new[] { windows[0] };
+    }
+
+    private static IReadOnlyList<WindowControlTargetInfo> LimitControlsForMutation(IReadOnlyList<WindowControlTargetInfo> controls, bool allWindows, bool allControls) {
+        if (allControls || controls.Count <= 1) {
+            return controls;
+        }
+
+        return new[] { controls[0] };
+    }
+
+    private static IReadOnlyList<ScreenshotResult> CaptureWindowArtifacts(DesktopAutomationService automation, IReadOnlyList<WindowInfo> windows, string action, string phase, MutationArtifactOptions options, List<string> warnings) {
+        if (windows.Count == 0) {
+            return Array.Empty<ScreenshotResult>();
+        }
+
+        string stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmssfff");
+        var screenshots = new List<ScreenshotResult>(windows.Count);
+        for (int index = 0; index < windows.Count; index++) {
+            WindowInfo window = windows[index];
+            try {
+                using DesktopCapture capture = automation.CaptureWindow(new WindowQueryOptions {
+                    Handle = window.Handle,
+                    IncludeHidden = true,
+                    IncludeCloaked = true,
+                    IncludeOwned = true,
+                    IncludeEmptyTitles = true
+                });
+                string prefix = BuildArtifactPrefix(action, phase, window.Handle, stamp, index);
+                screenshots.Add(SaveScreenshot(capture, prefix, ResolveArtifactOutputPath(options.ArtifactDirectory, prefix)));
+            } catch (Exception ex) when (IsArtifactWarning(ex)) {
+                warnings.Add($"Failed to capture {phase} window screenshot for {FormatWindowLabel(window)}: {ex.Message}");
+            }
+        }
+
+        return screenshots;
+    }
+
+    private static IReadOnlyList<ScreenshotResult> CaptureControlArtifacts(DesktopAutomationService automation, IReadOnlyList<WindowControlTargetInfo> controls, string action, string phase, MutationArtifactOptions options, List<string> warnings) {
+        if (controls.Count == 0) {
+            return Array.Empty<ScreenshotResult>();
+        }
+
+        string stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmssfff");
+        WindowControlTargetInfo[] uniqueControls = controls
+            .GroupBy(control => control.Window.Handle)
+            .Select(group => group.First())
+            .ToArray();
+
+        var screenshots = new List<ScreenshotResult>(uniqueControls.Length);
+        for (int index = 0; index < uniqueControls.Length; index++) {
+            WindowControlTargetInfo target = uniqueControls[index];
+            try {
+                using DesktopCapture capture = automation.CaptureWindow(new WindowQueryOptions {
+                    Handle = target.Window.Handle,
+                    IncludeHidden = true,
+                    IncludeCloaked = true,
+                    IncludeOwned = true,
+                    IncludeEmptyTitles = true
+                });
+                string prefix = BuildArtifactPrefix(action, phase, target.Window.Handle, stamp, index);
+                screenshots.Add(SaveScreenshot(capture, prefix, ResolveArtifactOutputPath(options.ArtifactDirectory, prefix)));
+            } catch (Exception ex) when (IsArtifactWarning(ex)) {
+                warnings.Add($"Failed to capture {phase} control screenshot for {FormatWindowLabel(target.Window)}: {ex.Message}");
+            }
+        }
+
+        return screenshots;
+    }
+
+    private static string DetermineControlClickSafetyMode(IReadOnlyList<WindowControlTargetInfo> controls) {
+        return HasZeroHandleUiAutomationControl(controls) ? "uia-direct-invoke" : "background-control-click";
+    }
+
+    private static string DetermineControlTextSafetyMode(IReadOnlyList<WindowControlTargetInfo> controls, bool allowForegroundInputFallback) {
+        if (controls.Any(control => control.Control.Source == WindowControlSource.UiAutomation && control.Control.Handle == IntPtr.Zero && !control.Control.SupportsBackgroundText)) {
+            return allowForegroundInputFallback ? "foreground-input-fallback" : "uia-direct-value";
+        }
+
+        return HasZeroHandleUiAutomationControl(controls) ? "uia-direct-value" : "background-control-text";
+    }
+
+    private static string DetermineControlKeySafetyMode(IReadOnlyList<WindowControlTargetInfo> controls, bool allowForegroundInputFallback) {
+        if (HasZeroHandleUiAutomationControl(controls)) {
+            return allowForegroundInputFallback ? "foreground-input-fallback" : "background-control-keys";
+        }
+
+        return "background-control-keys";
+    }
+
+    private static bool HasZeroHandleUiAutomationControl(IReadOnlyList<WindowControlTargetInfo> controls) {
+        return controls.Any(control => control.Control.Source == WindowControlSource.UiAutomation && control.Control.Handle == IntPtr.Zero);
+    }
+
+    private static string BuildArtifactPrefix(string action, string phase, IntPtr handle, string stamp, int index) {
+        return $"{action}-{phase}-{stamp}-{handle.ToInt64():X}-{index + 1}";
+    }
+
+    private static string? ResolveArtifactOutputPath(string? artifactDirectory, string prefix) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return Path.Combine(artifactDirectory, prefix + ".png");
+    }
+
+    private static string FormatWindowLabel(WindowInfo window) {
+        string title = string.IsNullOrWhiteSpace(window.Title) ? "<untitled>" : window.Title;
+        return $"{title} ({window.Handle.ToInt64():X})";
+    }
+
+    private static bool IsArtifactWarning(Exception exception) {
+        return exception is ArgumentException ||
+            exception is ArgumentOutOfRangeException ||
+            exception is DirectoryNotFoundException ||
+            exception is FileNotFoundException ||
+            exception is InvalidOperationException;
+    }
+}

--- a/Sources/DesktopManager.Cli/DesktopOperations.ProcessWorkflows.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.ProcessWorkflows.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace DesktopManager.Cli;
+
+internal static partial class DesktopOperations {
+    public static LaunchAndWaitResult LaunchAndWaitForWindow(string filePath, string? arguments, string? workingDirectory, int? waitForInputIdleMilliseconds, int? launchWaitForWindowMilliseconds, int? launchWaitForWindowIntervalMilliseconds, string? launchWindowTitlePattern, string? launchWindowClassNamePattern, string? windowTitlePattern, string? windowClassNamePattern, bool includeHidden, bool includeEmpty, bool all, int timeoutMilliseconds, int intervalMilliseconds, MutationArtifactOptions? artifactOptions = null) {
+        if (string.IsNullOrWhiteSpace(filePath)) {
+            throw new CommandLineException("Process path is required.");
+        }
+
+        if (timeoutMilliseconds <= 0) {
+            throw new CommandLineException("Wait timeout must be greater than 0.");
+        }
+
+        if (intervalMilliseconds <= 0) {
+            throw new CommandLineException("Wait interval must be greater than 0.");
+        }
+
+        return ExecuteCore(() => {
+            var warnings = new List<string>();
+            var notes = new List<string>();
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            MutationArtifactOptions options = artifactOptions ?? new MutationArtifactOptions();
+
+            IReadOnlyList<ScreenshotResult> beforeScreenshots = options.CaptureBefore
+                ? CaptureDesktopArtifacts("launch-and-wait-for-window", "before", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            ProcessLaunchResult launch = LaunchProcess(
+                filePath,
+                arguments,
+                workingDirectory,
+                waitForInputIdleMilliseconds,
+                launchWaitForWindowMilliseconds,
+                launchWaitForWindowIntervalMilliseconds,
+                launchWindowTitlePattern,
+                launchWindowClassNamePattern,
+                requireWindow: false);
+
+            int processId = launch.ResolvedProcessId ?? launch.ProcessId;
+            notes.Add($"Launched process {processId} from '{launch.FilePath}'.");
+
+            var waitCriteria = new WindowSelectionCriteria {
+                TitlePattern = windowTitlePattern ?? launchWindowTitlePattern ?? "*",
+                ClassNamePattern = windowClassNamePattern ?? launchWindowClassNamePattern ?? "*",
+                ProcessId = processId,
+                IncludeHidden = includeHidden,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = includeEmpty,
+                All = all
+            };
+            notes.Add($"Wait selector: processId={processId}, title='{waitCriteria.TitlePattern}', class='{waitCriteria.ClassNamePattern}'.");
+
+            WaitForWindowResult waitResult = WaitForWindow(waitCriteria, timeoutMilliseconds, intervalMilliseconds);
+            notes.Add($"Resolved {waitResult.Count} window(s) for process {processId}.");
+
+            IReadOnlyList<ScreenshotResult> afterScreenshots;
+            if (options.CaptureAfter) {
+                var automation = new DesktopAutomationService();
+                afterScreenshots = CaptureWindowArtifacts(
+                    automation,
+                    automation.GetWindows(CreateWindowQuery(waitCriteria)),
+                    "launch-and-wait-for-window",
+                    "after",
+                    options,
+                    warnings);
+            } else {
+                afterScreenshots = Array.Empty<ScreenshotResult>();
+            }
+
+            stopwatch.Stop();
+            return new LaunchAndWaitResult {
+                Action = "launch-and-wait-for-window",
+                Success = waitResult.Count > 0,
+                ElapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds,
+                WaitTimeoutMilliseconds = timeoutMilliseconds,
+                WaitIntervalMilliseconds = intervalMilliseconds,
+                Launch = launch,
+                WindowWait = waitResult,
+                Notes = notes,
+                BeforeScreenshots = beforeScreenshots,
+                AfterScreenshots = afterScreenshots,
+                ArtifactWarnings = warnings
+            };
+        });
+    }
+}

--- a/Sources/DesktopManager.Cli/DesktopOperations.Workflows.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.Workflows.cs
@@ -1,0 +1,465 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DesktopManager.Cli;
+
+internal static partial class DesktopOperations {
+    private const int WorkflowResolutionTimeoutMilliseconds = 2000;
+    private const int WorkflowResolutionIntervalMilliseconds = 100;
+
+    private static readonly string[] CodingProcessPatterns = {
+        "code",
+        "devenv",
+        "rider*",
+        "webstorm*",
+        "pycharm*",
+        "idea*",
+        "powershell",
+        "pwsh",
+        "wt",
+        "windowsterminal",
+        "cmd"
+    };
+
+    private static readonly string[] SharingProcessPatterns = {
+        "code",
+        "devenv",
+        "rider*",
+        "webstorm*",
+        "pycharm*",
+        "idea*",
+        "chrome",
+        "msedge",
+        "firefox",
+        "brave",
+        "powerpnt"
+    };
+
+    private static readonly string[] DistractingProcessPatterns = {
+        "teams*",
+        "ms-teams*",
+        "slack",
+        "discord",
+        "olk",
+        "outlook",
+        "thunderbird",
+        "whatsapp",
+        "telegram",
+        "signal",
+        "skype"
+    };
+
+    private static readonly string[] DistractingTitlePatterns = {
+        "*Inbox*",
+        "*Mail*",
+        "*Messenger*",
+        "*Chat*"
+    };
+
+    public static ControlValueAssertionResult AssertControlValue(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, string expected, bool contains, bool allWindows) {
+        return ExecuteControlValueAssertion(windowCriteria, allWindows, null, controlCriteria.All, expected, contains, automation => automation.GetControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), allWindows, controlCriteria.All));
+    }
+
+    public static ControlValueAssertionResult AssertControlTargetValue(WindowSelectionCriteria windowCriteria, string targetName, string expected, bool contains, bool allWindows, bool allControls) {
+        return ExecuteControlValueAssertion(windowCriteria, allWindows, targetName, allControls, expected, contains, automation => automation.GetControlTargets(CreateWindowQuery(windowCriteria), targetName, allWindows, allControls));
+    }
+
+    public static WorkflowResult PrepareForCoding(string? layoutName, WindowSelectionCriteria focusCriteria, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWorkflow("prepare-for-coding", layoutName, artifactOptions, notes => {
+            bool layoutApplied = TryApplyNamedLayout(layoutName, notes);
+            WindowResult? resolvedWindow;
+            WindowResult? focusedWindow;
+            if (HasExplicitSelector(focusCriteria)) {
+                WorkflowFocusResult? focusAttempt = TryFocusWorkflowWindow(focusCriteria, notes, "Focused requested coding window.");
+                resolvedWindow = focusAttempt?.ResolvedWindow;
+                focusedWindow = focusAttempt?.FocusedWindow;
+            } else {
+                focusedWindow = TryFocusPreferredProcesses(CodingProcessPatterns, notes, "Focused coding window.");
+                resolvedWindow = focusedWindow;
+            }
+
+            if (!layoutApplied && !string.IsNullOrWhiteSpace(layoutName)) {
+                notes.Add($"Named layout '{layoutName}' was not found.");
+            }
+
+            if (focusedWindow == null) {
+                notes.Add("No editor or terminal window could be focused for coding.");
+            }
+
+            return new WorkflowOutcome {
+                Success = true,
+                LayoutApplied = layoutApplied,
+                ResolvedWindow = resolvedWindow,
+                FocusedWindow = focusedWindow
+            };
+        });
+    }
+
+    public static WorkflowResult PrepareForScreenSharing(string? layoutName, WindowSelectionCriteria focusCriteria, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWorkflow("prepare-for-screen-sharing", layoutName, artifactOptions, notes => {
+            bool layoutApplied = TryApplyNamedLayout(layoutName, notes);
+            IReadOnlyList<WindowResult> minimizedWindows = MinimizeDistractingWindows(focusCriteria, notes);
+            WindowResult? resolvedWindow;
+            WindowResult? focusedWindow;
+            if (HasExplicitSelector(focusCriteria)) {
+                WorkflowFocusResult? focusAttempt = TryFocusWorkflowWindow(focusCriteria, notes, "Focused requested sharing window.");
+                resolvedWindow = focusAttempt?.ResolvedWindow;
+                focusedWindow = focusAttempt?.FocusedWindow;
+            } else {
+                focusedWindow = TryFocusPreferredProcesses(SharingProcessPatterns, notes, "Focused sharing window.");
+                resolvedWindow = focusedWindow;
+            }
+
+            if (focusedWindow == null) {
+                focusedWindow = TryFocusFirstVisibleNonDistractingWindow(notes);
+                if (resolvedWindow == null) {
+                    resolvedWindow = focusedWindow;
+                }
+            }
+
+            if (!layoutApplied && !string.IsNullOrWhiteSpace(layoutName)) {
+                notes.Add($"Named layout '{layoutName}' was not found.");
+            }
+
+            if (focusedWindow == null) {
+                notes.Add("No sharing window could be focused automatically.");
+            }
+
+            return new WorkflowOutcome {
+                Success = true,
+                LayoutApplied = layoutApplied,
+                ResolvedWindow = resolvedWindow,
+                FocusedWindow = focusedWindow,
+                MinimizedWindows = minimizedWindows
+            };
+        });
+    }
+
+    public static WorkflowResult CleanUpDistractions(MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWorkflow("clean-up-distractions", null, artifactOptions, notes => {
+            IReadOnlyList<WindowResult> minimizedWindows = MinimizeDistractingWindows(new WindowSelectionCriteria(), notes);
+            if (minimizedWindows.Count == 0) {
+                notes.Add("No distracting windows were identified.");
+            }
+
+            return new WorkflowOutcome {
+                Success = true,
+                MinimizedWindows = minimizedWindows
+            };
+        });
+    }
+
+    private static ControlValueAssertionResult ExecuteControlValueAssertion(WindowSelectionCriteria windowCriteria, bool allWindows, string? targetName, bool allControls, string expected, bool contains, Func<DesktopAutomationService, IReadOnlyList<WindowControlTargetInfo>> resolveControls) {
+        if (string.IsNullOrWhiteSpace(expected)) {
+            throw new CommandLineException("An expected value is required.");
+        }
+
+        return ExecuteCore(() => {
+            var automation = new DesktopAutomationService();
+            IReadOnlyList<WindowControlTargetInfo> controls = resolveControls(automation);
+            StringComparison comparison = StringComparison.OrdinalIgnoreCase;
+            int matchedCount = controls.Count(control => MatchesControlValue(control.Control, expected, contains, comparison));
+            return new ControlValueAssertionResult {
+                Assertion = "control-value",
+                Expected = expected,
+                MatchMode = contains ? "contains-ignore-case" : "equals-ignore-case",
+                PropertyName = "value-or-text",
+                Count = controls.Count,
+                MatchedCount = matchedCount,
+                Matched = controls.Count > 0 && matchedCount == controls.Count,
+                TargetName = targetName,
+                Controls = controls.Select(MapControl).ToArray()
+            };
+        });
+    }
+
+    private static bool MatchesControlValue(WindowControlInfo control, string expected, bool contains, StringComparison comparison) {
+        string value = string.IsNullOrWhiteSpace(control.Value) ? control.Text : control.Value;
+        if (contains) {
+            return value.IndexOf(expected, comparison) >= 0;
+        }
+
+        return string.Equals(value, expected, comparison);
+    }
+
+    private static WorkflowResult ExecuteWorkflow(string action, string? layoutName, MutationArtifactOptions? artifactOptions, Func<List<string>, WorkflowOutcome> body) {
+        return ExecuteCore(() => {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            MutationArtifactOptions options = artifactOptions ?? new MutationArtifactOptions();
+            var warnings = new List<string>();
+            var notes = new List<string>();
+
+            IReadOnlyList<ScreenshotResult> beforeScreenshots = options.CaptureBefore
+                ? CaptureDesktopArtifacts(action, "before", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            WorkflowOutcome outcome = body(notes);
+
+            IReadOnlyList<ScreenshotResult> afterScreenshots = options.CaptureAfter
+                ? CaptureDesktopArtifacts(action, "after", options, warnings)
+                : Array.Empty<ScreenshotResult>();
+
+            stopwatch.Stop();
+            return new WorkflowResult {
+                Action = action,
+                Success = outcome.Success,
+                ElapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds,
+                LayoutName = layoutName,
+                LayoutApplied = outcome.LayoutApplied,
+                MinimizedCount = outcome.MinimizedWindows.Count,
+                MinimizedWindows = outcome.MinimizedWindows,
+                ResolvedWindow = outcome.ResolvedWindow,
+                FocusedWindow = outcome.FocusedWindow,
+                Notes = notes,
+                BeforeScreenshots = beforeScreenshots,
+                AfterScreenshots = afterScreenshots,
+                ArtifactWarnings = warnings
+            };
+        });
+    }
+
+    private static IReadOnlyList<ScreenshotResult> CaptureDesktopArtifacts(string action, string phase, MutationArtifactOptions options, List<string> warnings) {
+        try {
+            using DesktopCapture capture = new DesktopAutomationService().CaptureDesktop();
+            string stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmssfff");
+            string prefix = $"{action}-{phase}-{stamp}";
+            return new[] { SaveScreenshot(capture, prefix, ResolveArtifactOutputPath(options.ArtifactDirectory, prefix)) };
+        } catch (Exception ex) when (IsArtifactWarning(ex)) {
+            warnings.Add($"Failed to capture {phase} workflow screenshot: {ex.Message}");
+            return Array.Empty<ScreenshotResult>();
+        }
+    }
+
+    private static bool TryApplyNamedLayout(string? layoutName, List<string> notes) {
+        if (string.IsNullOrWhiteSpace(layoutName)) {
+            return false;
+        }
+
+        if (!DesktopStateStore.ListNames("layouts").Contains(layoutName, StringComparer.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        ApplyLayout(layoutName, validate: false);
+        notes.Add($"Applied named layout '{layoutName}'.");
+        return true;
+    }
+
+    private static IReadOnlyList<WindowResult> MinimizeDistractingWindows(WindowSelectionCriteria focusCriteria, List<string> notes) {
+        var windows = new List<WindowInfo>();
+        DesktopAutomationService automation = new DesktopAutomationService();
+        foreach (string processPattern in DistractingProcessPatterns) {
+            windows.AddRange(ResolveWindowsForMutation(automation, new WindowSelectionCriteria {
+                ProcessNamePattern = processPattern,
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = true,
+                All = true
+            }));
+        }
+
+        foreach (string titlePattern in DistractingTitlePatterns) {
+            windows.AddRange(ResolveWindowsForMutation(automation, new WindowSelectionCriteria {
+                TitlePattern = titlePattern,
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = true,
+                All = true
+            }));
+        }
+
+        IntPtr protectedHandle = ResolveProtectedFocusHandle(focusCriteria);
+        WindowInfo[] distinctWindows = windows
+            .Where(window => window.Handle != IntPtr.Zero && window.Handle != protectedHandle)
+            .GroupBy(window => window.Handle)
+            .Select(group => group.First())
+            .ToArray();
+
+        var minimizedWindows = new List<WindowResult>(distinctWindows.Length);
+        foreach (WindowInfo window in distinctWindows) {
+            try {
+                IReadOnlyList<WindowInfo> minimized = automation.MinimizeWindows(new WindowQueryOptions {
+                    Handle = window.Handle,
+                    IncludeHidden = true,
+                    IncludeCloaked = true,
+                    IncludeOwned = true,
+                    IncludeEmptyTitles = true
+                });
+                minimizedWindows.AddRange(minimized.Select(MapWindow));
+            } catch (InvalidOperationException) {
+                // Ignore windows that disappeared between discovery and minimize.
+            }
+        }
+
+        if (minimizedWindows.Count > 0) {
+            notes.Add($"Minimized {minimizedWindows.Count} distracting window(s).");
+        }
+
+        return minimizedWindows;
+    }
+
+    private static IntPtr ResolveProtectedFocusHandle(WindowSelectionCriteria focusCriteria) {
+        if (!HasExplicitSelector(focusCriteria)) {
+            return IntPtr.Zero;
+        }
+
+        try {
+            DesktopAutomationService automation = new DesktopAutomationService();
+            IReadOnlyList<WindowInfo> windows = ResolveWindowsForMutation(automation, focusCriteria);
+            return windows.FirstOrDefault()?.Handle ?? IntPtr.Zero;
+        } catch {
+            return IntPtr.Zero;
+        }
+    }
+
+    private static WorkflowFocusResult? TryFocusWorkflowWindow(WindowSelectionCriteria criteria, List<string> notes, string successNote) {
+        WindowResult? resolvedWindow = null;
+        try {
+            DesktopAutomationService automation = new DesktopAutomationService();
+            WindowQueryOptions query = CreateWindowQuery(criteria);
+            IReadOnlyList<WindowInfo> windows = WaitForWorkflowWindows(automation, query);
+            if (windows.Count == 0) {
+                return null;
+            }
+
+            resolvedWindow = MapWindow(windows[0]);
+            IReadOnlyList<WindowInfo> focused = automation.FocusWindows(query, all: false);
+            if (focused.Count == 0) {
+                notes.Add("Resolved the requested workflow window, but Windows did not allow it to take foreground focus.");
+                return new WorkflowFocusResult {
+                    ResolvedWindow = resolvedWindow
+                };
+            }
+
+            WindowResult result = MapWindow(focused[0]);
+            notes.Add(successNote);
+            return new WorkflowFocusResult {
+                ResolvedWindow = resolvedWindow,
+                FocusedWindow = result
+            };
+        } catch (InvalidOperationException) {
+            if (resolvedWindow != null) {
+                notes.Add("Resolved the requested workflow window, but Windows rejected the foreground focus attempt.");
+                return new WorkflowFocusResult {
+                    ResolvedWindow = resolvedWindow
+                };
+            }
+
+            return null;
+        }
+    }
+
+    private static IReadOnlyList<WindowInfo> WaitForWorkflowWindows(DesktopAutomationService automation, WindowQueryOptions query) {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        IReadOnlyList<WindowInfo> windows = Array.Empty<WindowInfo>();
+        do {
+            windows = automation.GetWindows(query);
+            if (windows.Count > 0) {
+                return windows;
+            }
+
+            System.Threading.Thread.Sleep(WorkflowResolutionIntervalMilliseconds);
+        } while (stopwatch.ElapsedMilliseconds < WorkflowResolutionTimeoutMilliseconds);
+
+        return windows;
+    }
+
+    private static WindowResult? TryFocusFirstVisibleNonDistractingWindow(List<string> notes) {
+        try {
+            DesktopAutomationService automation = new DesktopAutomationService();
+            IReadOnlyList<WindowInfo> windows = automation.GetWindows(new WindowQueryOptions {
+                TitlePattern = "*",
+                ProcessNamePattern = "*",
+                ClassNamePattern = "*",
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = false
+            });
+
+            WindowInfo? candidate = windows.FirstOrDefault(window => !IsDistractingWindow(window));
+            if (candidate == null) {
+                return null;
+            }
+
+            IReadOnlyList<WindowInfo> focused = automation.FocusWindows(new WindowQueryOptions {
+                Handle = candidate.Handle,
+                IncludeHidden = true,
+                IncludeCloaked = true,
+                IncludeOwned = true,
+                IncludeEmptyTitles = true
+            }, all: false);
+            if (focused.Count == 0) {
+                return null;
+            }
+
+            notes.Add("Focused the first non-distracting visible window.");
+            return MapWindow(focused[0]);
+        } catch (InvalidOperationException) {
+            return null;
+        }
+    }
+
+    private static bool IsDistractingWindow(WindowInfo window) {
+        string title = window.Title ?? string.Empty;
+        return DistractingTitlePatterns.Any(pattern => MatchesPattern(title, pattern)) ||
+            TryGetProcessName(window.ProcessId, out string? processName) && DistractingProcessPatterns.Any(pattern => MatchesPattern(processName!, pattern));
+    }
+
+    private static bool TryGetProcessName(uint processId, out string? processName) {
+        processName = null;
+        try {
+            using Process process = Process.GetProcessById((int)processId);
+            processName = process.ProcessName;
+            return !string.IsNullOrWhiteSpace(processName);
+        } catch {
+            return false;
+        }
+    }
+
+    private static WindowResult? TryFocusPreferredProcesses(IEnumerable<string> processPatterns, List<string> notes, string successNote) {
+        foreach (string processPattern in processPatterns) {
+            WorkflowFocusResult? focusAttempt = TryFocusWorkflowWindow(new WindowSelectionCriteria {
+                ProcessNamePattern = processPattern,
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeOwned = true,
+                IncludeEmptyTitles = false
+            }, notes, successNote);
+            if (focusAttempt?.FocusedWindow != null) {
+                return focusAttempt.FocusedWindow;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool MatchesPattern(string text, string pattern) {
+        if (string.IsNullOrWhiteSpace(pattern) || pattern == "*") {
+            return true;
+        }
+
+        string regexPattern = "^" + Regex.Escape(pattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".") + "$";
+        return Regex.IsMatch(text ?? string.Empty, regexPattern, RegexOptions.IgnoreCase);
+    }
+
+    private sealed class WorkflowOutcome {
+        public bool Success { get; set; }
+        public bool LayoutApplied { get; set; }
+        public IReadOnlyList<WindowResult> MinimizedWindows { get; set; } = Array.Empty<WindowResult>();
+        public WindowResult? ResolvedWindow { get; set; }
+        public WindowResult? FocusedWindow { get; set; }
+    }
+
+    private sealed class WorkflowFocusResult {
+        public WindowResult? ResolvedWindow { get; set; }
+        public WindowResult? FocusedWindow { get; set; }
+    }
+}

--- a/Sources/DesktopManager.Cli/DesktopOperations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -8,7 +9,7 @@ using System.Threading;
 
 namespace DesktopManager.Cli;
 
-internal static class DesktopOperations {
+internal static partial class DesktopOperations {
     public static IReadOnlyList<WindowResult> ListWindows(WindowSelectionCriteria criteria) {
         return ExecuteCore(() => new DesktopAutomationService().GetWindows(CreateWindowQuery(criteria)).Select(MapWindow).ToArray());
     }
@@ -31,82 +32,131 @@ internal static class DesktopOperations {
             .ToArray());
     }
 
-    public static WindowChangeResult MoveWindow(WindowSelectionCriteria criteria, int? monitorIndex, int? x, int? y, int? width, int? height, bool activate) {
-        return ExecuteCore(() => BuildWindowChangeResult(
+    public static WindowChangeResult MoveWindow(WindowSelectionCriteria criteria, int? monitorIndex, int? x, int? y, int? width, int? height, bool activate, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWindowMutation(
             "move",
-            new DesktopAutomationService().MoveWindows(CreateWindowQuery(criteria), monitorIndex, x, y, width, height, activate, criteria.All)));
+            criteria,
+            activate ? "window-management-activate" : "window-management",
+            artifactOptions,
+            automation => automation.MoveWindows(CreateWindowQuery(criteria), monitorIndex, x, y, width, height, activate, criteria.All));
     }
 
-    public static WindowChangeResult FocusWindow(WindowSelectionCriteria criteria) {
-        return ExecuteCore(() => BuildWindowChangeResult(
+    public static WindowChangeResult FocusWindow(WindowSelectionCriteria criteria, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWindowMutation(
             "focus",
-            new DesktopAutomationService().FocusWindows(CreateWindowQuery(criteria), criteria.All)));
+            criteria,
+            "window-management-activate",
+            artifactOptions,
+            automation => automation.FocusWindows(CreateWindowQuery(criteria), criteria.All));
     }
 
-    public static WindowChangeResult ClickWindowPoint(WindowSelectionCriteria criteria, int? x, int? y, double? xRatio, double? yRatio, string button, bool activate, bool clientArea) {
+    public static WindowChangeResult ClickWindowPoint(WindowSelectionCriteria criteria, int? x, int? y, double? xRatio, double? yRatio, string button, bool activate, bool clientArea, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             "click-point",
-            new DesktopAutomationService().ClickWindowPoint(CreateWindowQuery(criteria), x, y, xRatio, yRatio, mouseButton, activate, clientArea, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.ClickWindowPoint(CreateWindowQuery(criteria), x, y, xRatio, yRatio, mouseButton, activate, clientArea, criteria.All));
     }
 
-    public static WindowChangeResult ClickWindowTarget(WindowSelectionCriteria criteria, string targetName, string button, bool activate) {
+    public static WindowChangeResult ClickWindowTarget(WindowSelectionCriteria criteria, string targetName, string button, bool activate, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             "click-target",
-            new DesktopAutomationService().ClickWindowTarget(CreateWindowQuery(criteria), targetName, mouseButton, activate, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.ClickWindowTarget(CreateWindowQuery(criteria), targetName, mouseButton, activate, criteria.All),
+            targetName,
+            "window-target");
     }
 
-    public static WindowChangeResult DragWindowPoints(WindowSelectionCriteria criteria, int? startX, int? startY, double? startXRatio, double? startYRatio, int? endX, int? endY, double? endXRatio, double? endYRatio, string button, int stepDelayMilliseconds, bool activate, bool clientArea) {
+    public static WindowChangeResult DragWindowPoints(WindowSelectionCriteria criteria, int? startX, int? startY, double? startXRatio, double? startYRatio, int? endX, int? endY, double? endXRatio, double? endYRatio, string button, int stepDelayMilliseconds, bool activate, bool clientArea, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             "drag-point",
-            new DesktopAutomationService().DragWindowPoints(CreateWindowQuery(criteria), startX, startY, startXRatio, startYRatio, endX, endY, endXRatio, endYRatio, mouseButton, stepDelayMilliseconds, activate, clientArea, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.DragWindowPoints(CreateWindowQuery(criteria), startX, startY, startXRatio, startYRatio, endX, endY, endXRatio, endYRatio, mouseButton, stepDelayMilliseconds, activate, clientArea, criteria.All));
     }
 
-    public static WindowChangeResult DragWindowTargets(WindowSelectionCriteria criteria, string startTargetName, string endTargetName, string button, int stepDelayMilliseconds, bool activate) {
+    public static WindowChangeResult DragWindowTargets(WindowSelectionCriteria criteria, string startTargetName, string endTargetName, string button, int stepDelayMilliseconds, bool activate, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             "drag-target",
-            new DesktopAutomationService().DragWindowTargets(CreateWindowQuery(criteria), startTargetName, endTargetName, mouseButton, stepDelayMilliseconds, activate, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.DragWindowTargets(CreateWindowQuery(criteria), startTargetName, endTargetName, mouseButton, stepDelayMilliseconds, activate, criteria.All),
+            $"{startTargetName}->{endTargetName}",
+            "window-target-pair");
     }
 
-    public static WindowChangeResult ScrollWindowPoint(WindowSelectionCriteria criteria, int? x, int? y, double? xRatio, double? yRatio, int delta, bool activate, bool clientArea) {
-        return ExecuteCore(() => BuildWindowChangeResult(
+    public static WindowChangeResult ScrollWindowPoint(WindowSelectionCriteria criteria, int? x, int? y, double? xRatio, double? yRatio, int delta, bool activate, bool clientArea, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWindowMutation(
             "scroll-point",
-            new DesktopAutomationService().ScrollWindowPoint(CreateWindowQuery(criteria), x, y, xRatio, yRatio, delta, activate, clientArea, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.ScrollWindowPoint(CreateWindowQuery(criteria), x, y, xRatio, yRatio, delta, activate, clientArea, criteria.All));
     }
 
-    public static WindowChangeResult ScrollWindowTarget(WindowSelectionCriteria criteria, string targetName, int delta, bool activate) {
-        return ExecuteCore(() => BuildWindowChangeResult(
+    public static WindowChangeResult ScrollWindowTarget(WindowSelectionCriteria criteria, string targetName, int delta, bool activate, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWindowMutation(
             "scroll-target",
-            new DesktopAutomationService().ScrollWindowTarget(CreateWindowQuery(criteria), targetName, delta, activate, criteria.All)));
+            criteria,
+            "foreground-mouse-input",
+            artifactOptions,
+            automation => automation.ScrollWindowTarget(CreateWindowQuery(criteria), targetName, delta, activate, criteria.All),
+            targetName,
+            "window-target");
     }
 
-    public static WindowChangeResult MinimizeWindows(WindowSelectionCriteria criteria) {
-        return ExecuteCore(() => BuildWindowChangeResult(
+    public static WindowChangeResult MinimizeWindows(WindowSelectionCriteria criteria, MutationArtifactOptions? artifactOptions = null) {
+        return ExecuteWindowMutation(
             "minimize",
-            new DesktopAutomationService().MinimizeWindows(CreateWindowQuery(criteria), criteria.All)));
+            criteria,
+            "window-management",
+            artifactOptions,
+            automation => automation.MinimizeWindows(CreateWindowQuery(criteria), criteria.All));
     }
 
-    public static WindowChangeResult SnapWindow(WindowSelectionCriteria criteria, string position) {
+    public static WindowChangeResult SnapWindow(WindowSelectionCriteria criteria, string position, MutationArtifactOptions? artifactOptions = null) {
         if (!TryParseSnapPosition(position, out SnapPosition snapPosition)) {
             throw new CommandLineException($"Unsupported snap position '{position}'.");
         }
 
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             "snap",
-            new DesktopAutomationService().SnapWindows(CreateWindowQuery(criteria), snapPosition, criteria.All)));
+            criteria,
+            "window-management",
+            artifactOptions,
+            automation => automation.SnapWindows(CreateWindowQuery(criteria), snapPosition, criteria.All));
     }
 
-    public static WindowChangeResult TypeWindowText(WindowSelectionCriteria criteria, string text, bool paste, int delayMilliseconds) {
+    public static WindowChangeResult TypeWindowText(WindowSelectionCriteria criteria, string text, bool paste, int delayMilliseconds, MutationArtifactOptions? artifactOptions = null) {
         if (text == null) {
             throw new CommandLineException("Text is required.");
         }
 
-        return ExecuteCore(() => BuildWindowChangeResult(
+        return ExecuteWindowMutation(
             paste ? "paste-text" : "type-text",
-            new DesktopAutomationService().TypeWindowText(CreateWindowQuery(criteria), text, paste, delayMilliseconds, criteria.All)));
+            criteria,
+            paste ? "window-text-paste" : "window-text-input",
+            artifactOptions,
+            automation => automation.TypeWindowText(CreateWindowQuery(criteria), text, paste, delayMilliseconds, criteria.All));
+    }
+
+    public static WindowChangeResult SendWindowKeys(WindowSelectionCriteria criteria, IReadOnlyList<string> keys, bool activate, MutationArtifactOptions? artifactOptions = null) {
+        VirtualKey[] virtualKeys = ParseVirtualKeys(keys);
+        return ExecuteWindowMutation(
+            "send-window-keys",
+            criteria,
+            "window-key-input",
+            artifactOptions,
+            automation => automation.SendWindowKeys(CreateWindowQuery(criteria), virtualKeys, activate, criteria.All));
     }
 
     public static IReadOnlyList<MonitorResult> ListMonitors(bool? connectedOnly = null, bool? primaryOnly = null, int? index = null) {
@@ -186,52 +236,94 @@ internal static class DesktopOperations {
             .ToArray());
     }
 
-    public static ControlActionResult ClickControl(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, string button, bool allWindows) {
+    public static ControlActionResult ClickControl(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, string button, bool allWindows, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "click-control",
-            new DesktopAutomationService().ClickControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), mouseButton, allWindows, controlCriteria.All)));
+            windowCriteria,
+            allWindows,
+            controlCriteria.All,
+            artifactOptions,
+            automation => automation.GetControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), allWindows, controlCriteria.All),
+            resolvedControls => DetermineControlClickSafetyMode(resolvedControls),
+            automation => automation.ClickControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), mouseButton, allWindows, controlCriteria.All));
     }
 
-    public static ControlActionResult ClickControlTarget(WindowSelectionCriteria windowCriteria, string targetName, string button, bool allWindows, bool allControls) {
+    public static ControlActionResult ClickControlTarget(WindowSelectionCriteria windowCriteria, string targetName, string button, bool allWindows, bool allControls, MutationArtifactOptions? artifactOptions = null) {
         MouseButton mouseButton = ParseMouseButton(button);
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "click-control",
-            new DesktopAutomationService().ClickControlTarget(CreateWindowQuery(windowCriteria), targetName, mouseButton, allWindows, allControls)));
+            windowCriteria,
+            allWindows,
+            allControls,
+            artifactOptions,
+            automation => automation.GetControlTargets(CreateWindowQuery(windowCriteria), targetName, allWindows, allControls),
+            resolvedControls => DetermineControlClickSafetyMode(resolvedControls),
+            automation => automation.ClickControlTarget(CreateWindowQuery(windowCriteria), targetName, mouseButton, allWindows, allControls),
+            targetName,
+            "control-target");
     }
 
-    public static ControlActionResult SetControlText(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, string text, bool allWindows) {
+    public static ControlActionResult SetControlText(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, string text, bool allWindows, MutationArtifactOptions? artifactOptions = null) {
         if (text == null) {
             throw new CommandLineException("Text is required.");
         }
 
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "set-control-text",
-            new DesktopAutomationService().SetControlText(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), text, allWindows, controlCriteria.All)));
+            windowCriteria,
+            allWindows,
+            controlCriteria.All,
+            artifactOptions,
+            automation => automation.GetControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), allWindows, controlCriteria.All),
+            resolvedControls => DetermineControlTextSafetyMode(resolvedControls, controlCriteria.AllowForegroundInputFallback),
+            automation => automation.SetControlText(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), text, allWindows, controlCriteria.All));
     }
 
-    public static ControlActionResult SetControlTargetText(WindowSelectionCriteria windowCriteria, string targetName, string text, bool ensureForegroundWindow, bool allowForegroundInputFallback, bool allWindows, bool allControls) {
+    public static ControlActionResult SetControlTargetText(WindowSelectionCriteria windowCriteria, string targetName, string text, bool ensureForegroundWindow, bool allowForegroundInputFallback, bool allWindows, bool allControls, MutationArtifactOptions? artifactOptions = null) {
         if (text == null) {
             throw new CommandLineException("Text is required.");
         }
 
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "set-control-text",
-            new DesktopAutomationService().SetControlTargetText(CreateWindowQuery(windowCriteria), targetName, text, ensureForegroundWindow, allowForegroundInputFallback, allWindows, allControls)));
+            windowCriteria,
+            allWindows,
+            allControls,
+            artifactOptions,
+            automation => automation.GetControlTargets(CreateWindowQuery(windowCriteria), targetName, allWindows, allControls),
+            resolvedControls => DetermineControlTextSafetyMode(resolvedControls, allowForegroundInputFallback),
+            automation => automation.SetControlTargetText(CreateWindowQuery(windowCriteria), targetName, text, ensureForegroundWindow, allowForegroundInputFallback, allWindows, allControls),
+            targetName,
+            "control-target");
     }
 
-    public static ControlActionResult SendControlKeys(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, IReadOnlyList<string> keys, bool allWindows) {
+    public static ControlActionResult SendControlKeys(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, IReadOnlyList<string> keys, bool allWindows, MutationArtifactOptions? artifactOptions = null) {
         VirtualKey[] virtualKeys = ParseVirtualKeys(keys);
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "send-control-keys",
-            new DesktopAutomationService().SendControlKeys(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), virtualKeys, allWindows, controlCriteria.All)));
+            windowCriteria,
+            allWindows,
+            controlCriteria.All,
+            artifactOptions,
+            automation => automation.GetControls(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), allWindows, controlCriteria.All),
+            resolvedControls => DetermineControlKeySafetyMode(resolvedControls, controlCriteria.AllowForegroundInputFallback),
+            automation => automation.SendControlKeys(CreateWindowQuery(windowCriteria), CreateControlQuery(controlCriteria), virtualKeys, allWindows, controlCriteria.All));
     }
 
-    public static ControlActionResult SendControlTargetKeys(WindowSelectionCriteria windowCriteria, string targetName, IReadOnlyList<string> keys, bool ensureForegroundWindow, bool allowForegroundInputFallback, bool allWindows, bool allControls) {
+    public static ControlActionResult SendControlTargetKeys(WindowSelectionCriteria windowCriteria, string targetName, IReadOnlyList<string> keys, bool ensureForegroundWindow, bool allowForegroundInputFallback, bool allWindows, bool allControls, MutationArtifactOptions? artifactOptions = null) {
         VirtualKey[] virtualKeys = ParseVirtualKeys(keys);
-        return ExecuteCore(() => BuildControlActionResult(
+        return ExecuteControlMutation(
             "send-control-keys",
-            new DesktopAutomationService().SendControlTargetKeys(CreateWindowQuery(windowCriteria), targetName, virtualKeys, ensureForegroundWindow, allowForegroundInputFallback, allWindows, allControls)));
+            windowCriteria,
+            allWindows,
+            allControls,
+            artifactOptions,
+            automation => automation.GetControlTargets(CreateWindowQuery(windowCriteria), targetName, allWindows, allControls),
+            resolvedControls => DetermineControlKeySafetyMode(resolvedControls, allowForegroundInputFallback),
+            automation => automation.SendControlTargetKeys(CreateWindowQuery(windowCriteria), targetName, virtualKeys, ensureForegroundWindow, allowForegroundInputFallback, allWindows, allControls),
+            targetName,
+            "control-target");
     }
 
     public static WaitForControlResult WaitForControl(WindowSelectionCriteria windowCriteria, ControlSelectionCriteria controlCriteria, int timeoutMilliseconds, int intervalMilliseconds, bool allWindows) {
@@ -322,7 +414,7 @@ internal static class DesktopOperations {
         return ExecuteCore(() => DesktopStateStore.ListNames("snapshots"));
     }
 
-    public static WindowTargetResult SaveWindowTarget(string name, string? description, int? x, int? y, double? xRatio, double? yRatio, bool clientArea) {
+    public static WindowTargetResult SaveWindowTarget(string name, string? description, int? x, int? y, double? xRatio, double? yRatio, int? width, int? height, double? widthRatio, double? heightRatio, bool clientArea) {
         return ExecuteCore(() => {
             DesktopWindowTargetDefinition definition = new DesktopWindowTargetDefinition {
                 Description = description,
@@ -330,6 +422,10 @@ internal static class DesktopOperations {
                 Y = y,
                 XRatio = xRatio,
                 YRatio = yRatio,
+                Width = width,
+                Height = height,
+                WidthRatio = widthRatio,
+                HeightRatio = heightRatio,
                 ClientArea = clientArea
             };
 
@@ -436,6 +532,14 @@ internal static class DesktopOperations {
         });
     }
 
+    public static ScreenshotResult CaptureWindowTargetScreenshot(WindowSelectionCriteria criteria, string targetName, string? outputPath) {
+        return ExecuteCore(() => {
+            using DesktopCapture capture = new DesktopAutomationService().CaptureWindowTarget(CreateWindowQuery(criteria), targetName);
+            string prefix = capture.Window == null ? $"target-{targetName}" : $"target-{targetName}-{capture.Window.ProcessId}";
+            return SaveScreenshot(capture, prefix, outputPath);
+        });
+    }
+
     public static ProcessLaunchResult LaunchProcess(string filePath, string? arguments, string? workingDirectory, int? waitForInputIdleMilliseconds, int? waitForWindowMilliseconds, int? waitForWindowIntervalMilliseconds, string? windowTitlePattern, string? windowClassNamePattern, bool requireWindow) {
         return ExecuteCore(() => {
             DesktopProcessLaunchInfo result = new DesktopAutomationService().LaunchProcess(new DesktopProcessStartOptions {
@@ -532,10 +636,18 @@ internal static class DesktopOperations {
         }
     }
 
-    private static WindowChangeResult BuildWindowChangeResult(string action, IReadOnlyList<WindowInfo> windows) {
+    private static WindowChangeResult BuildWindowChangeResult(string action, IReadOnlyList<WindowInfo> windows, int elapsedMilliseconds, string safetyMode, string? targetName, string? targetKind, IReadOnlyList<ScreenshotResult> beforeScreenshots, IReadOnlyList<ScreenshotResult> afterScreenshots, IReadOnlyList<string> artifactWarnings) {
         return new WindowChangeResult {
             Action = action,
+            Success = true,
             Count = windows.Count,
+            ElapsedMilliseconds = elapsedMilliseconds,
+            SafetyMode = safetyMode,
+            TargetName = targetName,
+            TargetKind = targetKind,
+            BeforeScreenshots = beforeScreenshots,
+            AfterScreenshots = afterScreenshots,
+            ArtifactWarnings = artifactWarnings,
             Windows = windows.Select(MapWindow).ToArray()
         };
     }
@@ -597,6 +709,10 @@ internal static class DesktopOperations {
             Y = target.Y,
             XRatio = target.XRatio,
             YRatio = target.YRatio,
+            Width = target.Width,
+            Height = target.Height,
+            WidthRatio = target.WidthRatio,
+            HeightRatio = target.HeightRatio,
             ClientArea = target.ClientArea
         };
     }
@@ -632,8 +748,12 @@ internal static class DesktopOperations {
             Geometry = MapWindowGeometry(target.Geometry),
             RelativeX = target.RelativeX,
             RelativeY = target.RelativeY,
+            RelativeWidth = target.RelativeWidth,
+            RelativeHeight = target.RelativeHeight,
             ScreenX = target.ScreenX,
-            ScreenY = target.ScreenY
+            ScreenY = target.ScreenY,
+            ScreenWidth = target.ScreenWidth,
+            ScreenHeight = target.ScreenHeight
         };
     }
 
@@ -724,10 +844,18 @@ internal static class DesktopOperations {
         };
     }
 
-    private static ControlActionResult BuildControlActionResult(string action, IReadOnlyList<WindowControlTargetInfo> controls) {
+    private static ControlActionResult BuildControlActionResult(string action, IReadOnlyList<WindowControlTargetInfo> controls, int elapsedMilliseconds, string safetyMode, string? targetName, string? targetKind, IReadOnlyList<ScreenshotResult> beforeScreenshots, IReadOnlyList<ScreenshotResult> afterScreenshots, IReadOnlyList<string> artifactWarnings) {
         return new ControlActionResult {
             Action = action,
+            Success = true,
             Count = controls.Count,
+            ElapsedMilliseconds = elapsedMilliseconds,
+            SafetyMode = safetyMode,
+            TargetName = targetName,
+            TargetKind = targetKind,
+            BeforeScreenshots = beforeScreenshots,
+            AfterScreenshots = afterScreenshots,
+            ArtifactWarnings = artifactWarnings,
             Controls = controls.Select(MapControl).ToArray()
         };
     }
@@ -856,7 +984,11 @@ internal static class DesktopOperations {
             throw new CommandLineException(ex.Message);
         } catch (DirectoryNotFoundException ex) {
             throw new CommandLineException(ex.Message);
+        } catch (InvalidDataException ex) {
+            throw new CommandLineException(ex.Message);
         } catch (FileNotFoundException ex) {
+            throw new CommandLineException(ex.Message);
+        } catch (Win32Exception ex) {
             throw new CommandLineException(ex.Message);
         } catch (InvalidOperationException ex) {
             throw new CommandLineException(ex.Message);

--- a/Sources/DesktopManager.Cli/HelpText.cs
+++ b/Sources/DesktopManager.Cli/HelpText.cs
@@ -18,6 +18,7 @@ Groups:
   control-target Save and resolve reusable control selector targets
   layout     Save, apply, and list named layouts
   snapshot   Save, restore, and list named snapshots
+  workflow   Run higher-level desktop workflows
   mcp        Host an MCP server over stdio
   help       Show help for a command group
 
@@ -26,6 +27,7 @@ Examples:
   desktopmanager window wait --process notepad --timeout-ms 5000
   desktopmanager control list --window-process notepad
   desktopmanager process start notepad.exe --wait-for-input-idle-ms 1000
+  desktopmanager process start-and-wait notepad.exe --timeout-ms 5000
   desktopmanager screenshot desktop
   desktopmanager target save editor-center --x-ratio 0.5 --y-ratio 0.5 --client-area
   desktopmanager control-target save edge-address --control-type Edit --background-text --uia
@@ -33,6 +35,7 @@ Examples:
   desktopmanager monitor list --json
   desktopmanager layout save coding
   desktopmanager layout apply coding --validate
+  desktopmanager layout assert coding --position-tolerance-px 50 --size-tolerance-px 50
   desktopmanager snapshot save workday
   desktopmanager snapshot restore workday
 
@@ -46,6 +49,7 @@ Use:
   desktopmanager help control-target
   desktopmanager help layout
   desktopmanager help snapshot
+  desktopmanager help workflow
   desktopmanager help mcp
 """;
     }
@@ -57,14 +61,15 @@ Window commands:
   desktopmanager window geometry [selector] [--all] [--json]
   desktopmanager window exists [selector] [--json]
   desktopmanager window active-matches [selector] [--json]
-  desktopmanager window move [selector] [--monitor <index>] [--x <value>] [--y <value>] [--width <value>] [--height <value>] [--activate] [--all] [--json]
-  desktopmanager window click [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) [--button <left|right>] [--activate] [--client-area] [--all] [--json]
-  desktopmanager window drag [selector] (((--start-x <value> --start-y <value>) | (--start-x-ratio <value> --start-y-ratio <value>)) ((--end-x <value> --end-y <value>) | (--end-x-ratio <value> --end-y-ratio <value>)) | (--start-target <name> --end-target <name>)) [--button <left|right>] [--step-delay-ms <value>] [--activate] [--client-area] [--all] [--json]
-  desktopmanager window scroll [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) --delta <value> [--activate] [--client-area] [--all] [--json]
-  desktopmanager window focus [selector] [--all] [--json]
-  desktopmanager window minimize [selector] [--all] [--json]
-  desktopmanager window snap [selector] --position <left|right|top-left|top-right|bottom-left|bottom-right> [--all] [--json]
-  desktopmanager window type [selector] --text <value> [--paste] [--delay-ms <value>] [--all] [--json]
+  desktopmanager window move [selector] [--monitor <index>] [--x <value>] [--y <value>] [--width <value>] [--height <value>] [--activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window click [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) [--button <left|right>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window drag [selector] (((--start-x <value> --start-y <value>) | (--start-x-ratio <value> --start-y-ratio <value>)) ((--end-x <value> --end-y <value>) | (--end-x-ratio <value> --end-y-ratio <value>)) | (--start-target <name> --end-target <name>)) [--button <left|right>] [--step-delay-ms <value>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window scroll [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) --delta <value> [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window focus [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window minimize [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window snap [selector] --position <left|right|top-left|top-right|bottom-left|bottom-right> [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window type [selector] --text <value> [--paste] [--delay-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window keys [selector] --keys <value>[,<value>...] [--no-activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
   desktopmanager window wait [selector] [--timeout-ms <value>] [--interval-ms <value>] [--all] [--json]
 
 Selectors:
@@ -75,6 +80,9 @@ Selectors:
   --handle <value>
   --active
   --include-empty
+  --capture-before
+  --capture-after
+  --artifact-directory <path>
 
 Examples:
   desktopmanager window list --title "*Notepad*" --json
@@ -94,6 +102,7 @@ Examples:
   desktopmanager window move --title "Visual Studio Code" --x 0 --y 0 --width 1920 --height 1400 --activate
   desktopmanager window snap --process notepad --position left
   desktopmanager window type --process notepad --text "Hello world"
+  desktopmanager window keys --process msedge --keys VK_RETURN
   desktopmanager window wait --process notepad --timeout-ms 5000
 """;
     }
@@ -101,7 +110,7 @@ Examples:
     public static string GetTargetHelp() {
         return """
 Target commands:
-  desktopmanager target save <name> (--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) [--client-area] [--description <text>] [--json]
+  desktopmanager target save <name> (--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) [(--width <value> --height <value>) | (--width-ratio <value> --height-ratio <value>)] [--client-area] [--description <text>] [--json]
   desktopmanager target get <name> [--json]
   desktopmanager target list [--json]
   desktopmanager target resolve <name> [selector] [--all] [--json]
@@ -117,6 +126,7 @@ Selectors:
 
 Examples:
   desktopmanager target save editor-center --x-ratio 0.5 --y-ratio 0.5 --client-area
+  desktopmanager target save edge-editor-pane --x-ratio 0.1 --y-ratio 0.15 --width-ratio 0.8 --height-ratio 0.7 --client-area
   desktopmanager target save browser-top-right --x-ratio 0.9 --y-ratio 0.1 --client-area --description "Toolbar area"
   desktopmanager target get editor-center --json
   desktopmanager target list
@@ -177,10 +187,11 @@ Control commands:
   desktopmanager control list [window-selector] ([control-selector] | --target <name>) [--all] [--all-windows] [--json]
   desktopmanager control diagnose [window-selector] ([control-selector] | --target <name>) [--sample-limit <value>] [--action-probe] [--all-windows] [--json]
   desktopmanager control exists [window-selector] ([control-selector] | --target <name>) [--all] [--all-windows] [--json]
+  desktopmanager control assert-value [window-selector] ([control-selector] | --target <name>) --expected-value <value> [--contains] [--all] [--all-windows] [--json]
   desktopmanager control wait [window-selector] ([control-selector] | --target <name>) [--timeout-ms <value>] [--interval-ms <value>] [--all] [--all-windows] [--json]
-  desktopmanager control click [window-selector] ([control-selector] | --target <name>) [--button <left|right>] [--all] [--all-windows] [--json]
-  desktopmanager control set-text [window-selector] ([control-selector] | --target <name>) --text <value> [--allow-foreground-input] [--all] [--all-windows] [--json]
-  desktopmanager control send-keys [window-selector] ([control-selector] | --target <name>) --keys <VK_A,VK_B> [--keys <VK_C>] [--allow-foreground-input] [--all] [--all-windows] [--json]
+  desktopmanager control click [window-selector] ([control-selector] | --target <name>) [--button <left|right>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--all-windows] [--json]
+  desktopmanager control set-text [window-selector] ([control-selector] | --target <name>) --text <value> [--allow-foreground-input] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--all-windows] [--json]
+  desktopmanager control send-keys [window-selector] ([control-selector] | --target <name>) --keys <VK_A,VK_B> [--keys <VK_C>] [--allow-foreground-input] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--all-windows] [--json]
 
 Window selectors:
   --window-title <pattern>
@@ -213,6 +224,11 @@ Control selectors:
   --allow-foreground-input
   --action-probe
   --target <name>
+  --expected-value <value>
+  --contains
+  --capture-before
+  --capture-after
+  --artifact-directory <path>
 
 Examples:
   desktopmanager control list --window-process notepad --json
@@ -221,6 +237,7 @@ Examples:
   desktopmanager control diagnose --window-process msedge --uia --ensure-foreground --sample-limit 5 --json
   desktopmanager control diagnose --window-title "Codex" --target codex-sidebar-toggle --sample-limit 5 --json
   desktopmanager control exists --window-active --uia --control-type Button --text-pattern "Hide sidebar" --enabled --focusable --ensure-foreground
+  desktopmanager control assert-value --window-process msedge --target edge-address --expected-value "https://evotec.xyz" --contains
   desktopmanager control list --window-process msedge --uia --background-click --json
   desktopmanager control list --window-process msedge --uia --foreground-fallback --json
   desktopmanager control list --window-title "Codex" --target codex-sidebar-toggle --json
@@ -234,6 +251,33 @@ Examples:
   desktopmanager control click --window-process notepad --class Edit
   desktopmanager control set-text --window-process notepad --class Edit --text "Hello world"
   desktopmanager control send-keys --window-process notepad --class Edit --keys VK_CONTROL,VK_A
+""";
+    }
+
+    public static string GetWorkflowHelp() {
+        return """
+Workflow commands:
+  desktopmanager workflow prepare-coding [--layout <name>] [focus-selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--json]
+  desktopmanager workflow prepare-screen-sharing [--layout <name>] [focus-selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--json]
+  desktopmanager workflow clean-up-distractions [--capture-before] [--capture-after] [--artifact-directory <path>] [--json]
+
+Focus selectors:
+  --title <pattern>
+  --process <pattern>
+  --class <pattern>
+  --pid <id>
+  --handle <value>
+  --active
+  --include-empty
+  --capture-before
+  --capture-after
+  --artifact-directory <path>
+
+Examples:
+  desktopmanager workflow prepare-coding --layout coding
+  desktopmanager workflow prepare-coding --process code --capture-after --json
+  desktopmanager workflow prepare-screen-sharing --layout meeting --process msedge --capture-before --capture-after --json
+  desktopmanager workflow clean-up-distractions --capture-after --json
 """;
     }
 
@@ -253,11 +297,13 @@ Examples:
         return """
 Process commands:
   desktopmanager process start <file> [--arguments <text>] [--working-directory <path>] [--wait-for-input-idle-ms <value>] [--wait-for-window-ms <value>] [--wait-for-window-interval-ms <value>] [--window-title <pattern>] [--window-class <pattern>] [--require-window] [--json]
+  desktopmanager process start-and-wait <file> [--arguments <text>] [--working-directory <path>] [--wait-for-input-idle-ms <value>] [--launch-wait-for-window-ms <value>] [--launch-wait-for-window-interval-ms <value>] [--launch-window-title <pattern>] [--launch-window-class <pattern>] [--window-title <pattern>] [--window-class <pattern>] [--include-hidden] [--include-empty] [--timeout-ms <value>] [--interval-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
 
 Examples:
   desktopmanager process start notepad.exe --wait-for-input-idle-ms 1000
   desktopmanager process start notepad.exe --wait-for-window-ms 5000
   desktopmanager process start notepad.exe --wait-for-window-ms 5000 --window-title "Untitled - Notepad" --require-window
+  desktopmanager process start-and-wait notepad.exe --window-title "*Notepad*" --timeout-ms 5000 --capture-after --json
   desktopmanager process start code --arguments "." --working-directory C:\Support\GitHub\DesktopManager
 """;
     }
@@ -266,13 +312,16 @@ Examples:
         return """
 Screenshot commands:
   desktopmanager screenshot desktop [--monitor <index>] [--device-id <value>] [--device-name <value>] [--left <value> --top <value> --width <value> --height <value>] [--output <path>] [--json]
-  desktopmanager screenshot window [selector] [--active] [--output <path>] [--json]
+  desktopmanager screenshot window [selector] [--target <name>] [--active] [--output <path>] [--json]
+  desktopmanager screenshot target <name> [selector] [--active] [--output <path>] [--json]
 
 Examples:
   desktopmanager screenshot desktop
   desktopmanager screenshot desktop --monitor 0 --output .\monitor0.png
   desktopmanager screenshot window --active --output .\active-window.png
   desktopmanager screenshot window --process notepad --output .\notepad.png
+  desktopmanager screenshot window --process msedge --target edge-editor-pane --output .\edge-editor-pane.png
+  desktopmanager screenshot target edge-editor-pane --process msedge --json
 """;
     }
 
@@ -281,6 +330,7 @@ Examples:
 Layout commands:
   desktopmanager layout save <name> [--json]
   desktopmanager layout apply <name> [--validate] [--json]
+  desktopmanager layout assert <name> [--position-tolerance-px <value>] [--size-tolerance-px <value>] [--ignore-state] [--include-hidden] [--include-empty] [--capture-before] [--capture-after] [--artifact-directory <path>] [--json]
   desktopmanager layout list [--json]
 
 Named layouts are stored under the current user's AppData profile.
@@ -302,9 +352,13 @@ to grow into broader desktop state capture later.
     public static string GetMcpHelp() {
         return """
 MCP commands:
-  desktopmanager mcp serve
+  desktopmanager mcp serve [--read-only] [--allow-mutations] [--allow-process <pattern>] [--deny-process <pattern>] [--allow-foreground-input] [--dry-run] [--json]
 
 This command group hosts a stdio MCP server that exposes tools, resources, and prompts.
+By default the server is read-only. Use --allow-mutations to enable mutating tools.
+Use --allow-process and --deny-process to constrain live desktop mutations to specific process patterns.
+Use --allow-foreground-input only when you intentionally want focused foreground fallback
+for zero-handle UIA text or key actions. Use --dry-run to preview mutating calls safely.
 """;
     }
 }

--- a/Sources/DesktopManager.Cli/LayoutCommands.cs
+++ b/Sources/DesktopManager.Cli/LayoutCommands.cs
@@ -8,6 +8,7 @@ internal static class LayoutCommands {
         return action switch {
             "save" => Save(arguments),
             "apply" => Apply(arguments),
+            "assert" => Assert(arguments),
             "list" => List(arguments),
             _ => throw new CommandLineException($"Unknown layout command '{action}'.")
         };
@@ -41,6 +42,42 @@ internal static class LayoutCommands {
         return 0;
     }
 
+    private static int Assert(CommandLineArguments arguments) {
+        WindowLayoutAssertionResult result = DesktopOperations.AssertWindowLayout(
+            arguments.GetRequiredCommandPart(2, "layout name"),
+            arguments.GetIntOption("position-tolerance-px") ?? 50,
+            arguments.GetIntOption("size-tolerance-px") ?? 50,
+            arguments.GetBoolFlag("include-hidden"),
+            arguments.GetBoolFlag("include-empty"),
+            !arguments.GetBoolFlag("ignore-state"),
+            CreateArtifactOptions(arguments));
+
+        if (arguments.GetBoolFlag("json")) {
+            OutputFormatter.WriteJson(result);
+            return result.Matched ? 0 : 2;
+        }
+
+        Console.WriteLine($"assert-layout: matched={result.Matched} expected={result.ExpectedCount} matched-count={result.MatchedCount} missing={result.MissingCount} mismatched={result.MismatchCount}");
+        Console.WriteLine(result.Path);
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (SavedWindowLayoutEntryResult window in result.MissingWindows) {
+            Console.WriteLine($"missing: {window.Title} [PID {window.ProcessId}]");
+        }
+
+        foreach (WindowLayoutMismatchResult mismatch in result.MismatchedWindows) {
+            Console.WriteLine($"mismatch: {mismatch.Expected.Title} [PID {mismatch.Expected.ProcessId}] left={mismatch.LeftDelta} top={mismatch.TopDelta} width={mismatch.WidthDelta} height={mismatch.HeightDelta} state={mismatch.StateMatched}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            Console.WriteLine($"warning: {warning}");
+        }
+
+        return result.Matched ? 0 : 2;
+    }
+
     private static int WritePathResult(CommandLineArguments arguments, NamedStateResult payload) {
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(payload);
@@ -50,5 +87,20 @@ internal static class LayoutCommands {
         Console.WriteLine($"{payload.Action}: {payload.Name}");
         Console.WriteLine(payload.Path);
         return 0;
+    }
+
+    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+        bool captureBefore = arguments.GetBoolFlag("capture-before");
+        bool captureAfter = arguments.GetBoolFlag("capture-after");
+        string? artifactDirectory = arguments.GetOption("artifact-directory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
     }
 }

--- a/Sources/DesktopManager.Cli/McpCatalog.cs
+++ b/Sources/DesktopManager.Cli/McpCatalog.cs
@@ -5,6 +5,171 @@ using System.Text.Json;
 namespace DesktopManager.Cli;
 
 internal static class McpCatalog {
+    private static readonly HashSet<string> KnownToolNames = new(StringComparer.Ordinal) {
+        "get_active_window",
+        "list_windows",
+        "get_window_geometry",
+        "window_exists",
+        "active_window_matches",
+        "wait_for_window",
+        "list_window_controls",
+        "diagnose_window_controls",
+        "control_exists",
+        "assert_control_value",
+        "wait_for_control",
+        "click_control",
+        "set_control_text",
+        "send_control_keys",
+        "move_window",
+        "click_window_point",
+        "drag_window_points",
+        "scroll_window_point",
+        "type_window_text",
+        "send_window_keys",
+        "focus_window",
+        "minimize_windows",
+        "snap_window",
+        "list_monitors",
+        "screenshot_desktop",
+        "screenshot_window",
+        "launch_process",
+        "launch_and_wait_for_window",
+        "list_named_targets",
+        "get_named_target",
+        "save_window_target",
+        "resolve_window_target",
+        "list_named_control_targets",
+        "get_named_control_target",
+        "save_control_target",
+        "resolve_control_target",
+        "list_named_layouts",
+        "save_current_layout",
+        "apply_named_layout",
+        "assert_window_layout",
+        "list_named_snapshots",
+        "save_current_snapshot",
+        "restore_saved_snapshot",
+        "prepare_for_coding",
+        "prepare_for_screen_sharing",
+        "clean_up_distractions"
+    };
+
+    private static readonly HashSet<string> MutatingToolNames = new(StringComparer.Ordinal) {
+        "click_control",
+        "set_control_text",
+        "send_control_keys",
+        "move_window",
+        "click_window_point",
+        "drag_window_points",
+        "scroll_window_point",
+        "type_window_text",
+        "send_window_keys",
+        "focus_window",
+        "minimize_windows",
+        "snap_window",
+        "launch_process",
+        "launch_and_wait_for_window",
+        "save_window_target",
+        "save_control_target",
+        "save_current_layout",
+        "apply_named_layout",
+        "save_current_snapshot",
+        "restore_saved_snapshot",
+        "prepare_for_coding",
+        "prepare_for_screen_sharing",
+        "clean_up_distractions"
+    };
+
+    private static readonly HashSet<string> LiveDesktopMutationToolNames = new(StringComparer.Ordinal) {
+        "click_control",
+        "set_control_text",
+        "send_control_keys",
+        "move_window",
+        "click_window_point",
+        "drag_window_points",
+        "scroll_window_point",
+        "type_window_text",
+        "send_window_keys",
+        "focus_window",
+        "minimize_windows",
+        "snap_window",
+        "launch_process",
+        "launch_and_wait_for_window",
+        "apply_named_layout",
+        "restore_saved_snapshot",
+        "prepare_for_coding",
+        "prepare_for_screen_sharing",
+        "clean_up_distractions"
+    };
+
+    private static readonly HashSet<string> ForegroundInputFallbackToolNames = new(StringComparer.Ordinal) {
+        "set_control_text",
+        "send_control_keys"
+    };
+
+    public static bool IsKnownTool(string name) {
+        return KnownToolNames.Contains(name);
+    }
+
+    public static bool IsMutatingTool(string name) {
+        return MutatingToolNames.Contains(name);
+    }
+
+    public static bool AffectsLiveDesktop(string name) {
+        return LiveDesktopMutationToolNames.Contains(name);
+    }
+
+    public static bool RequestsForegroundInputFallback(string name, JsonElement arguments) {
+        return ForegroundInputFallbackToolNames.Contains(name) && ReadBool(arguments, "allowForegroundInput");
+    }
+
+    public static bool TryGetMutatingProcessScope(string name, JsonElement arguments, out string[] processPatterns, out string? error) {
+        processPatterns = Array.Empty<string>();
+        error = null;
+
+        switch (name) {
+            case "launch_process":
+            case "launch_and_wait_for_window":
+                string? filePath = ReadOptionalString(arguments, "filePath");
+                if (string.IsNullOrWhiteSpace(filePath)) {
+                    error = "Process-scoped MCP safety filters require a non-empty 'filePath' for launch tools.";
+                    return false;
+                }
+
+                processPatterns = ExtractProcessPatternsFromFilePath(filePath);
+                return processPatterns.Length > 0;
+            case "click_control":
+            case "set_control_text":
+            case "send_control_keys":
+            case "move_window":
+            case "click_window_point":
+            case "drag_window_points":
+            case "scroll_window_point":
+            case "type_window_text":
+            case "send_window_keys":
+            case "focus_window":
+            case "minimize_windows":
+            case "snap_window":
+                string? processName = ReadOptionalString(arguments, "processName");
+                if (!string.IsNullOrWhiteSpace(processName) && !string.Equals(processName.Trim(), "*", StringComparison.Ordinal)) {
+                    processPatterns = new[] { processName.Trim() };
+                    return true;
+                }
+
+                error = "Process-scoped MCP safety filters require an explicit 'processName' selector for this tool.";
+                return false;
+            case "apply_named_layout":
+            case "restore_saved_snapshot":
+            case "prepare_for_coding":
+            case "prepare_for_screen_sharing":
+            case "clean_up_distractions":
+                error = "This tool can affect multiple applications and is blocked while MCP process allow/deny filters are active.";
+                return false;
+            default:
+                return true;
+        }
+    }
+
     public static object[] GetTools() {
         return new object[] {
             CreateTool("get_active_window", "Get Active Window", "Return information about the currently focused window.", CreateObjectSchema(), readOnly: true),
@@ -114,6 +279,37 @@ internal static class McpCatalog {
                     ["targetName"] = CreateStringSchema("Optional saved control target name."),
                     ["allWindows"] = CreateBooleanSchema("Enumerate controls for all matching windows.")
                 }), readOnly: true),
+            CreateTool("assert_control_value", "Assert Control Value", "Assert that matched controls expose a specific value or text.", CreateObjectSchema(
+                new Dictionary<string, object> {
+                    ["windowTitle"] = CreateStringSchema("Window title filter."),
+                    ["processName"] = CreateStringSchema("Process name filter."),
+                    ["windowClassName"] = CreateStringSchema("Window class filter."),
+                    ["processId"] = CreateIntegerSchema("Window process identifier."),
+                    ["windowHandle"] = CreateStringSchema("Window handle in decimal or hexadecimal format."),
+                    ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
+                    ["controlClassName"] = CreateStringSchema("Control class filter."),
+                    ["controlText"] = CreateStringSchema("Control text filter."),
+                    ["controlValue"] = CreateStringSchema("Control value filter."),
+                    ["controlId"] = CreateIntegerSchema("Control identifier."),
+                    ["controlHandle"] = CreateStringSchema("Control handle in decimal or hexadecimal format."),
+                    ["controlAutomationId"] = CreateStringSchema("UI Automation automation identifier filter."),
+                    ["controlType"] = CreateStringSchema("UI Automation control type filter."),
+                    ["controlFrameworkId"] = CreateStringSchema("UI Automation framework identifier filter."),
+                    ["isEnabled"] = CreateBooleanSchema("Filter by whether the control is enabled."),
+                    ["isKeyboardFocusable"] = CreateBooleanSchema("Filter by whether the control can receive keyboard focus."),
+                    ["supportsBackgroundClick"] = CreateBooleanSchema("Filter by whether the control supports background-safe click or invoke actions."),
+                    ["supportsBackgroundText"] = CreateBooleanSchema("Filter by whether the control supports background-safe text updates."),
+                    ["supportsBackgroundKeys"] = CreateBooleanSchema("Filter by whether the control supports background-safe key delivery."),
+                    ["supportsForegroundInputFallback"] = CreateBooleanSchema("Filter by whether the control supports explicit foreground input fallback."),
+                    ["uiAutomation"] = CreateBooleanSchema("Use UI Automation for control discovery."),
+                    ["includeUiAutomation"] = CreateBooleanSchema("Combine Win32 and UI Automation control results."),
+                    ["ensureForegroundWindow"] = CreateBooleanSchema("Bring the target window to the foreground before UI Automation queries."),
+                    ["targetName"] = CreateStringSchema("Optional saved control target name."),
+                    ["expectedValue"] = CreateStringSchema("Expected control value or text."),
+                    ["contains"] = CreateBooleanSchema("Use case-insensitive contains matching instead of exact equality."),
+                    ["all"] = CreateBooleanSchema("Require all matching controls to satisfy the assertion."),
+                    ["allWindows"] = CreateBooleanSchema("Enumerate controls for all matching windows.")
+                }, new[] { "expectedValue" }), readOnly: true),
             CreateTool("wait_for_control", "Wait For Control", "Wait for a matching control to appear.", CreateObjectSchema(
                 new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
@@ -146,7 +342,7 @@ internal static class McpCatalog {
                     ["intervalMs"] = CreateIntegerSchema("Polling interval in milliseconds.")
                 }), readOnly: true),
             CreateTool("click_control", "Click Control", "Click a matching child control.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["windowClassName"] = CreateStringSchema("Window class filter."),
@@ -174,9 +370,9 @@ internal static class McpCatalog {
                     ["button"] = CreateStringSchema("Mouse button: left or right."),
                     ["all"] = CreateBooleanSchema("Apply to all matching controls."),
                     ["allWindows"] = CreateBooleanSchema("Target controls in all matching windows.")
-                }), readOnly: false, destructive: false, idempotent: true),
+                })), readOnly: false, destructive: false, idempotent: true),
             CreateTool("set_control_text", "Set Control Text", "Set text on a matching child control.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["windowClassName"] = CreateStringSchema("Window class filter."),
@@ -205,9 +401,9 @@ internal static class McpCatalog {
                     ["text"] = CreateStringSchema("Text to set on the control."),
                     ["all"] = CreateBooleanSchema("Apply to all matching controls."),
                     ["allWindows"] = CreateBooleanSchema("Target controls in all matching windows.")
-                }, new[] { "text" }), readOnly: false, destructive: false, idempotent: true),
+                }), new[] { "text" }), readOnly: false, destructive: false, idempotent: true),
             CreateTool("send_control_keys", "Send Control Keys", "Send keys to a matching child control.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["windowClassName"] = CreateStringSchema("Window class filter."),
@@ -240,9 +436,9 @@ internal static class McpCatalog {
                     },
                     ["all"] = CreateBooleanSchema("Apply to all matching controls."),
                     ["allWindows"] = CreateBooleanSchema("Target controls in all matching windows.")
-                }, new[] { "keys" }), readOnly: false, destructive: false, idempotent: true),
+                }), new[] { "keys" }), readOnly: false, destructive: false, idempotent: true),
             CreateTool("move_window", "Move Window", "Move and optionally resize a window by title, process, pid, class, or handle.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -256,9 +452,9 @@ internal static class McpCatalog {
                     ["height"] = CreateIntegerSchema("Window height."),
                     ["activate"] = CreateBooleanSchema("Activate the window after moving."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }), readOnly: false, destructive: false, idempotent: true),
+                })), readOnly: false, destructive: false, idempotent: true),
             CreateTool("click_window_point", "Click Window Point", "Click a point relative to a matching window.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -274,9 +470,9 @@ internal static class McpCatalog {
                     ["activate"] = CreateBooleanSchema("Activate the window before clicking."),
                     ["clientArea"] = CreateBooleanSchema("Interpret coordinates relative to the window client area."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }), readOnly: false, destructive: false, idempotent: false),
+                })), readOnly: false, destructive: false, idempotent: false),
             CreateTool("drag_window_points", "Drag Window Points", "Drag between two points relative to a matching window.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -298,9 +494,9 @@ internal static class McpCatalog {
                     ["activate"] = CreateBooleanSchema("Activate the window before dragging."),
                     ["clientArea"] = CreateBooleanSchema("Interpret coordinates relative to the window client area."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }), readOnly: false, destructive: false, idempotent: false),
+                })), readOnly: false, destructive: false, idempotent: false),
             CreateTool("scroll_window_point", "Scroll Window Point", "Scroll the mouse wheel at a point relative to a matching window.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -316,9 +512,9 @@ internal static class McpCatalog {
                     ["activate"] = CreateBooleanSchema("Activate the window before scrolling."),
                     ["clientArea"] = CreateBooleanSchema("Interpret coordinates relative to the window client area."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }, new[] { "delta" }), readOnly: false, destructive: false, idempotent: false),
+                }), new[] { "delta" }), readOnly: false, destructive: false, idempotent: false),
             CreateTool("type_window_text", "Type Window Text", "Type or paste text into a matching window.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -329,11 +525,23 @@ internal static class McpCatalog {
                     ["paste"] = CreateBooleanSchema("Use clipboard paste instead of typed characters."),
                     ["delayMs"] = CreateIntegerSchema("Delay in milliseconds between typed characters."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }, new[] { "text" }), readOnly: false, destructive: false, idempotent: false),
-            CreateTool("focus_window", "Focus Window", "Bring a matching window to the foreground.", CreateWindowSelectorSchema(includeAll: true, includeEmpty: false), readOnly: false, destructive: false, idempotent: true),
-            CreateTool("minimize_windows", "Minimize Windows", "Minimize one or more matching windows.", CreateWindowSelectorSchema(includeAll: true, includeEmpty: false), readOnly: false, destructive: false, idempotent: true),
+                }), new[] { "text" }), readOnly: false, destructive: false, idempotent: false),
+            CreateTool("send_window_keys", "Send Window Keys", "Send keys to a matching window after activating it.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object> {
+                    ["windowTitle"] = CreateStringSchema("Window title filter."),
+                    ["processName"] = CreateStringSchema("Process name filter."),
+                    ["className"] = CreateStringSchema("Window class filter."),
+                    ["processId"] = CreateIntegerSchema("Process identifier."),
+                    ["handle"] = CreateStringSchema("Window handle in decimal or hexadecimal format."),
+                    ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
+                    ["keys"] = CreateArraySchema("Keys to send to the window.", CreateStringSchema("Virtual key name or single character.")),
+                    ["activate"] = CreateBooleanSchema("Activate the window before sending keys. Defaults to true."),
+                    ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
+                }), new[] { "keys" }), readOnly: false, destructive: false, idempotent: false),
+            CreateTool("focus_window", "Focus Window", "Bring a matching window to the foreground.", CreateWindowMutationSelectorSchema(includeAll: true, includeEmpty: false), readOnly: false, destructive: false, idempotent: true),
+            CreateTool("minimize_windows", "Minimize Windows", "Minimize one or more matching windows.", CreateWindowMutationSelectorSchema(includeAll: true, includeEmpty: false), readOnly: false, destructive: false, idempotent: true),
             CreateTool("snap_window", "Snap Window", "Snap one or more matching windows to a predefined monitor region.", CreateObjectSchema(
-                new Dictionary<string, object> {
+                AddMutationArtifactProperties(new Dictionary<string, object> {
                     ["windowTitle"] = CreateStringSchema("Window title filter."),
                     ["processName"] = CreateStringSchema("Process name filter."),
                     ["className"] = CreateStringSchema("Window class filter."),
@@ -342,7 +550,7 @@ internal static class McpCatalog {
                     ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
                     ["position"] = CreateStringSchema("One of left, right, top-left, top-right, bottom-left, bottom-right."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
-                }, new[] { "position" }), readOnly: false, destructive: false, idempotent: true),
+                }), new[] { "position" }), readOnly: false, destructive: false, idempotent: true),
             CreateTool("list_monitors", "List Monitors", "List connected monitors and their bounds.", CreateObjectSchema(
                 new Dictionary<string, object> {
                     ["connectedOnly"] = CreateBooleanSchema("Return only connected monitors."),
@@ -368,6 +576,7 @@ internal static class McpCatalog {
                     ["processId"] = CreateIntegerSchema("Process identifier."),
                     ["handle"] = CreateStringSchema("Window handle in decimal or hexadecimal format."),
                     ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
+                    ["targetName"] = CreateStringSchema("Optional named target area to capture within the window."),
                     ["outputPath"] = CreateStringSchema("Optional PNG output path.")
                 }), readOnly: true),
             CreateTool("launch_process", "Launch Process", "Start a desktop application or process.", CreateObjectSchema(
@@ -382,6 +591,24 @@ internal static class McpCatalog {
                     ["windowClassName"] = CreateStringSchema("Optional launched-window class filter."),
                     ["requireWindow"] = CreateBooleanSchema("Require a launched window to be found before returning.")
                 }, new[] { "filePath" }), readOnly: false, destructive: false, idempotent: false),
+            CreateTool("launch_and_wait_for_window", "Launch And Wait For Window", "Start a desktop application or process, then wait for a matching launched window.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object> {
+                    ["filePath"] = CreateStringSchema("Executable path or shell command."),
+                    ["arguments"] = CreateStringSchema("Optional argument string."),
+                    ["workingDirectory"] = CreateStringSchema("Optional working directory."),
+                    ["waitForInputIdleMs"] = CreateIntegerSchema("Optional wait for UI input idle in milliseconds."),
+                    ["launchWaitForWindowMs"] = CreateIntegerSchema("Optional launch-time correlation wait in milliseconds."),
+                    ["launchWaitForWindowIntervalMs"] = CreateIntegerSchema("Polling interval while correlating the launched window."),
+                    ["launchWindowTitle"] = CreateStringSchema("Optional launch-time window title filter."),
+                    ["launchWindowClass"] = CreateStringSchema("Optional launch-time window class filter."),
+                    ["windowTitle"] = CreateStringSchema("Optional final window title filter."),
+                    ["windowClass"] = CreateStringSchema("Optional final window class filter."),
+                    ["includeHidden"] = CreateBooleanSchema("Include hidden windows while waiting."),
+                    ["includeEmpty"] = CreateBooleanSchema("Include windows with empty titles while waiting."),
+                    ["all"] = CreateBooleanSchema("Return all matching windows instead of the first match."),
+                    ["timeoutMs"] = CreateIntegerSchema("Maximum time to wait for the final window in milliseconds."),
+                    ["intervalMs"] = CreateIntegerSchema("Polling interval while waiting for the final window.")
+                }), new[] { "filePath" }), readOnly: false, destructive: false, idempotent: false),
             CreateTool("list_named_targets", "List Named Targets", "List saved reusable window-relative targets.", CreateObjectSchema(), readOnly: true),
             CreateTool("get_named_target", "Get Named Target", "Get a saved reusable window-relative target definition.", CreateObjectSchema(
                 new Dictionary<string, object> {
@@ -395,6 +622,10 @@ internal static class McpCatalog {
                     ["y"] = CreateIntegerSchema("Vertical coordinate relative to the target bounds."),
                     ["xRatio"] = CreateNumberSchema("Horizontal coordinate ratio from 0 to 1."),
                     ["yRatio"] = CreateNumberSchema("Vertical coordinate ratio from 0 to 1."),
+                    ["width"] = CreateIntegerSchema("Optional target area width in pixels."),
+                    ["height"] = CreateIntegerSchema("Optional target area height in pixels."),
+                    ["widthRatio"] = CreateNumberSchema("Optional target area width ratio from 0 to 1."),
+                    ["heightRatio"] = CreateNumberSchema("Optional target area height ratio from 0 to 1."),
                     ["clientArea"] = CreateBooleanSchema("Interpret coordinates relative to the window client area.")
                 }, new[] { "name" }), readOnly: false, destructive: false, idempotent: true),
             CreateTool("resolve_window_target", "Resolve Window Target", "Resolve a saved target against one or more live windows.", CreateObjectSchema(
@@ -465,6 +696,15 @@ internal static class McpCatalog {
                     ["name"] = CreateStringSchema("Layout name."),
                     ["validate"] = CreateBooleanSchema("Validate the layout before applying it.")
                 }, new[] { "name" }), readOnly: false, destructive: false, idempotent: true),
+            CreateTool("assert_window_layout", "Assert Window Layout", "Assert that the current desktop windows satisfy a saved named layout within configurable tolerances.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object> {
+                    ["name"] = CreateStringSchema("Layout name."),
+                    ["positionTolerancePx"] = CreateIntegerSchema("Allowed left/top difference in pixels."),
+                    ["sizeTolerancePx"] = CreateIntegerSchema("Allowed width/height difference in pixels."),
+                    ["checkState"] = CreateBooleanSchema("Require saved window state values to match when present."),
+                    ["includeHidden"] = CreateBooleanSchema("Include hidden windows while asserting."),
+                    ["includeEmpty"] = CreateBooleanSchema("Include windows with empty titles while asserting.")
+                }), new[] { "name" }), readOnly: true),
             CreateTool("list_named_snapshots", "List Named Snapshots", "List saved named snapshots.", CreateObjectSchema(), readOnly: true),
             CreateTool("save_current_snapshot", "Save Current Snapshot", "Save the current desktop snapshot. Snapshots are windows-only for now.", CreateObjectSchema(
                 new Dictionary<string, object> {
@@ -474,7 +714,29 @@ internal static class McpCatalog {
                 new Dictionary<string, object> {
                     ["name"] = CreateStringSchema("Snapshot name."),
                     ["validate"] = CreateBooleanSchema("Validate the snapshot before applying it.")
-                }, new[] { "name" }), readOnly: false, destructive: false, idempotent: true)
+                }, new[] { "name" }), readOnly: false, destructive: false, idempotent: true),
+            CreateTool("prepare_for_coding", "Prepare For Coding", "Apply a preferred layout when available and focus a likely editor or terminal window.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object> {
+                    ["layoutName"] = CreateStringSchema("Optional preferred layout to apply."),
+                    ["windowTitle"] = CreateStringSchema("Optional explicit focus window title filter."),
+                    ["processName"] = CreateStringSchema("Optional explicit focus process filter."),
+                    ["className"] = CreateStringSchema("Optional explicit focus class filter."),
+                    ["processId"] = CreateIntegerSchema("Optional explicit focus process identifier."),
+                    ["handle"] = CreateStringSchema("Optional explicit focus window handle."),
+                    ["activeWindow"] = CreateBooleanSchema("Focus the current active window when requested.")
+                })), readOnly: false, destructive: false, idempotent: true),
+            CreateTool("prepare_for_screen_sharing", "Prepare For Screen Sharing", "Apply a preferred layout, minimize common distractions, and focus a likely sharing window.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object> {
+                    ["layoutName"] = CreateStringSchema("Optional preferred layout to apply."),
+                    ["windowTitle"] = CreateStringSchema("Optional explicit focus window title filter."),
+                    ["processName"] = CreateStringSchema("Optional explicit focus process filter."),
+                    ["className"] = CreateStringSchema("Optional explicit focus class filter."),
+                    ["processId"] = CreateIntegerSchema("Optional explicit focus process identifier."),
+                    ["handle"] = CreateStringSchema("Optional explicit focus window handle."),
+                    ["activeWindow"] = CreateBooleanSchema("Focus the current active window when requested.")
+                })), readOnly: false, destructive: false, idempotent: true),
+            CreateTool("clean_up_distractions", "Clean Up Distractions", "Minimize common chat, mail, and messaging windows before focused work or sharing.", CreateObjectSchema(
+                AddMutationArtifactProperties(new Dictionary<string, object>())), readOnly: false, destructive: false, idempotent: true)
         };
     }
 
@@ -586,13 +848,14 @@ internal static class McpCatalog {
                     ReadInt(arguments, "y"),
                     ReadInt(arguments, "width"),
                     ReadInt(arguments, "height"),
-                    ReadBool(arguments, "activate")),
+                    ReadBool(arguments, "activate"),
+                    ReadMutationArtifactOptions(arguments)),
                 "click_window_point" => CallClickWindowPoint(arguments),
                 "drag_window_points" => CallDragWindowPoints(arguments),
                 "scroll_window_point" => CallScrollWindowPoint(arguments),
-                "focus_window" => DesktopOperations.FocusWindow(ReadWindowCriteria(arguments, true)),
-                "minimize_windows" => DesktopOperations.MinimizeWindows(ReadWindowCriteria(arguments, true)),
-                "snap_window" => DesktopOperations.SnapWindow(ReadWindowCriteria(arguments, true), ReadRequiredString(arguments, "position")),
+                "focus_window" => DesktopOperations.FocusWindow(ReadWindowCriteria(arguments, true), ReadMutationArtifactOptions(arguments)),
+                "minimize_windows" => DesktopOperations.MinimizeWindows(ReadWindowCriteria(arguments, true), ReadMutationArtifactOptions(arguments)),
+                "snap_window" => DesktopOperations.SnapWindow(ReadWindowCriteria(arguments, true), ReadRequiredString(arguments, "position"), ReadMutationArtifactOptions(arguments)),
                 "list_monitors" => DesktopOperations.ListMonitors(ReadNullableBool(arguments, "connectedOnly"), ReadNullableBool(arguments, "primaryOnly"), ReadInt(arguments, "index")),
                 "screenshot_desktop" => DesktopOperations.CaptureDesktopScreenshot(
                     ReadInt(arguments, "monitor"),
@@ -603,7 +866,9 @@ internal static class McpCatalog {
                     ReadInt(arguments, "width"),
                     ReadInt(arguments, "height"),
                     ReadOptionalString(arguments, "outputPath")),
-                "screenshot_window" => DesktopOperations.CaptureWindowScreenshot(ReadWindowCriteria(arguments, true), ReadOptionalString(arguments, "outputPath")),
+                "screenshot_window" => string.IsNullOrWhiteSpace(ReadOptionalString(arguments, "targetName"))
+                    ? DesktopOperations.CaptureWindowScreenshot(ReadWindowCriteria(arguments, true), ReadOptionalString(arguments, "outputPath"))
+                    : DesktopOperations.CaptureWindowTargetScreenshot(ReadWindowCriteria(arguments, true), ReadRequiredString(arguments, "targetName"), ReadOptionalString(arguments, "outputPath")),
                 "launch_process" => DesktopOperations.LaunchProcess(
                     ReadRequiredString(arguments, "filePath"),
                     ReadOptionalString(arguments, "arguments"),
@@ -614,6 +879,23 @@ internal static class McpCatalog {
                     ReadOptionalString(arguments, "windowTitle"),
                     ReadOptionalString(arguments, "windowClassName"),
                     ReadBool(arguments, "requireWindow")),
+                "launch_and_wait_for_window" => DesktopOperations.LaunchAndWaitForWindow(
+                    ReadRequiredString(arguments, "filePath"),
+                    ReadOptionalString(arguments, "arguments"),
+                    ReadOptionalString(arguments, "workingDirectory"),
+                    ReadInt(arguments, "waitForInputIdleMs"),
+                    ReadInt(arguments, "launchWaitForWindowMs"),
+                    ReadInt(arguments, "launchWaitForWindowIntervalMs"),
+                    ReadOptionalString(arguments, "launchWindowTitle"),
+                    ReadOptionalString(arguments, "launchWindowClass"),
+                    ReadOptionalString(arguments, "windowTitle"),
+                    ReadOptionalString(arguments, "windowClass"),
+                    ReadBool(arguments, "includeHidden"),
+                    ReadBool(arguments, "includeEmpty"),
+                    ReadBool(arguments, "all"),
+                    ReadInt(arguments, "timeoutMs") ?? 10000,
+                    ReadInt(arguments, "intervalMs") ?? 200,
+                    ReadMutationArtifactOptions(arguments)),
                 "list_named_targets" => DesktopOperations.ListWindowTargets(),
                 "get_named_target" => DesktopOperations.GetWindowTarget(ReadRequiredString(arguments, "name")),
                 "save_window_target" => DesktopOperations.SaveWindowTarget(
@@ -623,6 +905,10 @@ internal static class McpCatalog {
                     ReadInt(arguments, "y"),
                     ReadDouble(arguments, "xRatio"),
                     ReadDouble(arguments, "yRatio"),
+                    ReadInt(arguments, "width"),
+                    ReadInt(arguments, "height"),
+                    ReadDouble(arguments, "widthRatio"),
+                    ReadDouble(arguments, "heightRatio"),
                     ReadBool(arguments, "clientArea")),
                 "resolve_window_target" => DesktopOperations.ResolveWindowTargets(ReadWindowCriteria(arguments, true), ReadRequiredString(arguments, "name")),
                 "list_named_control_targets" => DesktopOperations.ListControlTargets(),
@@ -668,6 +954,20 @@ internal static class McpCatalog {
                         ReadRequiredString(arguments, "targetName"),
                         ReadBool(arguments, "allWindows"),
                         ReadBool(arguments, "all")),
+                "assert_control_value" => string.IsNullOrWhiteSpace(ReadOptionalString(arguments, "targetName"))
+                    ? DesktopOperations.AssertControlValue(
+                        ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
+                        ReadControlCriteria(arguments),
+                        ReadRequiredString(arguments, "expectedValue"),
+                        ReadBool(arguments, "contains"),
+                        ReadBool(arguments, "allWindows"))
+                    : DesktopOperations.AssertControlTargetValue(
+                        ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
+                        ReadRequiredString(arguments, "targetName"),
+                        ReadRequiredString(arguments, "expectedValue"),
+                        ReadBool(arguments, "contains"),
+                        ReadBool(arguments, "allWindows"),
+                        ReadBool(arguments, "all")),
                 "wait_for_control" => string.IsNullOrWhiteSpace(ReadOptionalString(arguments, "targetName"))
                     ? DesktopOperations.WaitForControl(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
@@ -687,19 +987,22 @@ internal static class McpCatalog {
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadControlCriteria(arguments),
                         ReadOptionalString(arguments, "button") ?? "left",
-                        ReadBool(arguments, "allWindows"))
+                        ReadBool(arguments, "allWindows"),
+                        ReadMutationArtifactOptions(arguments))
                     : DesktopOperations.ClickControlTarget(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadRequiredString(arguments, "targetName"),
                         ReadOptionalString(arguments, "button") ?? "left",
                         ReadBool(arguments, "allWindows"),
-                        ReadBool(arguments, "all")),
+                        ReadBool(arguments, "all"),
+                        ReadMutationArtifactOptions(arguments)),
                 "set_control_text" => string.IsNullOrWhiteSpace(ReadOptionalString(arguments, "targetName"))
                     ? DesktopOperations.SetControlText(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadControlCriteria(arguments),
                         ReadRequiredString(arguments, "text"),
-                        ReadBool(arguments, "allWindows"))
+                        ReadBool(arguments, "allWindows"),
+                        ReadMutationArtifactOptions(arguments))
                     : DesktopOperations.SetControlTargetText(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadRequiredString(arguments, "targetName"),
@@ -707,13 +1010,15 @@ internal static class McpCatalog {
                         ReadBool(arguments, "ensureForegroundWindow"),
                         ReadBool(arguments, "allowForegroundInput"),
                         ReadBool(arguments, "allWindows"),
-                        ReadBool(arguments, "all")),
+                        ReadBool(arguments, "all"),
+                        ReadMutationArtifactOptions(arguments)),
                 "send_control_keys" => string.IsNullOrWhiteSpace(ReadOptionalString(arguments, "targetName"))
                     ? DesktopOperations.SendControlKeys(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadControlCriteria(arguments),
                         ReadStringList(arguments, "keys"),
-                        ReadBool(arguments, "allWindows"))
+                        ReadBool(arguments, "allWindows"),
+                        ReadMutationArtifactOptions(arguments))
                     : DesktopOperations.SendControlTargetKeys(
                         ReadWindowCriteria(arguments, true, "windowTitle", "processName", "windowClassName", "processId", "windowHandle"),
                         ReadRequiredString(arguments, "targetName"),
@@ -721,18 +1026,42 @@ internal static class McpCatalog {
                         ReadBool(arguments, "ensureForegroundWindow"),
                         ReadBool(arguments, "allowForegroundInput"),
                         ReadBool(arguments, "allWindows"),
-                        ReadBool(arguments, "all")),
+                        ReadBool(arguments, "all"),
+                        ReadMutationArtifactOptions(arguments)),
                 "type_window_text" => DesktopOperations.TypeWindowText(
                     ReadWindowCriteria(arguments, true),
                     ReadRequiredString(arguments, "text"),
                     ReadBool(arguments, "paste"),
-                    ReadInt(arguments, "delayMs") ?? 0),
+                    ReadInt(arguments, "delayMs") ?? 0,
+                    ReadMutationArtifactOptions(arguments)),
+                "send_window_keys" => DesktopOperations.SendWindowKeys(
+                    ReadWindowCriteria(arguments, true),
+                    ReadStringList(arguments, "keys"),
+                    ReadNullableBool(arguments, "activate") ?? true,
+                    ReadMutationArtifactOptions(arguments)),
                 "list_named_layouts" => DesktopOperations.ListLayouts(),
                 "save_current_layout" => DesktopOperations.SaveLayout(ReadRequiredString(arguments, "name")),
                 "apply_named_layout" => DesktopOperations.ApplyLayout(ReadRequiredString(arguments, "name"), ReadBool(arguments, "validate")),
+                "assert_window_layout" => DesktopOperations.AssertWindowLayout(
+                    ReadRequiredString(arguments, "name"),
+                    ReadInt(arguments, "positionTolerancePx") ?? 50,
+                    ReadInt(arguments, "sizeTolerancePx") ?? 50,
+                    ReadBool(arguments, "includeHidden"),
+                    ReadBool(arguments, "includeEmpty"),
+                    ReadNullableBool(arguments, "checkState") ?? true,
+                    ReadMutationArtifactOptions(arguments)),
                 "list_named_snapshots" => DesktopOperations.ListSnapshots(),
                 "save_current_snapshot" => DesktopOperations.SaveSnapshot(ReadRequiredString(arguments, "name")),
                 "restore_saved_snapshot" => DesktopOperations.RestoreSnapshot(ReadRequiredString(arguments, "name"), ReadBool(arguments, "validate")),
+                "prepare_for_coding" => DesktopOperations.PrepareForCoding(
+                    ReadOptionalString(arguments, "layoutName"),
+                    ReadWorkflowFocusCriteria(arguments),
+                    ReadMutationArtifactOptions(arguments)),
+                "prepare_for_screen_sharing" => DesktopOperations.PrepareForScreenSharing(
+                    ReadOptionalString(arguments, "layoutName"),
+                    ReadWorkflowFocusCriteria(arguments),
+                    ReadMutationArtifactOptions(arguments)),
+                "clean_up_distractions" => DesktopOperations.CleanUpDistractions(ReadMutationArtifactOptions(arguments)),
                 _ => throw new CommandLineException($"Unknown tool '{name}'.")
             };
             error = null;
@@ -780,6 +1109,22 @@ internal static class McpCatalog {
                     }
                 }
             }
+        };
+    }
+
+    private static WindowSelectionCriteria ReadWorkflowFocusCriteria(JsonElement element) {
+        return new WindowSelectionCriteria {
+            TitlePattern = ReadOptionalString(element, "windowTitle") ?? "*",
+            ProcessNamePattern = ReadOptionalString(element, "processName") ?? "*",
+            ClassNamePattern = ReadOptionalString(element, "className") ?? "*",
+            ProcessId = ReadInt(element, "processId"),
+            Handle = ReadOptionalString(element, "handle"),
+            Active = ReadBool(element, "activeWindow"),
+            IncludeHidden = false,
+            IncludeCloaked = false,
+            IncludeOwned = true,
+            IncludeEmptyTitles = false,
+            All = false
         };
     }
 
@@ -835,7 +1180,8 @@ internal static class McpCatalog {
                 criteria,
                 targetName,
                 ReadOptionalString(arguments, "button") ?? "left",
-                ReadBool(arguments, "activate"));
+                ReadBool(arguments, "activate"),
+                ReadMutationArtifactOptions(arguments));
         }
 
         return DesktopOperations.ClickWindowPoint(
@@ -846,7 +1192,8 @@ internal static class McpCatalog {
             ReadDouble(arguments, "yRatio"),
             ReadOptionalString(arguments, "button") ?? "left",
             ReadBool(arguments, "activate"),
-            ReadBool(arguments, "clientArea"));
+            ReadBool(arguments, "clientArea"),
+            ReadMutationArtifactOptions(arguments));
     }
 
     private static object CallDragWindowPoints(JsonElement arguments) {
@@ -859,7 +1206,8 @@ internal static class McpCatalog {
                 ReadRequiredString(arguments, "endTargetName"),
                 ReadOptionalString(arguments, "button") ?? "left",
                 ReadInt(arguments, "stepDelayMs") ?? 0,
-                ReadBool(arguments, "activate"));
+                ReadBool(arguments, "activate"),
+                ReadMutationArtifactOptions(arguments));
         }
 
         return DesktopOperations.DragWindowPoints(
@@ -875,7 +1223,8 @@ internal static class McpCatalog {
             ReadOptionalString(arguments, "button") ?? "left",
             ReadInt(arguments, "stepDelayMs") ?? 0,
             ReadBool(arguments, "activate"),
-            ReadBool(arguments, "clientArea"));
+            ReadBool(arguments, "clientArea"),
+            ReadMutationArtifactOptions(arguments));
     }
 
     private static object CallScrollWindowPoint(JsonElement arguments) {
@@ -887,7 +1236,8 @@ internal static class McpCatalog {
                 criteria,
                 targetName,
                 delta,
-                ReadBool(arguments, "activate"));
+                ReadBool(arguments, "activate"),
+                ReadMutationArtifactOptions(arguments));
         }
 
         return DesktopOperations.ScrollWindowPoint(
@@ -898,7 +1248,8 @@ internal static class McpCatalog {
             ReadDouble(arguments, "yRatio"),
             delta,
             ReadBool(arguments, "activate"),
-            ReadBool(arguments, "clientArea"));
+            ReadBool(arguments, "clientArea"),
+            ReadMutationArtifactOptions(arguments));
     }
 
     private static object CreateTool(string name, string title, string description, object inputSchema, bool readOnly, bool destructive = false, bool idempotent = false) {
@@ -941,6 +1292,37 @@ internal static class McpCatalog {
         return CreateObjectSchema(properties);
     }
 
+    private static object CreateWindowMutationSelectorSchema(bool includeAll, bool includeEmpty) {
+        var properties = new Dictionary<string, object> {
+            ["windowTitle"] = CreateStringSchema("Window title filter."),
+            ["processName"] = CreateStringSchema("Process name filter."),
+            ["className"] = CreateStringSchema("Window class filter."),
+            ["processId"] = CreateIntegerSchema("Process identifier."),
+            ["handle"] = CreateStringSchema("Window handle in decimal or hexadecimal format."),
+            ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
+            ["includeHidden"] = CreateBooleanSchema("Include hidden windows."),
+            ["excludeCloaked"] = CreateBooleanSchema("Exclude DWM-cloaked windows."),
+            ["excludeOwned"] = CreateBooleanSchema("Exclude owned windows.")
+        };
+
+        if (includeEmpty) {
+            properties["includeEmpty"] = CreateBooleanSchema("Include windows with empty titles.");
+        }
+
+        if (includeAll) {
+            properties["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.");
+        }
+
+        return CreateObjectSchema(AddMutationArtifactProperties(properties));
+    }
+
+    private static Dictionary<string, object> AddMutationArtifactProperties(Dictionary<string, object> properties) {
+        properties["captureBefore"] = CreateBooleanSchema("Capture a best-effort screenshot before the mutation.");
+        properties["captureAfter"] = CreateBooleanSchema("Capture a best-effort screenshot after the mutation.");
+        properties["artifactDirectory"] = CreateStringSchema("Optional directory for mutation screenshots.");
+        return properties;
+    }
+
     private static object CreateObjectSchema(Dictionary<string, object>? properties = null, string[]? required = null) {
         return new {
             type = "object",
@@ -977,12 +1359,47 @@ internal static class McpCatalog {
         };
     }
 
+    private static object CreateArraySchema(string description, object items) {
+        return new {
+            type = "array",
+            description,
+            items
+        };
+    }
+
+    private static string[] ExtractProcessPatternsFromFilePath(string filePath) {
+        string trimmed = filePath.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed)) {
+            return Array.Empty<string>();
+        }
+
+        string leaf = trimmed;
+        int lastSlash = Math.Max(trimmed.LastIndexOf('\\'), trimmed.LastIndexOf('/'));
+        if (lastSlash >= 0 && lastSlash < trimmed.Length - 1) {
+            leaf = trimmed.Substring(lastSlash + 1);
+        }
+
+        if (string.IsNullOrWhiteSpace(leaf)) {
+            return Array.Empty<string>();
+        }
+
+        string withoutExtension = leaf.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? leaf.Substring(0, leaf.Length - 4)
+            : leaf;
+
+        if (string.Equals(leaf, withoutExtension, StringComparison.OrdinalIgnoreCase)) {
+            return new[] { leaf };
+        }
+
+        return new[] { leaf, withoutExtension };
+    }
+
     private static string ReadRequiredString(JsonElement element, string propertyName) {
         return ReadOptionalString(element, propertyName) ?? throw new CommandLineException($"Property '{propertyName}' is required.");
     }
 
     private static string? ReadOptionalString(JsonElement element, string propertyName) {
-        if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
+        if (!TryReadProperty(element, propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
             return null;
         }
 
@@ -990,7 +1407,7 @@ internal static class McpCatalog {
     }
 
     private static IReadOnlyList<string> ReadStringList(JsonElement element, string propertyName) {
-        if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
+        if (!TryReadProperty(element, propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
             return Array.Empty<string>();
         }
 
@@ -1012,7 +1429,7 @@ internal static class McpCatalog {
     }
 
     private static int? ReadInt(JsonElement element, string propertyName) {
-        if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
+        if (!TryReadProperty(element, propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
             return null;
         }
 
@@ -1028,7 +1445,7 @@ internal static class McpCatalog {
     }
 
     private static double? ReadDouble(JsonElement element, string propertyName) {
-        if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
+        if (!TryReadProperty(element, propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
             return null;
         }
 
@@ -1047,8 +1464,23 @@ internal static class McpCatalog {
         return ReadNullableBool(element, propertyName) ?? false;
     }
 
+    private static MutationArtifactOptions? ReadMutationArtifactOptions(JsonElement element) {
+        bool captureBefore = ReadBool(element, "captureBefore");
+        bool captureAfter = ReadBool(element, "captureAfter");
+        string? artifactDirectory = ReadOptionalString(element, "artifactDirectory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
+    }
+
     private static bool? ReadNullableBool(JsonElement element, string propertyName) {
-        if (!element.TryGetProperty(propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
+        if (!TryReadProperty(element, propertyName, out JsonElement property) || property.ValueKind == JsonValueKind.Null) {
             return null;
         }
 
@@ -1065,5 +1497,10 @@ internal static class McpCatalog {
         }
 
         throw new CommandLineException($"Property '{propertyName}' expects a boolean value.");
+    }
+
+    private static bool TryReadProperty(JsonElement element, string propertyName, out JsonElement property) {
+        property = default;
+        return element.ValueKind == JsonValueKind.Object && element.TryGetProperty(propertyName, out property);
     }
 }

--- a/Sources/DesktopManager.Cli/McpCommands.cs
+++ b/Sources/DesktopManager.Cli/McpCommands.cs
@@ -9,15 +9,30 @@ internal static class McpCommands {
     }
 
     private static int Serve(CommandLineArguments arguments) {
+        bool readOnly = arguments.GetBoolFlag("read-only");
+        bool allowMutations = arguments.GetBoolFlag("allow-mutations");
+        bool allowForegroundInput = arguments.GetBoolFlag("allow-foreground-input");
+        bool dryRun = arguments.GetBoolFlag("dry-run");
+        if (readOnly && allowMutations) {
+            throw new CommandLineException("Choose either '--read-only' or '--allow-mutations', not both.");
+        }
+
+        var safetyPolicy = new McpSafetyPolicy(
+            allowMutations,
+            allowForegroundInput,
+            dryRun,
+            arguments.GetOptions("allow-process"),
+            arguments.GetOptions("deny-process"));
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(new {
                 status = "ready",
                 protocolVersion = "2025-06-18",
-                mode = "stdio"
+                mode = "stdio",
+                safetyPolicy = safetyPolicy.ToModel()
             });
             return 0;
         }
 
-        return new McpServer().Run();
+        return new McpServer(safetyPolicy).Run();
     }
 }

--- a/Sources/DesktopManager.Cli/McpSafetyPolicy.cs
+++ b/Sources/DesktopManager.Cli/McpSafetyPolicy.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Text.Json;
+
+namespace DesktopManager.Cli;
+
+internal enum McpToolSafetyDecisionKind {
+    Allow,
+    Deny,
+    DryRun
+}
+
+internal sealed class McpToolSafetyDecision {
+    private McpToolSafetyDecision(McpToolSafetyDecisionKind kind, string? message = null, object? result = null) {
+        Kind = kind;
+        Message = message;
+        Result = result;
+    }
+
+    public McpToolSafetyDecisionKind Kind { get; }
+    public string? Message { get; }
+    public object? Result { get; }
+
+    public static McpToolSafetyDecision Allow() {
+        return new McpToolSafetyDecision(McpToolSafetyDecisionKind.Allow);
+    }
+
+    public static McpToolSafetyDecision Deny(string message) {
+        return new McpToolSafetyDecision(McpToolSafetyDecisionKind.Deny, message);
+    }
+
+    public static McpToolSafetyDecision DryRun(object result) {
+        return new McpToolSafetyDecision(McpToolSafetyDecisionKind.DryRun, result: result);
+    }
+}
+
+internal sealed class McpSafetyPolicy {
+    public McpSafetyPolicy(bool allowMutations, bool allowForegroundInput, bool dryRun, IReadOnlyList<string>? allowedProcessPatterns = null, IReadOnlyList<string>? deniedProcessPatterns = null) {
+        AllowMutations = allowMutations;
+        AllowForegroundInput = allowForegroundInput;
+        DryRun = dryRun;
+        AllowedProcessPatterns = NormalizePatterns(allowedProcessPatterns);
+        DeniedProcessPatterns = NormalizePatterns(deniedProcessPatterns);
+    }
+
+    public bool AllowMutations { get; }
+    public bool AllowForegroundInput { get; }
+    public bool DryRun { get; }
+    public bool ReadOnly => !AllowMutations;
+    public IReadOnlyList<string> AllowedProcessPatterns { get; }
+    public IReadOnlyList<string> DeniedProcessPatterns { get; }
+    private bool HasProcessFilters => AllowedProcessPatterns.Count > 0 || DeniedProcessPatterns.Count > 0;
+
+    public object ToModel() {
+        return new {
+            readOnly = ReadOnly,
+            allowMutations = AllowMutations,
+            allowForegroundInput = AllowForegroundInput,
+            dryRun = DryRun,
+            allowedProcesses = AllowedProcessPatterns,
+            deniedProcesses = DeniedProcessPatterns
+        };
+    }
+
+    public string BuildInstructions() {
+        string mutationMode = DryRun
+            ? "Mutating MCP tools are running in dry-run mode and will return simulated results without changing the desktop."
+            : AllowMutations
+                ? "Mutating MCP tools are enabled for this session."
+                : "This MCP server is read-only by default; restart with --allow-mutations to enable mutating tools.";
+
+        string foregroundMode = AllowForegroundInput
+            ? "Focused foreground input fallback is enabled for zero-handle UI Automation text and key actions."
+            : "Focused foreground input fallback is blocked unless the server is started with --allow-foreground-input.";
+
+        string processScopeMode = BuildProcessScopeInstructions();
+
+        return mutationMode + " " + foregroundMode + " " + processScopeMode + " Use read-only inspection tools before mutating the desktop. Layouts and snapshots are stored per-user. Snapshots currently store window layout state only.";
+    }
+
+    public McpToolSafetyDecision EvaluateToolCall(string name, JsonElement arguments) {
+        if (!McpCatalog.IsKnownTool(name) || !McpCatalog.IsMutatingTool(name)) {
+            return McpToolSafetyDecision.Allow();
+        }
+
+        if (HasProcessFilters && McpCatalog.AffectsLiveDesktop(name)) {
+            if (!McpCatalog.TryGetMutatingProcessScope(name, arguments, out string[] processPatterns, out string? scopeError)) {
+                return McpToolSafetyDecision.Deny(scopeError ?? "This MCP server requires an explicit process-scoped target for the requested mutating tool.");
+            }
+
+            for (int index = 0; index < processPatterns.Length; index++) {
+                string processPattern = processPatterns[index];
+                if (MatchesAnyPattern(processPattern, DeniedProcessPatterns)) {
+                    return McpToolSafetyDecision.Deny($"The requested mutation targets '{processPattern}', which is blocked by the MCP denied-process policy.");
+                }
+            }
+
+            if (AllowedProcessPatterns.Count > 0 && !MatchesAnyPattern(processPatterns, AllowedProcessPatterns)) {
+                string requested = string.Join(", ", processPatterns);
+                return McpToolSafetyDecision.Deny($"The requested mutation targets '{requested}', which is outside the MCP allowed-process policy.");
+            }
+        }
+
+        bool requestsForegroundInput = McpCatalog.RequestsForegroundInputFallback(name, arguments);
+        if (requestsForegroundInput && !AllowForegroundInput && !DryRun) {
+            return McpToolSafetyDecision.Deny("This MCP server blocks focused foreground input fallback. Restart with --allow-foreground-input to permit this request.");
+        }
+
+        if (DryRun) {
+            return McpToolSafetyDecision.DryRun(new {
+                success = true,
+                applied = false,
+                dryRun = true,
+                toolName = name,
+                requestedForegroundInputFallback = requestsForegroundInput,
+                requestedProcesses = HasProcessFilters && McpCatalog.AffectsLiveDesktop(name) && McpCatalog.TryGetMutatingProcessScope(name, arguments, out string[] scopedProcesses, out _)
+                    ? scopedProcesses
+                    : Array.Empty<string>(),
+                safetyMode = "dry-run",
+                message = "Mutation skipped because the MCP server is running in dry-run mode.",
+                policy = ToModel()
+            });
+        }
+
+        if (!AllowMutations) {
+            return McpToolSafetyDecision.Deny("This MCP server is running in read-only mode. Restart with --allow-mutations or use --dry-run to preview mutating requests safely.");
+        }
+
+        return McpToolSafetyDecision.Allow();
+    }
+
+    private string BuildProcessScopeInstructions() {
+        if (!HasProcessFilters) {
+            return "No process allow/deny filters are active for this session.";
+        }
+
+        string allowed = AllowedProcessPatterns.Count > 0
+            ? "Allowed processes: " + string.Join(", ", AllowedProcessPatterns) + "."
+            : "No explicit process allowlist is active.";
+        string denied = DeniedProcessPatterns.Count > 0
+            ? "Denied processes: " + string.Join(", ", DeniedProcessPatterns) + "."
+            : "No explicit process denylist is active.";
+
+        return allowed + " " + denied + " Live desktop mutations must resolve to an explicit process scope when these filters are active.";
+    }
+
+    private static string[] NormalizePatterns(IReadOnlyList<string>? patterns) {
+        if (patterns == null || patterns.Count == 0) {
+            return Array.Empty<string>();
+        }
+
+        var normalized = new List<string>();
+        for (int index = 0; index < patterns.Count; index++) {
+            string? pattern = patterns[index];
+            if (string.IsNullOrWhiteSpace(pattern)) {
+                continue;
+            }
+
+            normalized.Add(pattern.Trim());
+        }
+
+        return normalized.ToArray();
+    }
+
+    private static bool MatchesAnyPattern(string value, IReadOnlyList<string> patterns) {
+        for (int index = 0; index < patterns.Count; index++) {
+            if (MatchesPattern(value, patterns[index])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesAnyPattern(IReadOnlyList<string> values, IReadOnlyList<string> patterns) {
+        for (int valueIndex = 0; valueIndex < values.Count; valueIndex++) {
+            if (MatchesAnyPattern(values[valueIndex], patterns)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesPattern(string value, string pattern) {
+        string regexPattern = "^" + Regex.Escape(pattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".") + "$";
+        return Regex.IsMatch(value, regexPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/Sources/DesktopManager.Cli/McpServer.cs
+++ b/Sources/DesktopManager.Cli/McpServer.cs
@@ -9,6 +9,11 @@ namespace DesktopManager.Cli;
 internal sealed class McpServer {
     private const string ProtocolVersion = "2025-06-18";
     private static readonly byte[] HeaderSeparator = Encoding.ASCII.GetBytes("\r\n\r\n");
+    private readonly McpSafetyPolicy _safetyPolicy;
+
+    public McpServer(McpSafetyPolicy? safetyPolicy = null) {
+        _safetyPolicy = safetyPolicy ?? new McpSafetyPolicy(allowMutations: false, allowForegroundInput: false, dryRun: false);
+    }
 
     public int Run() {
         using Stream input = Console.OpenStandardInput();
@@ -32,7 +37,7 @@ internal sealed class McpServer {
         }
     }
 
-    private static void ProcessMessage(JsonElement message, Stream output) {
+    private void ProcessMessage(JsonElement message, Stream output) {
         if (!message.TryGetProperty("method", out JsonElement methodElement)) {
             return;
         }
@@ -54,7 +59,8 @@ internal sealed class McpServer {
                         name = "DesktopManager.Cli",
                         version = "0.1.0"
                     },
-                    instructions = "Use read-only inspection tools before mutating the desktop. Layouts and snapshots are stored per-user. Snapshots currently store window layout state only."
+                    safetyPolicy = _safetyPolicy.ToModel(),
+                    instructions = _safetyPolicy.BuildInstructions()
                 });
                 return;
             case "notifications/initialized":
@@ -99,7 +105,7 @@ internal sealed class McpServer {
         }
     }
 
-    private static void HandleToolCall(Stream output, JsonElement id, JsonElement parameters) {
+    private void HandleToolCall(Stream output, JsonElement id, JsonElement parameters) {
         if (!parameters.TryGetProperty("name", out JsonElement nameElement)) {
             WriteError(output, id, -32602, "Tool calls require a tool name.");
             return;
@@ -107,6 +113,42 @@ internal sealed class McpServer {
 
         string name = nameElement.GetString() ?? string.Empty;
         JsonElement arguments = parameters.TryGetProperty("arguments", out JsonElement argsElement) ? argsElement : default;
+        McpToolSafetyDecision safetyDecision = _safetyPolicy.EvaluateToolCall(name, arguments);
+        if (safetyDecision.Kind == McpToolSafetyDecisionKind.Deny) {
+            object deniedResult = new {
+                error = safetyDecision.Message ?? "The requested tool call is blocked by the active MCP safety policy."
+            };
+            WriteSuccess(output, id, new {
+                content = new[] {
+                    new {
+                        type = "text",
+                        text = JsonUtilities.Serialize(deniedResult)
+                    }
+                },
+                structuredContent = deniedResult,
+                isError = true,
+                message = safetyDecision.Message
+            });
+            return;
+        }
+
+        if (safetyDecision.Kind == McpToolSafetyDecisionKind.DryRun) {
+            object dryRunResult = safetyDecision.Result ?? new {
+                dryRun = true,
+                message = "Mutation skipped because the MCP server is running in dry-run mode."
+            };
+            WriteSuccess(output, id, new {
+                content = new[] {
+                    new {
+                        type = "text",
+                        text = JsonUtilities.Serialize(dryRunResult)
+                    }
+                },
+                structuredContent = dryRunResult,
+                isError = false
+            });
+            return;
+        }
 
         bool success = McpCatalog.TryCallTool(name, arguments, out object result, out string? error);
         WriteSuccess(output, id, new {
@@ -122,7 +164,7 @@ internal sealed class McpServer {
         });
     }
 
-    private static void HandleResourceRead(Stream output, JsonElement id, JsonElement parameters) {
+    private void HandleResourceRead(Stream output, JsonElement id, JsonElement parameters) {
         if (!parameters.TryGetProperty("uri", out JsonElement uriElement)) {
             WriteError(output, id, -32602, "Resource reads require a uri.");
             return;
@@ -145,7 +187,7 @@ internal sealed class McpServer {
         }
     }
 
-    private static void HandlePromptGet(Stream output, JsonElement id, JsonElement parameters) {
+    private void HandlePromptGet(Stream output, JsonElement id, JsonElement parameters) {
         if (!parameters.TryGetProperty("name", out JsonElement nameElement)) {
             WriteError(output, id, -32602, "Prompt requests require a name.");
             return;

--- a/Sources/DesktopManager.Cli/ProcessCommands.cs
+++ b/Sources/DesktopManager.Cli/ProcessCommands.cs
@@ -6,6 +6,7 @@ internal static class ProcessCommands {
     public static int Run(string action, CommandLineArguments arguments) {
         return action switch {
             "start" => Start(arguments),
+            "start-and-wait" => StartAndWait(arguments),
             _ => throw new CommandLineException($"Unknown process command '{action}'.")
         };
     }
@@ -42,5 +43,71 @@ internal static class ProcessCommands {
             Console.WriteLine($"- Window: {result.MainWindow.Title}");
         }
         return 0;
+    }
+
+    private static int StartAndWait(CommandLineArguments arguments) {
+        LaunchAndWaitResult result = DesktopOperations.LaunchAndWaitForWindow(
+            arguments.GetRequiredCommandPart(2, "process path"),
+            arguments.GetOption("arguments"),
+            arguments.GetOption("working-directory"),
+            arguments.GetIntOption("wait-for-input-idle-ms"),
+            arguments.GetIntOption("launch-wait-for-window-ms"),
+            arguments.GetIntOption("launch-wait-for-window-interval-ms"),
+            arguments.GetOption("launch-window-title"),
+            arguments.GetOption("launch-window-class"),
+            arguments.GetOption("window-title"),
+            arguments.GetOption("window-class"),
+            arguments.GetBoolFlag("include-hidden"),
+            arguments.GetBoolFlag("include-empty"),
+            arguments.GetBoolFlag("all"),
+            arguments.GetIntOption("timeout-ms") ?? 10000,
+            arguments.GetIntOption("interval-ms") ?? 200,
+            CreateArtifactOptions(arguments));
+
+        if (arguments.GetBoolFlag("json")) {
+            OutputFormatter.WriteJson(result);
+            return result.Success ? 0 : 2;
+        }
+
+        Console.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
+        Console.WriteLine($"- PID: {result.Launch.ProcessId}");
+        if (result.Launch.ResolvedProcessId.HasValue && result.Launch.ResolvedProcessId.Value != result.Launch.ProcessId) {
+            Console.WriteLine($"- ResolvedPID: {result.Launch.ResolvedProcessId.Value}");
+        }
+        Console.WriteLine($"- File: {result.Launch.FilePath}");
+        Console.WriteLine($"- WaitCount: {result.WindowWait.Count}");
+        Console.WriteLine($"- WaitElapsedMs: {result.WindowWait.ElapsedMilliseconds}");
+        foreach (WindowResult window in result.WindowWait.Windows) {
+            Console.WriteLine($"- Window: {window.Title} [PID {window.ProcessId}]");
+        }
+
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            Console.WriteLine($"- Artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            Console.WriteLine($"- Warning: {warning}");
+        }
+
+        foreach (string note in result.Notes) {
+            Console.WriteLine($"- Note: {note}");
+        }
+
+        return result.Success ? 0 : 2;
+    }
+
+    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+        bool captureBefore = arguments.GetBoolFlag("capture-before");
+        bool captureAfter = arguments.GetBoolFlag("capture-after");
+        string? artifactDirectory = arguments.GetOption("artifact-directory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
     }
 }

--- a/Sources/DesktopManager.Cli/ScreenshotCommands.cs
+++ b/Sources/DesktopManager.Cli/ScreenshotCommands.cs
@@ -7,6 +7,7 @@ internal static class ScreenshotCommands {
         return action switch {
             "desktop" => Desktop(arguments),
             "window" => Window(arguments),
+            "target" => Target(arguments),
             _ => throw new CommandLineException($"Unknown screenshot command '{action}'.")
         };
     }
@@ -25,6 +26,26 @@ internal static class ScreenshotCommands {
     }
 
     private static int Window(CommandLineArguments arguments) {
+        string? targetName = arguments.GetOption("target");
+        if (!string.IsNullOrWhiteSpace(targetName)) {
+            ScreenshotResult targetResult = DesktopOperations.CaptureWindowTargetScreenshot(
+                new WindowSelectionCriteria {
+                    TitlePattern = arguments.GetOption("title") ?? "*",
+                    ProcessNamePattern = arguments.GetOption("process") ?? "*",
+                    ClassNamePattern = arguments.GetOption("class") ?? "*",
+                    ProcessId = arguments.GetIntOption("pid"),
+                    Handle = arguments.GetOption("handle"),
+                    Active = arguments.GetBoolFlag("active"),
+                    IncludeHidden = true,
+                    IncludeCloaked = true,
+                    IncludeOwned = true,
+                    IncludeEmptyTitles = true
+                },
+                targetName,
+                arguments.GetOption("output"));
+            return WriteScreenshotResult(arguments, targetResult);
+        }
+
         ScreenshotResult result = DesktopOperations.CaptureWindowScreenshot(
             new WindowSelectionCriteria {
                 TitlePattern = arguments.GetOption("title") ?? "*",
@@ -38,6 +59,25 @@ internal static class ScreenshotCommands {
                 IncludeOwned = true,
                 IncludeEmptyTitles = true
             },
+            arguments.GetOption("output"));
+        return WriteScreenshotResult(arguments, result);
+    }
+
+    private static int Target(CommandLineArguments arguments) {
+        ScreenshotResult result = DesktopOperations.CaptureWindowTargetScreenshot(
+            new WindowSelectionCriteria {
+                TitlePattern = arguments.GetOption("title") ?? "*",
+                ProcessNamePattern = arguments.GetOption("process") ?? "*",
+                ClassNamePattern = arguments.GetOption("class") ?? "*",
+                ProcessId = arguments.GetIntOption("pid"),
+                Handle = arguments.GetOption("handle"),
+                Active = arguments.GetBoolFlag("active"),
+                IncludeHidden = true,
+                IncludeCloaked = true,
+                IncludeOwned = true,
+                IncludeEmptyTitles = true
+            },
+            arguments.GetRequiredCommandPart(2, "target name"),
             arguments.GetOption("output"));
         return WriteScreenshotResult(arguments, result);
     }

--- a/Sources/DesktopManager.Cli/TargetCommands.cs
+++ b/Sources/DesktopManager.Cli/TargetCommands.cs
@@ -22,6 +22,10 @@ internal static class TargetCommands {
             arguments.GetIntOption("y"),
             arguments.GetDoubleOption("x-ratio"),
             arguments.GetDoubleOption("y-ratio"),
+            arguments.GetIntOption("width"),
+            arguments.GetIntOption("height"),
+            arguments.GetDoubleOption("width-ratio"),
+            arguments.GetDoubleOption("height-ratio"),
             arguments.GetBoolFlag("client-area"));
 
         if (arguments.GetBoolFlag("json")) {
@@ -48,6 +52,10 @@ internal static class TargetCommands {
         Console.WriteLine($"- Y: {result.Target.Y?.ToString() ?? "-"}");
         Console.WriteLine($"- XRatio: {result.Target.XRatio?.ToString() ?? "-"}");
         Console.WriteLine($"- YRatio: {result.Target.YRatio?.ToString() ?? "-"}");
+        Console.WriteLine($"- Width: {result.Target.Width?.ToString() ?? "-"}");
+        Console.WriteLine($"- Height: {result.Target.Height?.ToString() ?? "-"}");
+        Console.WriteLine($"- WidthRatio: {result.Target.WidthRatio?.ToString() ?? "-"}");
+        Console.WriteLine($"- HeightRatio: {result.Target.HeightRatio?.ToString() ?? "-"}");
         if (!string.IsNullOrWhiteSpace(result.Target.Description)) {
             Console.WriteLine($"- Description: {result.Target.Description}");
         }
@@ -86,6 +94,9 @@ internal static class TargetCommands {
             Console.WriteLine($"{result.Name}: {result.Window.Title} ({result.Window.Handle})");
             Console.WriteLine($"- Relative: {result.RelativeX},{result.RelativeY}");
             Console.WriteLine($"- Screen: {result.ScreenX},{result.ScreenY}");
+            if (result.ScreenWidth.HasValue && result.ScreenHeight.HasValue) {
+                Console.WriteLine($"- Area: {result.ScreenWidth}x{result.ScreenHeight}");
+            }
             Console.WriteLine($"- ClientArea: {(result.Target.ClientArea ? "Yes" : "No")}");
         }
         return 0;

--- a/Sources/DesktopManager.Cli/WindowCommands.cs
+++ b/Sources/DesktopManager.Cli/WindowCommands.cs
@@ -19,6 +19,7 @@ internal static class WindowCommands {
             "minimize" => Minimize(arguments),
             "snap" => Snap(arguments),
             "type" => Type(arguments),
+            "keys" => Keys(arguments),
             "wait" => Wait(arguments),
             _ => throw new CommandLineException($"Unknown window command '{action}'.")
         };
@@ -93,12 +94,13 @@ internal static class WindowCommands {
             arguments.GetIntOption("y"),
             arguments.GetIntOption("width"),
             arguments.GetIntOption("height"),
-            arguments.GetBoolFlag("activate"));
+            arguments.GetBoolFlag("activate"),
+            CreateArtifactOptions(arguments));
         return WriteWindowMutationResult(arguments, result);
     }
 
     private static int Focus(CommandLineArguments arguments) {
-        return WriteWindowMutationResult(arguments, DesktopOperations.FocusWindow(CreateCriteria(arguments, includeEmptyDefault: true)));
+        return WriteWindowMutationResult(arguments, DesktopOperations.FocusWindow(CreateCriteria(arguments, includeEmptyDefault: true), CreateArtifactOptions(arguments)));
     }
 
     private static int Click(CommandLineArguments arguments) {
@@ -110,7 +112,8 @@ internal static class WindowCommands {
                     CreateCriteria(arguments, includeEmptyDefault: true),
                     targetName,
                     arguments.GetOption("button") ?? "left",
-                    arguments.GetBoolFlag("activate")));
+                    arguments.GetBoolFlag("activate"),
+                    CreateArtifactOptions(arguments)));
         }
 
         return WriteWindowMutationResult(
@@ -123,7 +126,8 @@ internal static class WindowCommands {
                 arguments.GetDoubleOption("y-ratio"),
                 arguments.GetOption("button") ?? "left",
                 arguments.GetBoolFlag("activate"),
-                arguments.GetBoolFlag("client-area")));
+                arguments.GetBoolFlag("client-area"),
+                CreateArtifactOptions(arguments)));
     }
 
     private static int Drag(CommandLineArguments arguments) {
@@ -142,7 +146,8 @@ internal static class WindowCommands {
                     endTargetName,
                     arguments.GetOption("button") ?? "left",
                     arguments.GetIntOption("step-delay-ms") ?? 0,
-                    arguments.GetBoolFlag("activate")));
+                    arguments.GetBoolFlag("activate"),
+                    CreateArtifactOptions(arguments)));
         }
 
         return WriteWindowMutationResult(
@@ -160,7 +165,8 @@ internal static class WindowCommands {
                 arguments.GetOption("button") ?? "left",
                 arguments.GetIntOption("step-delay-ms") ?? 0,
                 arguments.GetBoolFlag("activate"),
-                arguments.GetBoolFlag("client-area")));
+                arguments.GetBoolFlag("client-area"),
+                CreateArtifactOptions(arguments)));
     }
 
     private static int Scroll(CommandLineArguments arguments) {
@@ -172,7 +178,8 @@ internal static class WindowCommands {
                     CreateCriteria(arguments, includeEmptyDefault: true),
                     targetName,
                     arguments.GetRequiredIntOption("delta"),
-                    arguments.GetBoolFlag("activate")));
+                    arguments.GetBoolFlag("activate"),
+                    CreateArtifactOptions(arguments)));
         }
 
         return WriteWindowMutationResult(
@@ -185,17 +192,18 @@ internal static class WindowCommands {
                 arguments.GetDoubleOption("y-ratio"),
                 arguments.GetRequiredIntOption("delta"),
                 arguments.GetBoolFlag("activate"),
-                arguments.GetBoolFlag("client-area")));
+                arguments.GetBoolFlag("client-area"),
+                CreateArtifactOptions(arguments)));
     }
 
     private static int Minimize(CommandLineArguments arguments) {
-        return WriteWindowMutationResult(arguments, DesktopOperations.MinimizeWindows(CreateCriteria(arguments, includeEmptyDefault: true)));
+        return WriteWindowMutationResult(arguments, DesktopOperations.MinimizeWindows(CreateCriteria(arguments, includeEmptyDefault: true), CreateArtifactOptions(arguments)));
     }
 
     private static int Snap(CommandLineArguments arguments) {
         return WriteWindowMutationResult(
             arguments,
-            DesktopOperations.SnapWindow(CreateCriteria(arguments, includeEmptyDefault: true), arguments.GetRequiredOption("position")));
+            DesktopOperations.SnapWindow(CreateCriteria(arguments, includeEmptyDefault: true), arguments.GetRequiredOption("position"), CreateArtifactOptions(arguments)));
     }
 
     private static int Type(CommandLineArguments arguments) {
@@ -205,7 +213,24 @@ internal static class WindowCommands {
                 CreateCriteria(arguments, includeEmptyDefault: true),
                 arguments.GetRequiredOption("text"),
                 arguments.GetBoolFlag("paste"),
-                arguments.GetIntOption("delay-ms") ?? 0));
+                arguments.GetIntOption("delay-ms") ?? 0,
+                CreateArtifactOptions(arguments)));
+    }
+
+    private static int Keys(CommandLineArguments arguments) {
+        IReadOnlyList<string> keys = arguments.GetOptions("keys");
+        if (keys.Count == 0) {
+            string single = arguments.GetRequiredOption("keys");
+            keys = new[] { single };
+        }
+
+        return WriteWindowMutationResult(
+            arguments,
+            DesktopOperations.SendWindowKeys(
+                CreateCriteria(arguments, includeEmptyDefault: true),
+                keys,
+                !arguments.GetBoolFlag("no-activate"),
+                CreateArtifactOptions(arguments)));
     }
 
     private static int Wait(CommandLineArguments arguments) {
@@ -232,11 +257,38 @@ internal static class WindowCommands {
             return 0;
         }
 
-        Console.WriteLine($"{payload.Action}: {payload.Count} window(s)");
+        Console.WriteLine($"{payload.Action}: {payload.Count} window(s) success={payload.Success} safety={payload.SafetyMode} elapsed-ms={payload.ElapsedMilliseconds}");
+        if (!string.IsNullOrWhiteSpace(payload.TargetName)) {
+            Console.WriteLine($"target: {payload.TargetKind ?? "selector"} {payload.TargetName}");
+        }
+
+        if (payload.BeforeScreenshots.Count > 0 || payload.AfterScreenshots.Count > 0) {
+            Console.WriteLine($"artifacts: before={payload.BeforeScreenshots.Count} after={payload.AfterScreenshots.Count}");
+        }
+
+        foreach (string warning in payload.ArtifactWarnings) {
+            Console.WriteLine($"warning: {warning}");
+        }
+
         foreach (WindowResult window in payload.Windows) {
             Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
         }
         return 0;
+    }
+
+    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+        bool captureBefore = arguments.GetBoolFlag("capture-before");
+        bool captureAfter = arguments.GetBoolFlag("capture-after");
+        string? artifactDirectory = arguments.GetOption("artifact-directory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
     }
 
     private static int WriteAssertionResult(CommandLineArguments arguments, WindowAssertionResult payload, string successText, string failureText) {

--- a/Sources/DesktopManager.Cli/WorkflowCommands.cs
+++ b/Sources/DesktopManager.Cli/WorkflowCommands.cs
@@ -1,0 +1,106 @@
+using System;
+
+namespace DesktopManager.Cli;
+
+internal static class WorkflowCommands {
+    public static int Run(string action, CommandLineArguments arguments) {
+        return action switch {
+            "prepare-coding" => PrepareCoding(arguments),
+            "prepare-screen-sharing" => PrepareScreenSharing(arguments),
+            "clean-up-distractions" => CleanUpDistractions(arguments),
+            _ => throw new CommandLineException($"Unknown workflow command '{action}'.")
+        };
+    }
+
+    private static int PrepareCoding(CommandLineArguments arguments) {
+        WorkflowResult result = DesktopOperations.PrepareForCoding(
+            arguments.GetOption("layout"),
+            CreateFocusCriteria(arguments),
+            CreateArtifactOptions(arguments));
+        return WriteWorkflow(arguments, result);
+    }
+
+    private static int PrepareScreenSharing(CommandLineArguments arguments) {
+        WorkflowResult result = DesktopOperations.PrepareForScreenSharing(
+            arguments.GetOption("layout"),
+            CreateFocusCriteria(arguments),
+            CreateArtifactOptions(arguments));
+        return WriteWorkflow(arguments, result);
+    }
+
+    private static int CleanUpDistractions(CommandLineArguments arguments) {
+        return WriteWorkflow(arguments, DesktopOperations.CleanUpDistractions(CreateArtifactOptions(arguments)));
+    }
+
+    private static int WriteWorkflow(CommandLineArguments arguments, WorkflowResult result) {
+        if (arguments.GetBoolFlag("json")) {
+            OutputFormatter.WriteJson(result);
+            return result.Success ? 0 : 2;
+        }
+
+        Console.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
+        if (result.LayoutApplied && !string.IsNullOrWhiteSpace(result.LayoutName)) {
+            Console.WriteLine($"layout: applied {result.LayoutName}");
+        } else if (!string.IsNullOrWhiteSpace(result.LayoutName)) {
+            Console.WriteLine($"layout: not-applied {result.LayoutName}");
+        }
+
+        if (result.FocusedWindow != null) {
+            Console.WriteLine($"focused: {result.FocusedWindow.Title} [PID {result.FocusedWindow.ProcessId}]");
+        } else if (result.ResolvedWindow != null) {
+            Console.WriteLine($"resolved: {result.ResolvedWindow.Title} [PID {result.ResolvedWindow.ProcessId}]");
+        }
+
+        if (result.MinimizedWindows.Count > 0) {
+            Console.WriteLine($"minimized: {result.MinimizedWindows.Count} window(s)");
+            foreach (WindowResult window in result.MinimizedWindows) {
+                Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
+            }
+        }
+
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            Console.WriteLine($"warning: {warning}");
+        }
+
+        foreach (string note in result.Notes) {
+            Console.WriteLine($"note: {note}");
+        }
+
+        return result.Success ? 0 : 2;
+    }
+
+    private static WindowSelectionCriteria CreateFocusCriteria(CommandLineArguments arguments) {
+        return new WindowSelectionCriteria {
+            TitlePattern = arguments.GetOption("title") ?? "*",
+            ProcessNamePattern = arguments.GetOption("process") ?? "*",
+            ClassNamePattern = arguments.GetOption("class") ?? "*",
+            ProcessId = arguments.GetIntOption("pid"),
+            Handle = arguments.GetOption("handle"),
+            Active = arguments.GetBoolFlag("active"),
+            IncludeHidden = arguments.GetBoolFlag("include-hidden"),
+            IncludeCloaked = !arguments.GetBoolFlag("exclude-cloaked"),
+            IncludeOwned = !arguments.GetBoolFlag("exclude-owned"),
+            IncludeEmptyTitles = arguments.GetBoolFlag("include-empty"),
+            All = false
+        };
+    }
+
+    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+        bool captureBefore = arguments.GetBoolFlag("capture-before");
+        bool captureAfter = arguments.GetBoolFlag("capture-after");
+        string? artifactDirectory = arguments.GetOption("artifact-directory");
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return null;
+        }
+
+        return new MutationArtifactOptions {
+            CaptureBefore = captureBefore,
+            CaptureAfter = captureAfter,
+            ArtifactDirectory = artifactDirectory
+        };
+    }
+}

--- a/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
@@ -83,6 +83,8 @@ public class DesktopAutomationCoreTests {
                 Description = "Editor center",
                 XRatio = 0.5,
                 YRatio = 0.5,
+                WidthRatio = 0.8,
+                HeightRatio = 0.6,
                 ClientArea = true
             });
 
@@ -92,6 +94,8 @@ public class DesktopAutomationCoreTests {
             Assert.AreEqual(saved.Description, loaded.Description);
             Assert.AreEqual(saved.XRatio, loaded.XRatio);
             Assert.AreEqual(saved.YRatio, loaded.YRatio);
+            Assert.AreEqual(saved.WidthRatio, loaded.WidthRatio);
+            Assert.AreEqual(saved.HeightRatio, loaded.HeightRatio);
             Assert.AreEqual(saved.ClientArea, loaded.ClientArea);
             Assert.IsTrue(File.Exists(path));
         } finally {
@@ -305,6 +309,22 @@ public class DesktopAutomationCoreTests {
 
         Assert.ThrowsException<ArgumentException>(() => automation.SaveWindowTarget(targetName, new DesktopWindowTargetDefinition {
             YRatio = 0.5
+        }));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target area definitions reject zero width.
+    /// </summary>
+    public void DesktopAutomationService_SaveWindowTarget_ZeroWidth_ThrowsArgumentOutOfRangeException() {
+        string targetName = "DesktopAutomationCoreTests-" + Guid.NewGuid().ToString("N");
+        var automation = new DesktopAutomationService();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => automation.SaveWindowTarget(targetName, new DesktopWindowTargetDefinition {
+            XRatio = 0.5,
+            YRatio = 0.5,
+            Width = 0,
+            Height = 100
         }));
     }
 

--- a/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
@@ -1,0 +1,1327 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// End-to-end MCP server tests against a disposable desktop application.
+/// </summary>
+public class McpServerEndToEndTests {
+    private const int NotepadLaunchTimeoutMs = 20000;
+    private const int NotepadControlDiscoveryTimeoutMs = 20000;
+    private const int EdgeLaunchTimeoutMs = 30000;
+    private const int EdgeControlDiscoveryTimeoutMs = 15000;
+    private const double EdgeOmniboxFallbackXRatio = 0.42;
+    private const double EdgeOmniboxFallbackYRatio = 0.05;
+
+    [TestCleanup]
+    public void Cleanup() {
+        TestHelper.KillAllNotepads();
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP can launch Notepad, discover an editable control, set text, assert the value, and capture an artifact.
+    /// </summary>
+    public void McpServer_NotepadRoundTrip_LaunchesSetsTextAssertsValueAndCapturesArtifact() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            JsonElement launchResult = client.CallTool(2, "launch_and_wait_for_window", new {
+                filePath = "notepad.exe",
+                timeoutMs = NotepadLaunchTimeoutMs,
+                intervalMs = 100,
+                captureAfter = true,
+                artifactDirectory
+            });
+
+            Assert.IsTrue(launchResult.GetProperty("Success").GetBoolean());
+            Assert.IsTrue(launchResult.GetProperty("WindowWait").GetProperty("Count").GetInt32() > 0);
+            resolvedProcessId = ReadResolvedProcessId(launchResult.GetProperty("Launch"));
+            Assert.IsTrue(resolvedProcessId > 0);
+            AssertScreenshotPathsExist(launchResult.GetProperty("AfterScreenshots"));
+            JsonElement launchedWindow = launchResult.GetProperty("WindowWait").GetProperty("Windows")[0];
+            string launchedWindowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched Notepad window to expose a handle.");
+
+            int requestId = 3;
+            JsonElement editor = WaitForEditableNotepadControl(client, ref requestId, launchedWindowHandle, NotepadControlDiscoveryTimeoutMs, 100);
+            string editorClassName = editor.GetProperty("ClassName").GetString() ?? string.Empty;
+            string editorHandle = editor.GetProperty("Handle").GetString() ?? string.Empty;
+            string windowHandle = editor.GetProperty("ParentWindow").GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(editorClassName), "Expected an editable Notepad control class.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the resolved editor control to include its parent window handle.");
+
+            string resolvedControlHandle = editorHandle;
+            if (string.IsNullOrWhiteSpace(resolvedControlHandle)) {
+                JsonElement waitedControl = client.CallTool(requestId++, "wait_for_control", new {
+                    windowHandle,
+                    controlClassName = editorClassName,
+                    timeoutMs = 5000,
+                    intervalMs = 100
+                });
+                Assert.IsTrue(waitedControl.GetProperty("Count").GetInt32() >= 1, "Expected MCP to wait for the Notepad editor control before mutating it.");
+                JsonElement freshEditor = waitedControl.GetProperty("Controls")[0];
+                resolvedControlHandle = freshEditor.GetProperty("Handle").GetString() ?? string.Empty;
+            }
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(resolvedControlHandle), "Expected the resolved Notepad editor control to expose a handle.");
+
+            string expectedText = "DesktopManager MCP E2E " + Guid.NewGuid().ToString("N");
+            JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
+                windowHandle,
+                controlHandle = resolvedControlHandle,
+                text = expectedText,
+                captureAfter = true,
+                artifactDirectory
+            });
+
+            Assert.IsTrue(setTextResult.GetProperty("Success").GetBoolean());
+            Assert.IsTrue(setTextResult.GetProperty("Count").GetInt32() >= 1);
+            StringAssert.Contains(setTextResult.GetProperty("SafetyMode").GetString() ?? string.Empty, "background");
+            AssertScreenshotPathsExist(setTextResult.GetProperty("AfterScreenshots"));
+
+            JsonElement assertionResult = client.CallTool(requestId++, "assert_control_value", new {
+                windowHandle,
+                controlHandle = resolvedControlHandle,
+                expectedValue = expectedText
+            });
+
+            Assert.IsTrue(assertionResult.GetProperty("Matched").GetBoolean(), "Expected MCP to verify the Notepad editor value after text entry.");
+            Assert.IsTrue(assertionResult.GetProperty("MatchedCount").GetInt32() >= 1);
+        } finally {
+            if (resolvedProcessId > 0) {
+                try {
+                    using Process process = Process.GetProcessById(resolvedProcessId);
+                    TestHelper.SafeKillProcess(process);
+                } catch {
+                    // Ignore cleanup failures for already exited processes.
+                }
+            }
+
+            if (Directory.Exists(artifactDirectory)) {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP can save a reusable target area, resolve it against Notepad, and capture that exact region.
+    /// </summary>
+    public void McpServer_NotepadTargetAreaRoundTrip_SavesResolvesAndCapturesTarget() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        string targetName = "McpServerEndToEnd-" + Guid.NewGuid().ToString("N");
+        string targetPath = DesktopStateStore.GetTargetPath(targetName);
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            int requestId = 2;
+            WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "target capture");
+
+            JsonElement saveTargetResult = client.CallTool(requestId++, "save_window_target", new {
+                name = targetName,
+                description = "Notepad center area",
+                xRatio = 0.25,
+                yRatio = 0.2,
+                widthRatio = 0.5,
+                heightRatio = 0.5,
+                clientArea = true
+            });
+
+            Assert.AreEqual(targetName, saveTargetResult.GetProperty("Name").GetString());
+            Assert.IsTrue(File.Exists(targetPath));
+
+            JsonElement resolvedTargets = client.CallTool(requestId++, "resolve_window_target", new {
+                name = targetName,
+                processId = resolvedProcessId
+            });
+
+            Assert.IsTrue(resolvedTargets.ValueKind == JsonValueKind.Array && resolvedTargets.GetArrayLength() == 1, "Expected the named target to resolve against exactly one Notepad window.");
+            JsonElement resolvedTarget = resolvedTargets[0];
+            Assert.AreEqual(targetName, resolvedTarget.GetProperty("Name").GetString());
+            Assert.IsTrue(resolvedTarget.GetProperty("Target").GetProperty("ClientArea").GetBoolean());
+            int screenWidth = resolvedTarget.GetProperty("ScreenWidth").GetInt32();
+            int screenHeight = resolvedTarget.GetProperty("ScreenHeight").GetInt32();
+            Assert.IsTrue(screenWidth > 0);
+            Assert.IsTrue(screenHeight > 0);
+
+            string outputPath = Path.Combine(artifactDirectory, "notepad-target.png");
+            JsonElement screenshotResult = client.CallTool(requestId++, "screenshot_window", new {
+                processId = resolvedProcessId,
+                targetName,
+                outputPath
+            });
+
+            Assert.AreEqual("window-target", screenshotResult.GetProperty("Kind").GetString());
+            Assert.AreEqual(screenWidth, screenshotResult.GetProperty("Width").GetInt32());
+            Assert.AreEqual(screenHeight, screenshotResult.GetProperty("Height").GetInt32());
+            Assert.AreEqual(resolvedProcessId, screenshotResult.GetProperty("Window").GetProperty("ProcessId").GetInt32());
+            Assert.IsTrue(File.Exists(screenshotResult.GetProperty("Path").GetString() ?? string.Empty));
+            Assert.IsTrue(screenshotResult.TryGetProperty("Geometry", out JsonElement geometry));
+            Assert.IsTrue(geometry.GetProperty("ClientWidth").GetInt32() >= screenshotResult.GetProperty("Width").GetInt32());
+            Assert.IsTrue(geometry.GetProperty("ClientHeight").GetInt32() >= screenshotResult.GetProperty("Height").GetInt32());
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+
+            if (File.Exists(targetPath)) {
+                File.Delete(targetPath);
+            }
+
+            if (Directory.Exists(artifactDirectory)) {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP can move a live window, return screenshot artifacts, and verify the new geometry.
+    /// </summary>
+    public void McpServer_NotepadWindowMutationRoundTrip_MovesWindowAndVerifiesGeometry() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            int requestId = 2;
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "window mutation");
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Notepad window to expose a handle.");
+
+            JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(initialGeometryResult.ValueKind == JsonValueKind.Array && initialGeometryResult.GetArrayLength() == 1);
+            JsonElement initialGeometry = initialGeometryResult[0];
+
+            int initialLeft = initialGeometry.GetProperty("WindowLeft").GetInt32();
+            int initialTop = initialGeometry.GetProperty("WindowTop").GetInt32();
+            int initialWidth = initialGeometry.GetProperty("WindowWidth").GetInt32();
+            int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
+            int targetLeft = initialLeft >= 40 ? initialLeft - 20 : initialLeft + 20;
+            int targetTop = initialTop >= 40 ? initialTop - 20 : initialTop + 20;
+
+            JsonElement moveResult = client.CallTool(requestId++, "move_window", new {
+                handle = windowHandle,
+                x = targetLeft,
+                y = targetTop,
+                width = initialWidth,
+                height = initialHeight,
+                captureAfter = true,
+                artifactDirectory
+            });
+
+            Assert.IsTrue(moveResult.GetProperty("Success").GetBoolean());
+            Assert.IsTrue(moveResult.GetProperty("Count").GetInt32() >= 1);
+            AssertScreenshotPathsExist(moveResult.GetProperty("AfterScreenshots"));
+
+            JsonElement finalGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(finalGeometryResult.ValueKind == JsonValueKind.Array && finalGeometryResult.GetArrayLength() == 1);
+            JsonElement finalGeometry = finalGeometryResult[0];
+
+            AssertIntWithinTolerance(targetLeft, finalGeometry.GetProperty("WindowLeft").GetInt32(), 10, "Moved window left position");
+            AssertIntWithinTolerance(targetTop, finalGeometry.GetProperty("WindowTop").GetInt32(), 10, "Moved window top position");
+            AssertIntWithinTolerance(initialWidth, finalGeometry.GetProperty("WindowWidth").GetInt32(), 10, "Moved window width");
+            AssertIntWithinTolerance(initialHeight, finalGeometry.GetProperty("WindowHeight").GetInt32(), 10, "Moved window height");
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+
+            if (Directory.Exists(artifactDirectory)) {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP can run a higher-level workflow against a live Notepad window and return structured evidence.
+    /// </summary>
+    public void McpServer_NotepadWorkflowRoundTrip_PreparesForCodingAndCapturesArtifact() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            int requestId = 2;
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "workflow");
+            string launchedWindowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched Notepad window to expose a handle.");
+
+            JsonElement workflowResult = client.CallTool(requestId++, "prepare_for_coding", new {
+                handle = launchedWindowHandle,
+                captureAfter = true,
+                artifactDirectory
+            });
+
+            Assert.IsTrue(workflowResult.GetProperty("Success").GetBoolean());
+            Assert.IsFalse(workflowResult.GetProperty("LayoutApplied").GetBoolean());
+            Assert.AreEqual("prepare-for-coding", workflowResult.GetProperty("Action").GetString());
+            bool resolvedWindowMatched = workflowResult.TryGetProperty("ResolvedWindow", out JsonElement resolvedWindow) &&
+                resolvedWindow.ValueKind == JsonValueKind.Object &&
+                resolvedWindow.GetProperty("ProcessId").GetInt32() == resolvedProcessId &&
+                string.Equals(launchedWindowHandle, resolvedWindow.GetProperty("Handle").GetString(), StringComparison.OrdinalIgnoreCase);
+
+            bool focusedWindowMatched = false;
+            if (workflowResult.TryGetProperty("FocusedWindow", out JsonElement focusedWindow) && focusedWindow.ValueKind == JsonValueKind.Object) {
+                focusedWindowMatched =
+                    focusedWindow.GetProperty("ProcessId").GetInt32() == resolvedProcessId &&
+                    string.Equals(launchedWindowHandle, focusedWindow.GetProperty("Handle").GetString(), StringComparison.OrdinalIgnoreCase);
+            }
+
+            JsonElement notes = workflowResult.GetProperty("Notes");
+            bool hasNotes = notes.ValueKind == JsonValueKind.Array && notes.GetArrayLength() > 0;
+            Assert.IsTrue(resolvedWindowMatched || focusedWindowMatched || hasNotes, "Expected the workflow to return either resolved/focused window evidence or explanatory notes.");
+            AssertScreenshotPathsExist(workflowResult.GetProperty("AfterScreenshots"));
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+
+            if (Directory.Exists(artifactDirectory)) {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP process allowlists permit a scoped live Notepad mutation when both process name and exact handle are supplied.
+    /// </summary>
+    public void McpServer_NotepadAllowedProcessPolicy_AllowsScopedMoveWindowMutation() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process notepad");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            int requestId = 2;
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "allowed-process policy");
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Notepad window to expose a handle.");
+
+            JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(initialGeometryResult.ValueKind == JsonValueKind.Array && initialGeometryResult.GetArrayLength() == 1);
+            JsonElement initialGeometry = initialGeometryResult[0];
+
+            int initialLeft = initialGeometry.GetProperty("WindowLeft").GetInt32();
+            int initialTop = initialGeometry.GetProperty("WindowTop").GetInt32();
+            int initialWidth = initialGeometry.GetProperty("WindowWidth").GetInt32();
+            int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
+            int targetLeft = initialLeft >= 60 ? initialLeft - 30 : initialLeft + 30;
+            int targetTop = initialTop >= 60 ? initialTop - 30 : initialTop + 30;
+
+            JsonElement moveResult = client.CallTool(requestId++, "move_window", new {
+                processName = "notepad",
+                handle = windowHandle,
+                x = targetLeft,
+                y = targetTop,
+                width = initialWidth,
+                height = initialHeight,
+                captureAfter = true,
+                artifactDirectory
+            });
+
+            Assert.IsTrue(moveResult.GetProperty("Success").GetBoolean());
+            Assert.IsTrue(moveResult.GetProperty("Count").GetInt32() >= 1);
+            AssertScreenshotPathsExist(moveResult.GetProperty("AfterScreenshots"));
+
+            JsonElement finalGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(finalGeometryResult.ValueKind == JsonValueKind.Array && finalGeometryResult.GetArrayLength() == 1);
+            JsonElement finalGeometry = finalGeometryResult[0];
+
+            AssertIntWithinTolerance(targetLeft, finalGeometry.GetProperty("WindowLeft").GetInt32(), 10, "Allowed-policy moved window left position");
+            AssertIntWithinTolerance(targetTop, finalGeometry.GetProperty("WindowTop").GetInt32(), 10, "Allowed-policy moved window top position");
+            AssertIntWithinTolerance(initialWidth, finalGeometry.GetProperty("WindowWidth").GetInt32(), 10, "Allowed-policy moved window width");
+            AssertIntWithinTolerance(initialHeight, finalGeometry.GetProperty("WindowHeight").GetInt32(), 10, "Allowed-policy moved window height");
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+
+            if (Directory.Exists(artifactDirectory)) {
+                Directory.Delete(artifactDirectory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP denied-process filters block a scoped live Notepad window mutation without changing geometry.
+    /// </summary>
+    public void McpServer_NotepadDeniedProcessPolicy_BlocksScopedMoveWindowMutation() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --deny-process notepad");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+
+            int requestId = 2;
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "denied-process policy");
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the denied-policy Notepad window to expose a handle.");
+
+            JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(initialGeometryResult.ValueKind == JsonValueKind.Array && initialGeometryResult.GetArrayLength() == 1);
+            JsonElement initialGeometry = initialGeometryResult[0];
+
+            int initialLeft = initialGeometry.GetProperty("WindowLeft").GetInt32();
+            int initialTop = initialGeometry.GetProperty("WindowTop").GetInt32();
+            int initialWidth = initialGeometry.GetProperty("WindowWidth").GetInt32();
+            int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
+
+            JsonElement toolError = client.CallToolExpectError(requestId++, "move_window", new {
+                processName = "notepad",
+                handle = windowHandle,
+                x = initialLeft + 40,
+                y = initialTop + 40,
+                width = initialWidth,
+                height = initialHeight
+            });
+            StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "denied-process policy");
+
+            JsonElement finalGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(finalGeometryResult.ValueKind == JsonValueKind.Array && finalGeometryResult.GetArrayLength() == 1);
+            JsonElement finalGeometry = finalGeometryResult[0];
+
+            AssertIntWithinTolerance(initialLeft, finalGeometry.GetProperty("WindowLeft").GetInt32(), 5, "Denied-policy blocked window left position");
+            AssertIntWithinTolerance(initialTop, finalGeometry.GetProperty("WindowTop").GetInt32(), 5, "Denied-policy blocked window top position");
+            AssertIntWithinTolerance(initialWidth, finalGeometry.GetProperty("WindowWidth").GetInt32(), 5, "Denied-policy blocked window width");
+            AssertIntWithinTolerance(initialHeight, finalGeometry.GetProperty("WindowHeight").GetInt32(), 5, "Denied-policy blocked window height");
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures MCP dry-run mode previews a scoped live Notepad window mutation without changing geometry.
+    /// </summary>
+    public void McpServer_NotepadDryRunPolicy_PreviewsScopedMoveWindowMutationWithoutChangingGeometry() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireDesktopChanges();
+
+        int launcherProcessId = 0;
+        int resolvedProcessId = 0;
+
+        try {
+            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+
+            using var client = McpTestClient.Start("mcp serve --dry-run --allow-process notepad");
+            JsonElement initializeResult = client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+            Assert.IsTrue(initializeResult.GetProperty("safetyPolicy").GetProperty("dryRun").GetBoolean());
+
+            int requestId = 2;
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "dry-run policy");
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the dry-run Notepad window to expose a handle.");
+
+            JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(initialGeometryResult.ValueKind == JsonValueKind.Array && initialGeometryResult.GetArrayLength() == 1);
+            JsonElement initialGeometry = initialGeometryResult[0];
+
+            int initialLeft = initialGeometry.GetProperty("WindowLeft").GetInt32();
+            int initialTop = initialGeometry.GetProperty("WindowTop").GetInt32();
+            int initialWidth = initialGeometry.GetProperty("WindowWidth").GetInt32();
+            int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
+
+            JsonElement dryRunResult = client.CallTool(requestId++, "move_window", new {
+                processName = "notepad",
+                handle = windowHandle,
+                x = initialLeft + 40,
+                y = initialTop + 40,
+                width = initialWidth,
+                height = initialHeight
+            });
+
+            Assert.IsTrue(dryRunResult.GetProperty("dryRun").GetBoolean());
+            Assert.IsFalse(dryRunResult.GetProperty("applied").GetBoolean());
+            Assert.AreEqual("move_window", dryRunResult.GetProperty("toolName").GetString());
+            Assert.AreEqual("dry-run", dryRunResult.GetProperty("safetyMode").GetString());
+            Assert.AreEqual("notepad", dryRunResult.GetProperty("requestedProcesses")[0].GetString());
+
+            JsonElement finalGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
+                handle = windowHandle
+            });
+            Assert.IsTrue(finalGeometryResult.ValueKind == JsonValueKind.Array && finalGeometryResult.GetArrayLength() == 1);
+            JsonElement finalGeometry = finalGeometryResult[0];
+
+            AssertIntWithinTolerance(initialLeft, finalGeometry.GetProperty("WindowLeft").GetInt32(), 5, "Dry-run preserved window left position");
+            AssertIntWithinTolerance(initialTop, finalGeometry.GetProperty("WindowTop").GetInt32(), 5, "Dry-run preserved window top position");
+            AssertIntWithinTolerance(initialWidth, finalGeometry.GetProperty("WindowWidth").GetInt32(), 5, "Dry-run preserved window width");
+            AssertIntWithinTolerance(initialHeight, finalGeometry.GetProperty("WindowHeight").GetInt32(), 5, "Dry-run preserved window height");
+        } finally {
+            KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    [TestCategory("ExperimentalUITest")]
+    /// <summary>
+    /// Ensures the live Edge omnibox key path is blocked when foreground-input fallback is requested without server opt-in.
+    /// </summary>
+    public void McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireExperimentalDesktopChanges();
+
+        string edgePath = RequireEdgeExecutablePath();
+        string profileDirectory = CreateTemporaryDirectory("DesktopManager-EdgeProfile-");
+        string diagnosticDirectory = CreateTemporaryDirectory(Path.Combine("DesktopManager.Tests", "McpE2E", "Experimental", "Edge-Blocked-"));
+        string windowTargetName = "McpServerEndToEnd-EdgeOmniboxWindow-" + Guid.NewGuid().ToString("N");
+        string windowTargetPath = DesktopStateStore.GetTargetPath(windowTargetName);
+        string controlTargetName = "McpServerEndToEnd-EdgeOmniboxControl-" + Guid.NewGuid().ToString("N");
+        string controlTargetPath = DesktopStateStore.GetControlTargetPath(controlTargetName);
+        string startTitle = "Foreground Fallback Start " + Guid.NewGuid().ToString("N");
+        string targetTitle = "Foreground Fallback Target " + Guid.NewGuid().ToString("N");
+        string startPagePath = CreateForegroundFallbackPage(startTitle);
+        string targetPagePath = CreateForegroundFallbackPage(targetTitle);
+        Process? edgeProcess = null;
+        int resolvedProcessId = 0;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process msedge");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+            int requestId = 2;
+            SaveEdgeOmniboxTarget(client, ref requestId, windowTargetName);
+            SaveEdgeOmniboxControlTarget(client, ref requestId, controlTargetName);
+
+            edgeProcess = LaunchEdgeProcess(edgePath, profileDirectory, BuildFileUrl(startPagePath));
+
+            JsonElement waitResult = client.CallTool(requestId++, "wait_for_window", new {
+                processName = "msedge",
+                windowTitle = "*" + startTitle + "*",
+                timeoutMs = EdgeLaunchTimeoutMs,
+                intervalMs = 200
+            });
+
+            Assert.IsTrue(waitResult.GetProperty("Count").GetInt32() >= 1, "Expected the sacrificial Edge start page window to appear.");
+            JsonElement launchedWindow = waitResult.GetProperty("Windows")[0];
+            resolvedProcessId = launchedWindow.GetProperty("ProcessId").GetInt32();
+            Assert.IsTrue(resolvedProcessId > 0);
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Edge window to expose a handle.");
+
+            WaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName);
+
+            JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
+                processName = "msedge",
+                windowHandle,
+                targetName = controlTargetName,
+                text = BuildFileUrl(targetPagePath)
+            });
+            Assert.IsTrue(setTextResult.GetProperty("Success").GetBoolean());
+
+            JsonElement toolError = client.CallToolExpectError(requestId++, "send_control_keys", new {
+                processName = "msedge",
+                windowHandle,
+                targetName = controlTargetName,
+                allowForegroundInput = true,
+                keys = new[] { "VK_RETURN" }
+            });
+            StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "--allow-foreground-input");
+        } finally {
+            TestHelper.SafeKillProcess(edgeProcess);
+            TryDeleteFile(startPagePath);
+            TryDeleteFile(targetPagePath);
+            TryDeleteDirectory(profileDirectory);
+            TryDeleteDirectory(diagnosticDirectory);
+            TryDeleteFile(windowTargetPath);
+            TryDeleteFile(controlTargetPath);
+            KillProcessById(resolvedProcessId);
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    [TestCategory("ExperimentalUITest")]
+    /// <summary>
+    /// Ensures the live Edge omnibox key path can navigate to a local page when both the MCP server and tool call explicitly opt into foreground-input fallback.
+    /// </summary>
+    public void McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        RequireNet8McpLiveHarness();
+        TestHelper.RequireExperimentalDesktopChanges();
+
+        string edgePath = RequireEdgeExecutablePath();
+        string profileDirectory = CreateTemporaryDirectory("DesktopManager-EdgeProfile-");
+        string diagnosticDirectory = CreateTemporaryDirectory(Path.Combine("DesktopManager.Tests", "McpE2E", "Experimental", "Edge-Allow-"));
+        string windowTargetName = "McpServerEndToEnd-EdgeOmniboxWindow-" + Guid.NewGuid().ToString("N");
+        string windowTargetPath = DesktopStateStore.GetTargetPath(windowTargetName);
+        string controlTargetName = "McpServerEndToEnd-EdgeOmniboxControl-" + Guid.NewGuid().ToString("N");
+        string controlTargetPath = DesktopStateStore.GetControlTargetPath(controlTargetName);
+        string startTitle = "Foreground Fallback Start " + Guid.NewGuid().ToString("N");
+        string targetTitle = "Foreground Fallback Target " + Guid.NewGuid().ToString("N");
+        string startPagePath = CreateForegroundFallbackPage(startTitle);
+        string targetPagePath = CreateForegroundFallbackPage(targetTitle);
+        Process? edgeProcess = null;
+        int resolvedProcessId = 0;
+        bool preserveDiagnostics = false;
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process msedge --allow-foreground-input");
+            client.SendRequest(1, "initialize", new {
+                protocolVersion = "2025-06-18"
+            });
+            int requestId = 2;
+            SaveEdgeOmniboxTarget(client, ref requestId, windowTargetName);
+            SaveEdgeOmniboxControlTarget(client, ref requestId, controlTargetName);
+
+            edgeProcess = LaunchEdgeProcess(edgePath, profileDirectory, BuildFileUrl(startPagePath));
+
+            JsonElement waitResult = client.CallTool(requestId++, "wait_for_window", new {
+                processName = "msedge",
+                windowTitle = "*" + startTitle + "*",
+                timeoutMs = EdgeLaunchTimeoutMs,
+                intervalMs = 200
+            });
+
+            Assert.IsTrue(waitResult.GetProperty("Count").GetInt32() >= 1, "Expected the sacrificial Edge start page window to appear.");
+            JsonElement launchedWindow = waitResult.GetProperty("Windows")[0];
+            resolvedProcessId = launchedWindow.GetProperty("ProcessId").GetInt32();
+            Assert.IsTrue(resolvedProcessId > 0);
+            string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Edge window to expose a handle.");
+
+            JsonElement focusResult = client.CallTool(requestId++, "focus_window", new {
+                processName = "msedge",
+                handle = windowHandle
+            });
+            Assert.IsTrue(focusResult.GetProperty("Success").GetBoolean());
+            var decisionTrace = new List<string> {
+                "Saved window target: " + windowTargetName,
+                "Saved control target: " + controlTargetName,
+                "Focused window handle: " + windowHandle
+            };
+            string targetUrl = BuildFileUrl(targetPagePath);
+            string? navigationSafetyMode = TryNavigateEdgeOmnibox(client, ref requestId, windowHandle, windowTargetName, controlTargetName, targetUrl, decisionTrace);
+            if (string.IsNullOrWhiteSpace(navigationSafetyMode)) {
+                preserveDiagnostics = true;
+                string bundlePath = CaptureEdgeForegroundDiagnostics(client, ref requestId, windowHandle, controlTargetName, diagnosticDirectory, decisionTrace);
+                Assert.Inconclusive($"Edge did not expose a reusable omnibox control through MCP in this session, so the experimental foreground-input success harness could not complete. Diagnostic bundle: {bundlePath}");
+            }
+
+            Assert.IsTrue(
+                navigationSafetyMode.IndexOf("foreground", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                string.Equals(navigationSafetyMode, "window-key-input", StringComparison.OrdinalIgnoreCase),
+                "Expected the Edge navigation safety mode to reflect either explicit foreground control input or the shared window-level key fallback.");
+            decisionTrace.Add("Navigation safety mode: " + navigationSafetyMode);
+
+            try {
+                JsonElement targetWindowWait = client.CallTool(requestId++, "wait_for_window", new {
+                    processName = "msedge",
+                    windowTitle = "*" + targetTitle + "*",
+                    timeoutMs = EdgeLaunchTimeoutMs,
+                    intervalMs = 200
+                });
+
+                Assert.IsTrue(targetWindowWait.GetProperty("Count").GetInt32() >= 1, "Expected Edge to navigate to the target page after explicit foreground-input opt-in.");
+                JsonElement targetWindow = targetWindowWait.GetProperty("Windows")[0];
+                Assert.AreEqual(resolvedProcessId, targetWindow.GetProperty("ProcessId").GetInt32(), "Expected the target page to reuse the same sacrificial Edge window process.");
+            } catch (AssertFailedException ex) {
+                preserveDiagnostics = true;
+                decisionTrace.Add("Navigation verification failed: " + ex.Message);
+                string bundlePath = CaptureEdgeForegroundDiagnostics(client, ref requestId, windowHandle, controlTargetName, diagnosticDirectory, decisionTrace);
+                Assert.Inconclusive($"Edge accepted the experimental input path but did not complete navigation reliably in this session. Diagnostic bundle: {bundlePath}. Failure: {ex.Message}");
+            }
+        } finally {
+            TestHelper.SafeKillProcess(edgeProcess);
+            TryDeleteFile(startPagePath);
+            TryDeleteFile(targetPagePath);
+            TryDeleteDirectory(profileDirectory);
+            if (!preserveDiagnostics) {
+                TryDeleteDirectory(diagnosticDirectory);
+            }
+            TryDeleteFile(windowTargetPath);
+            TryDeleteFile(controlTargetPath);
+            KillProcessById(resolvedProcessId);
+        }
+    }
+
+    private static int ReadResolvedProcessId(JsonElement launchResult) {
+        JsonElement resolvedProcessId = launchResult.GetProperty("ResolvedProcessId");
+        if (resolvedProcessId.ValueKind == JsonValueKind.Number) {
+            return resolvedProcessId.GetInt32();
+        }
+
+        return launchResult.GetProperty("ProcessId").GetInt32();
+    }
+
+    private static void LaunchNotepadProcess(out int launcherProcessId, out int resolvedProcessId) {
+        var automation = new DesktopAutomationService();
+        DesktopProcessLaunchInfo launch = automation.LaunchProcess(new DesktopProcessStartOptions {
+            FilePath = "notepad.exe",
+            WaitForInputIdleMilliseconds = 5000,
+            WaitForWindowMilliseconds = NotepadLaunchTimeoutMs,
+            WaitForWindowIntervalMilliseconds = 100,
+            RequireWindow = true
+        });
+
+        launcherProcessId = launch.ProcessId;
+        resolvedProcessId = launch.ResolvedProcessId ?? launch.ProcessId;
+        Assert.IsTrue(launcherProcessId > 0, "Expected direct Notepad setup to return a launcher process id.");
+        Assert.IsTrue(resolvedProcessId > 0, "Expected direct Notepad setup to resolve the live window process.");
+        Assert.IsNotNull(launch.MainWindow, "Expected direct Notepad setup to resolve a visible window.");
+    }
+
+    private static void RequireNet8McpLiveHarness() {
+#if NET472
+        Assert.Inconclusive("Live MCP desktop harness runs only under net8.0-windows to avoid driving the same desktop twice through the shared net8 CLI executable.");
+#endif
+    }
+
+    private static string RequireEdgeExecutablePath() {
+        string[] candidates = {
+            @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+            @"C:\Program Files\Microsoft\Edge\Application\msedge.exe"
+        };
+
+        foreach (string candidate in candidates) {
+            if (File.Exists(candidate)) {
+                return candidate;
+            }
+        }
+
+        Assert.Inconclusive("Microsoft Edge was not found on this machine, so the live foreground-input MCP harness cannot run.");
+        return string.Empty;
+    }
+
+    private static string CreateTemporaryDirectory(string prefix) {
+        string path = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string CreateForegroundFallbackPage(string title) {
+        string path = Path.Combine(Path.GetTempPath(), "DesktopManager-ForegroundFallback-" + Guid.NewGuid().ToString("N") + ".html");
+        string html = @"<!doctype html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <title>" + title + @"</title>
+</head>
+<body style=""font-family:Segoe UI;padding:24px"">
+    <h1>" + title + @"</h1>
+    <textarea id=""editor"" autofocus style=""width:900px;height:260px"">seed</textarea>
+    <script>
+        window.addEventListener('load', function () {
+            var editor = document.getElementById('editor');
+            if (editor) {
+                editor.focus();
+            }
+        });
+    </script>
+</body>
+</html>";
+        File.WriteAllText(path, html);
+        return path;
+    }
+
+    private static string BuildFileUrl(string path) {
+        return new Uri(path).AbsoluteUri;
+    }
+
+    private static string BuildEdgeArguments(string profileDirectory, string url) {
+        return $"--user-data-dir=\"{profileDirectory}\" --no-first-run --new-window {url}";
+    }
+
+    private static Process? LaunchEdgeProcess(string edgePath, string profileDirectory, string url) {
+        var startInfo = new ProcessStartInfo(edgePath, BuildEdgeArguments(profileDirectory, url)) {
+            UseShellExecute = true
+        };
+
+        return Process.Start(startInfo);
+    }
+
+    private static void WaitForEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, int timeoutMilliseconds = EdgeControlDiscoveryTimeoutMs) {
+        if (TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, timeoutMilliseconds)) {
+            return;
+        }
+
+        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for the Edge omnibox control to be discoverable through MCP.");
+    }
+
+    private static bool TryWaitForEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, int timeoutMilliseconds) {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds) {
+            JsonElement controls = GetEdgeOmniboxControls(client, ref requestId, windowHandle, controlTargetName);
+            if (controls.ValueKind == JsonValueKind.Array && controls.GetArrayLength() > 0) {
+                return true;
+            }
+
+            System.Threading.Thread.Sleep(100);
+        }
+
+        return false;
+    }
+
+    private static string? TryNavigateEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string windowTargetName, string controlTargetName, string targetUrl, IList<string> decisionTrace) {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            try {
+                decisionTrace.Add($"Attempt {attempt + 1}: start");
+                if (!TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeControlDiscoveryTimeoutMs)) {
+                    decisionTrace.Add($"Attempt {attempt + 1}: named control target not resolved within {EdgeControlDiscoveryTimeoutMs}ms");
+                    ClickEdgeOmniboxFallbackPoint(client, ref requestId, windowHandle, windowTargetName);
+                    decisionTrace.Add($"Attempt {attempt + 1}: clicked named window target fallback {windowTargetName}");
+                    WaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeLaunchTimeoutMs);
+                    decisionTrace.Add($"Attempt {attempt + 1}: named control target resolved after fallback click");
+                } else {
+                    decisionTrace.Add($"Attempt {attempt + 1}: named control target resolved without fallback");
+                }
+
+                JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
+                    processName = "msedge",
+                    windowHandle,
+                    targetName = controlTargetName,
+                    allowForegroundInput = true,
+                    text = targetUrl
+                });
+                Assert.IsTrue(setTextResult.GetProperty("Success").GetBoolean(), "Expected Edge omnibox text entry to succeed once foreground-input fallback is explicitly allowed.");
+                decisionTrace.Add($"Attempt {attempt + 1}: set_control_text succeeded with safety mode {setTextResult.GetProperty("SafetyMode").GetString()}");
+
+                bool controlAvailableAfterText = TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeControlDiscoveryTimeoutMs);
+                if (!controlAvailableAfterText) {
+                    decisionTrace.Add($"Attempt {attempt + 1}: named control target disappeared after text entry");
+                    ClickEdgeOmniboxFallbackPoint(client, ref requestId, windowHandle, windowTargetName);
+                    decisionTrace.Add($"Attempt {attempt + 1}: clicked named window target fallback after text entry");
+                    JsonElement sendWindowKeysResult = client.CallTool(requestId++, "send_window_keys", new {
+                        processName = "msedge",
+                        handle = windowHandle,
+                        keys = new[] { "VK_RETURN" },
+                        activate = true
+                    });
+
+                    Assert.IsTrue(sendWindowKeysResult.GetProperty("Success").GetBoolean(), "Expected the window-level Edge Enter fallback to succeed after omnibox text entry.");
+                    decisionTrace.Add($"Attempt {attempt + 1}: send_window_keys fallback succeeded with safety mode {sendWindowKeysResult.GetProperty("SafetyMode").GetString()}");
+                    return sendWindowKeysResult.GetProperty("SafetyMode").GetString();
+                } else {
+                    decisionTrace.Add($"Attempt {attempt + 1}: named control target remained available after text entry");
+                }
+
+                JsonElement sendKeysResult = client.CallTool(requestId++, "send_control_keys", new {
+                    processName = "msedge",
+                    windowHandle,
+                    targetName = controlTargetName,
+                    allowForegroundInput = true,
+                    keys = new[] { "VK_RETURN" }
+                });
+
+                Assert.IsTrue(sendKeysResult.GetProperty("Success").GetBoolean(), "Expected Edge omnibox Enter to succeed once foreground-input fallback is explicitly allowed.");
+                decisionTrace.Add($"Attempt {attempt + 1}: send_control_keys succeeded with safety mode {sendKeysResult.GetProperty("SafetyMode").GetString()}");
+                return sendKeysResult.GetProperty("SafetyMode").GetString();
+            } catch (AssertFailedException) when (attempt < 2) {
+                decisionTrace.Add($"Attempt {attempt + 1}: assertion failed, retrying");
+                System.Threading.Thread.Sleep(500);
+            } catch (AssertFailedException) {
+                decisionTrace.Add($"Attempt {attempt + 1}: assertion failed, giving up");
+                return null;
+            }
+        }
+
+        decisionTrace.Add("Navigation failed after all attempts");
+        return null;
+    }
+
+    private static void ClickEdgeOmniboxFallbackPoint(McpTestClient client, ref int requestId, string windowHandle, string targetName) {
+        JsonElement clickResult = client.CallTool(requestId++, "click_window_point", new {
+            processName = "msedge",
+            handle = windowHandle,
+            targetName,
+            activate = true,
+            clientArea = false
+        });
+        Assert.IsTrue(clickResult.GetProperty("Success").GetBoolean(), "Expected the geometry-assisted Edge omnibox fallback click to succeed.");
+        System.Threading.Thread.Sleep(250);
+    }
+
+    private static void SaveEdgeOmniboxTarget(McpTestClient client, ref int requestId, string targetName) {
+        JsonElement saveTargetResult = client.CallTool(requestId++, "save_window_target", new {
+            name = targetName,
+            description = "Experimental Edge omnibox fallback point",
+            xRatio = EdgeOmniboxFallbackXRatio,
+            yRatio = EdgeOmniboxFallbackYRatio,
+            clientArea = false
+        });
+        Assert.AreEqual(targetName, saveTargetResult.GetProperty("Name").GetString());
+    }
+
+    private static void SaveEdgeOmniboxControlTarget(McpTestClient client, ref int requestId, string targetName) {
+        JsonElement saveResult = client.CallTool(requestId++, "save_control_target", new {
+            name = targetName,
+            description = "Experimental Edge omnibox control",
+            controlClassName = "OmniboxViewViews",
+            controlType = "Edit",
+            controlText = "Address and search bar",
+            isKeyboardFocusable = true,
+            supportsForegroundInputFallback = true,
+            uiAutomation = true
+        });
+        Assert.AreEqual(targetName, saveResult.GetProperty("Name").GetString());
+    }
+
+    private static string CaptureEdgeForegroundDiagnostics(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, string diagnosticDirectory, IReadOnlyList<string>? decisionTrace = null) {
+        Directory.CreateDirectory(diagnosticDirectory);
+
+        string screenshotPath = Path.Combine(diagnosticDirectory, "edge-window.png");
+        JsonElement screenshotResult = client.CallTool(requestId++, "screenshot_window", new {
+            processName = "msedge",
+            windowHandle,
+            outputPath = screenshotPath
+        });
+
+        JsonElement diagnostics = client.CallTool(requestId++, "diagnose_window_controls", new {
+            processName = "msedge",
+            windowHandle,
+            targetName = controlTargetName,
+            sampleLimit = 10
+        });
+
+        JsonElement controls = GetEdgeOmniboxControls(client, ref requestId, windowHandle, controlTargetName);
+
+        File.WriteAllText(Path.Combine(diagnosticDirectory, "screenshot.json"), JsonSerializer.Serialize(JsonDocument.Parse(screenshotResult.GetRawText()).RootElement, new JsonSerializerOptions {
+            WriteIndented = true
+        }));
+        File.WriteAllText(Path.Combine(diagnosticDirectory, "diagnostics.json"), JsonSerializer.Serialize(JsonDocument.Parse(diagnostics.GetRawText()).RootElement, new JsonSerializerOptions {
+            WriteIndented = true
+        }));
+        File.WriteAllText(Path.Combine(diagnosticDirectory, "controls.json"), JsonSerializer.Serialize(JsonDocument.Parse(controls.GetRawText()).RootElement, new JsonSerializerOptions {
+            WriteIndented = true
+        }));
+        if (decisionTrace != null && decisionTrace.Count > 0) {
+            File.WriteAllLines(Path.Combine(diagnosticDirectory, "decision-trace.txt"), decisionTrace);
+        }
+        WriteEdgeForegroundComparisonReport(diagnosticDirectory);
+
+        return diagnosticDirectory;
+    }
+
+    private static void WriteEdgeForegroundComparisonReport(string diagnosticDirectory) {
+        string? familyPrefix = GetEdgeDiagnosticFamilyPrefix(diagnosticDirectory);
+        if (string.IsNullOrWhiteSpace(familyPrefix)) {
+            return;
+        }
+
+        string parentDirectory = Path.GetDirectoryName(diagnosticDirectory) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(parentDirectory) || !Directory.Exists(parentDirectory)) {
+            return;
+        }
+
+        DirectoryInfo? previousBundle = new DirectoryInfo(parentDirectory)
+            .EnumerateDirectories(familyPrefix + "*", SearchOption.TopDirectoryOnly)
+            .Where(directory => !string.Equals(directory.FullName, diagnosticDirectory, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(directory => directory.LastWriteTimeUtc)
+            .FirstOrDefault();
+
+        var summaryLines = new List<string> {
+            "Current bundle: " + diagnosticDirectory
+        };
+
+        if (previousBundle == null) {
+            summaryLines.Add("Previous bundle: none");
+            File.WriteAllLines(Path.Combine(diagnosticDirectory, "comparison.txt"), summaryLines);
+            return;
+        }
+
+        summaryLines.Add("Previous bundle: " + previousBundle.FullName);
+
+        EdgeDiagnosticSnapshot currentSnapshot = ReadEdgeDiagnosticSnapshot(diagnosticDirectory);
+        EdgeDiagnosticSnapshot previousSnapshot = ReadEdgeDiagnosticSnapshot(previousBundle.FullName);
+
+        summaryLines.Add(string.Format("Matched controls: current {0}, previous {1}, delta {2}", currentSnapshot.MatchedControlCount, previousSnapshot.MatchedControlCount, currentSnapshot.MatchedControlCount - previousSnapshot.MatchedControlCount));
+        summaryLines.Add(string.Format("Effective controls: current {0}, previous {1}, delta {2}", currentSnapshot.EffectiveControlCount, previousSnapshot.EffectiveControlCount, currentSnapshot.EffectiveControlCount - previousSnapshot.EffectiveControlCount));
+        summaryLines.Add(string.Format("Listed controls: current {0}, previous {1}, delta {2}", currentSnapshot.ListedControlCount, previousSnapshot.ListedControlCount, currentSnapshot.ListedControlCount - previousSnapshot.ListedControlCount));
+        summaryLines.Add(string.Format("Elapsed milliseconds: current {0}, previous {1}, delta {2}", currentSnapshot.ElapsedMilliseconds, previousSnapshot.ElapsedMilliseconds, currentSnapshot.ElapsedMilliseconds - previousSnapshot.ElapsedMilliseconds));
+        summaryLines.Add("Preferred root handle: current " + currentSnapshot.PreferredRootHandle + ", previous " + previousSnapshot.PreferredRootHandle);
+        summaryLines.Add("Preferred root reused: current " + currentSnapshot.UsedPreferredRoot + ", previous " + previousSnapshot.UsedPreferredRoot);
+        summaryLines.Add("Cached controls reused: current " + currentSnapshot.UsedCachedControls + ", previous " + previousSnapshot.UsedCachedControls);
+        summaryLines.Add("First listed control: current " + currentSnapshot.FirstListedControlSummary + ", previous " + previousSnapshot.FirstListedControlSummary);
+        summaryLines.Add("Sample control classes: current " + currentSnapshot.SampleControlClasses + ", previous " + previousSnapshot.SampleControlClasses);
+
+        File.WriteAllLines(Path.Combine(diagnosticDirectory, "comparison.txt"), summaryLines);
+    }
+
+    private static string? GetEdgeDiagnosticFamilyPrefix(string diagnosticDirectory) {
+        string name = Path.GetFileName(diagnosticDirectory);
+        if (name.StartsWith("Edge-Allow-", StringComparison.OrdinalIgnoreCase)) {
+            return "Edge-Allow-";
+        }
+
+        if (name.StartsWith("Edge-Blocked-", StringComparison.OrdinalIgnoreCase)) {
+            return "Edge-Blocked-";
+        }
+
+        return null;
+    }
+
+    private static EdgeDiagnosticSnapshot ReadEdgeDiagnosticSnapshot(string diagnosticDirectory) {
+        string diagnosticsPath = Path.Combine(diagnosticDirectory, "diagnostics.json");
+        string controlsPath = Path.Combine(diagnosticDirectory, "controls.json");
+        var snapshot = new EdgeDiagnosticSnapshot();
+
+        if (File.Exists(diagnosticsPath)) {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(diagnosticsPath));
+            if (document.RootElement.ValueKind == JsonValueKind.Array && document.RootElement.GetArrayLength() > 0) {
+                JsonElement diagnostic = document.RootElement[0];
+                snapshot.MatchedControlCount = ReadOptionalInt32(diagnostic, "MatchedControlCount");
+                snapshot.EffectiveControlCount = ReadOptionalInt32(diagnostic, "EffectiveControlCount");
+                snapshot.ElapsedMilliseconds = ReadOptionalInt32(diagnostic, "ElapsedMilliseconds");
+                snapshot.PreferredRootHandle = ReadOptionalString(diagnostic, "PreferredUiAutomationRootHandle");
+                snapshot.UsedPreferredRoot = ReadOptionalBoolean(diagnostic, "UsedPreferredUiAutomationRoot");
+                snapshot.UsedCachedControls = ReadOptionalBoolean(diagnostic, "UsedCachedUiAutomationControls");
+                snapshot.SampleControlClasses = ReadSampleControlClasses(diagnostic);
+            }
+        }
+
+        if (File.Exists(controlsPath)) {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(controlsPath));
+            if (document.RootElement.ValueKind == JsonValueKind.Array) {
+                snapshot.ListedControlCount = document.RootElement.GetArrayLength();
+                if (snapshot.ListedControlCount > 0) {
+                    JsonElement firstControl = document.RootElement[0];
+                    snapshot.FirstListedControlSummary = string.Format(
+                        "{0} / {1} / {2}",
+                        ReadOptionalString(firstControl, "ClassName"),
+                        ReadOptionalString(firstControl, "ControlType"),
+                        ReadOptionalString(firstControl, "AutomationId"));
+                }
+            }
+        }
+
+        return snapshot;
+    }
+
+    private static int ReadOptionalInt32(JsonElement element, string propertyName) {
+        if (element.TryGetProperty(propertyName, out JsonElement value) && value.ValueKind == JsonValueKind.Number) {
+            return value.GetInt32();
+        }
+
+        return 0;
+    }
+
+    private static bool ReadOptionalBoolean(JsonElement element, string propertyName) {
+        if (element.TryGetProperty(propertyName, out JsonElement value) && (value.ValueKind == JsonValueKind.True || value.ValueKind == JsonValueKind.False)) {
+            return value.GetBoolean();
+        }
+
+        return false;
+    }
+
+    private static string ReadOptionalString(JsonElement element, string propertyName) {
+        if (element.TryGetProperty(propertyName, out JsonElement value) && value.ValueKind == JsonValueKind.String) {
+            return value.GetString() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static string ReadSampleControlClasses(JsonElement diagnostic) {
+        if (!diagnostic.TryGetProperty("SampleControls", out JsonElement sampleControls) || sampleControls.ValueKind != JsonValueKind.Array) {
+            return string.Empty;
+        }
+
+        return string.Join(", ", sampleControls.EnumerateArray().Take(5).Select(control => ReadOptionalString(control, "ClassName")).Where(className => !string.IsNullOrWhiteSpace(className)));
+    }
+
+    private sealed class EdgeDiagnosticSnapshot {
+        public int MatchedControlCount { get; set; }
+        public int EffectiveControlCount { get; set; }
+        public int ListedControlCount { get; set; }
+        public int ElapsedMilliseconds { get; set; }
+        public string PreferredRootHandle { get; set; } = string.Empty;
+        public bool UsedPreferredRoot { get; set; }
+        public bool UsedCachedControls { get; set; }
+        public string FirstListedControlSummary { get; set; } = string.Empty;
+        public string SampleControlClasses { get; set; } = string.Empty;
+    }
+
+    private static JsonElement GetEdgeOmniboxControls(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName) {
+        JsonElement namedTargetControls = client.CallTool(requestId++, "list_window_controls", new {
+            processName = "msedge",
+            windowHandle,
+            targetName = controlTargetName
+        });
+        if (namedTargetControls.ValueKind == JsonValueKind.Array && namedTargetControls.GetArrayLength() > 0) {
+            return namedTargetControls;
+        }
+
+        JsonElement preferredControls = client.CallTool(requestId++, "list_window_controls", new {
+            processName = "msedge",
+            windowHandle,
+            controlClassName = "OmniboxViewViews",
+            controlType = "Edit",
+            controlText = "Address and search bar",
+            isKeyboardFocusable = true,
+            supportsForegroundInputFallback = true,
+            uiAutomation = true,
+            ensureForegroundWindow = true
+        });
+        if (preferredControls.ValueKind == JsonValueKind.Array && preferredControls.GetArrayLength() > 0) {
+            return preferredControls;
+        }
+
+        return client.CallTool(requestId++, "list_window_controls", new {
+            processName = "msedge",
+            windowHandle,
+            controlType = "Edit",
+            isKeyboardFocusable = true,
+            supportsForegroundInputFallback = true,
+            uiAutomation = true,
+            ensureForegroundWindow = true
+        });
+    }
+
+    private static JsonElement WaitForProcessWindow(McpTestClient client, ref int requestId, int processId, int timeoutMilliseconds, int intervalMilliseconds, string scenario) {
+        JsonElement windows = client.CallTool(requestId++, "wait_for_window", new {
+            processId,
+            timeoutMs = timeoutMilliseconds,
+            intervalMs = intervalMilliseconds
+        });
+        Assert.IsTrue(windows.GetProperty("Count").GetInt32() >= 1, $"Expected MCP to resolve a live window for the {scenario} scenario.");
+        return windows.GetProperty("Windows")[0];
+    }
+
+    private static void KillProcessById(int processId) {
+        if (processId <= 0) {
+            return;
+        }
+
+        try {
+            using Process process = Process.GetProcessById(processId);
+            TestHelper.SafeKillProcess(process);
+        } catch {
+            // Ignore cleanup failures for already exited processes.
+        }
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            if (Directory.Exists(path)) {
+                Directory.Delete(path, recursive: true);
+            }
+        } catch {
+            // Ignore cleanup failures for files still locked by the browser.
+        }
+    }
+
+    private static void TryDeleteFile(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch {
+            // Ignore cleanup failures for already removed files.
+        }
+    }
+
+    private static JsonElement FindEditableNotepadControl(JsonElement controls) {
+        if (TryFindEditableNotepadControl(controls, out JsonElement control)) {
+            return control;
+        }
+
+        Assert.Inconclusive("No editable Notepad control with background text support was exposed through MCP.");
+        return default;
+    }
+
+    private static JsonElement WaitForEditableNotepadControl(McpTestClient client, ref int requestId, string windowHandle, int timeoutMilliseconds, int intervalMilliseconds) {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds) {
+            JsonElement controls = client.CallTool(requestId++, "list_window_controls", new {
+                windowHandle,
+                includeUiAutomation = true,
+                ensureForegroundWindow = true
+            });
+            if (controls.ValueKind == JsonValueKind.Array &&
+                controls.GetArrayLength() > 0 &&
+                TryFindEditableNotepadControl(controls, out JsonElement control)) {
+                return control;
+            }
+
+            System.Threading.Thread.Sleep(intervalMilliseconds);
+        }
+
+        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for Notepad to expose an editable control through MCP.");
+        return default;
+    }
+
+    private static bool TryFindEditableNotepadControl(JsonElement controls, out JsonElement control) {
+        JsonElement? richEdit = null;
+        JsonElement? fallback = null;
+
+        foreach (JsonElement candidate in controls.EnumerateArray()) {
+            string className = candidate.GetProperty("ClassName").GetString() ?? string.Empty;
+            bool supportsBackgroundText = candidate.GetProperty("SupportsBackgroundText").GetBoolean();
+            if (!supportsBackgroundText) {
+                continue;
+            }
+
+            if (string.Equals(className, "RichEditD2DPT", StringComparison.OrdinalIgnoreCase)) {
+                richEdit = candidate.Clone();
+                break;
+            }
+
+            if (fallback == null &&
+                (string.Equals(className, "NotepadTextBox", StringComparison.OrdinalIgnoreCase) ||
+                 className.IndexOf("Edit", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                 className.IndexOf("TextBox", StringComparison.OrdinalIgnoreCase) >= 0)) {
+                fallback = candidate.Clone();
+            }
+        }
+
+        if (richEdit.HasValue) {
+            control = richEdit.Value;
+            return true;
+        }
+
+        if (fallback.HasValue) {
+            control = fallback.Value;
+            return true;
+        }
+
+        control = default;
+        return false;
+    }
+
+    private static void AssertScreenshotPathsExist(JsonElement screenshots) {
+        if (screenshots.ValueKind != JsonValueKind.Array) {
+            Assert.Fail("Expected screenshots to be returned as an array.");
+        }
+
+        Assert.IsTrue(screenshots.GetArrayLength() > 0, "Expected at least one screenshot artifact.");
+        foreach (JsonElement screenshot in screenshots.EnumerateArray()) {
+            string? path = screenshot.GetProperty("Path").GetString();
+            Assert.IsFalse(string.IsNullOrWhiteSpace(path), "Expected a non-empty artifact path.");
+            Assert.IsTrue(File.Exists(path), $"Expected artifact file to exist: {path}");
+        }
+    }
+
+    private static void AssertIntWithinTolerance(int expected, int actual, int tolerance, string label) {
+        int delta = Math.Abs(expected - actual);
+        Assert.IsTrue(delta <= tolerance, $"{label} expected {expected} but was {actual} (delta {delta}, tolerance {tolerance}).");
+    }
+}

--- a/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
@@ -719,11 +719,12 @@ public class McpServerEndToEndTests {
                 Assert.Inconclusive($"Edge did not expose a reusable omnibox control through MCP in this session, so the experimental foreground-input success harness could not complete. Diagnostic bundle: {bundlePath}");
             }
 
+            string resolvedNavigationSafetyMode = navigationSafetyMode!;
             Assert.IsTrue(
-                navigationSafetyMode.IndexOf("foreground", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                string.Equals(navigationSafetyMode, "window-key-input", StringComparison.OrdinalIgnoreCase),
+                resolvedNavigationSafetyMode.IndexOf("foreground", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                string.Equals(resolvedNavigationSafetyMode, "window-key-input", StringComparison.OrdinalIgnoreCase),
                 "Expected the Edge navigation safety mode to reflect either explicit foreground control input or the shared window-level key fallback.");
-            decisionTrace.Add("Navigation safety mode: " + navigationSafetyMode);
+            decisionTrace.Add("Navigation safety mode: " + resolvedNavigationSafetyMode);
 
             try {
                 JsonElement targetWindowWait = client.CallTool(requestId++, "wait_for_window", new {

--- a/Sources/DesktopManager.Tests/McpServerTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerTests.cs
@@ -1,0 +1,475 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Black-box tests for the DesktopManager MCP stdio server.
+/// </summary>
+public class McpServerTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the MCP transport advertises the expected tools, prompts, and resources.
+    /// </summary>
+    public void McpServer_InitializeAndListCatalog_ReturnsExpectedSurface() {
+        using var client = McpTestClient.Start();
+
+        JsonElement initializeResult = client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+        Assert.AreEqual("2025-06-18", initializeResult.GetProperty("protocolVersion").GetString());
+        JsonElement safetyPolicy = initializeResult.GetProperty("safetyPolicy");
+        Assert.IsTrue(safetyPolicy.GetProperty("readOnly").GetBoolean());
+        Assert.IsFalse(safetyPolicy.GetProperty("allowMutations").GetBoolean());
+        Assert.IsFalse(safetyPolicy.GetProperty("allowForegroundInput").GetBoolean());
+        Assert.IsFalse(safetyPolicy.GetProperty("dryRun").GetBoolean());
+        Assert.AreEqual(0, safetyPolicy.GetProperty("allowedProcesses").GetArrayLength());
+        Assert.AreEqual(0, safetyPolicy.GetProperty("deniedProcesses").GetArrayLength());
+        StringAssert.Contains(initializeResult.GetProperty("instructions").GetString() ?? string.Empty, "read-only");
+
+        JsonElement toolsResult = client.SendRequest(2, "tools/list");
+        HashSet<string> toolNames = toolsResult
+            .GetProperty("tools")
+            .EnumerateArray()
+            .Select(tool => tool.GetProperty("name").GetString() ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+        Dictionary<string, JsonElement> toolsByName = toolsResult
+            .GetProperty("tools")
+            .EnumerateArray()
+            .ToDictionary(
+                tool => tool.GetProperty("name").GetString() ?? string.Empty,
+                tool => tool.Clone(),
+                StringComparer.Ordinal);
+
+        Assert.IsTrue(toolNames.Contains("list_named_control_targets"));
+        Assert.IsTrue(toolNames.Contains("get_named_control_target"));
+        Assert.IsTrue(toolNames.Contains("save_control_target"));
+        Assert.IsTrue(toolNames.Contains("resolve_control_target"));
+        Assert.IsTrue(toolNames.Contains("diagnose_window_controls"));
+        Assert.IsTrue(toolNames.Contains("get_window_geometry"));
+        Assert.IsTrue(toolNames.Contains("assert_control_value"));
+        Assert.IsTrue(toolNames.Contains("assert_window_layout"));
+        Assert.IsTrue(toolNames.Contains("launch_and_wait_for_window"));
+        Assert.IsTrue(toolNames.Contains("send_window_keys"));
+        Assert.IsTrue(toolNames.Contains("prepare_for_coding"));
+        Assert.IsTrue(toolNames.Contains("prepare_for_screen_sharing"));
+        Assert.IsTrue(toolNames.Contains("clean_up_distractions"));
+        AssertToolHasArtifactProperties(toolsByName["move_window"]);
+        AssertToolHasArtifactProperties(toolsByName["focus_window"]);
+        AssertToolHasArtifactProperties(toolsByName["click_control"]);
+        AssertToolHasArtifactProperties(toolsByName["set_control_text"]);
+        AssertToolHasArtifactProperties(toolsByName["send_window_keys"]);
+        AssertToolHasArtifactProperties(toolsByName["launch_and_wait_for_window"]);
+        AssertToolHasArtifactProperties(toolsByName["prepare_for_coding"]);
+        AssertToolHasArtifactProperties(toolsByName["prepare_for_screen_sharing"]);
+        AssertToolHasArtifactProperties(toolsByName["clean_up_distractions"]);
+        AssertToolHasArtifactProperties(toolsByName["assert_window_layout"]);
+        AssertToolHasProperty(toolsByName["save_window_target"], "widthRatio");
+        AssertToolHasProperty(toolsByName["save_window_target"], "heightRatio");
+        AssertToolHasProperty(toolsByName["screenshot_window"], "targetName");
+        AssertToolHasProperty(toolsByName["launch_and_wait_for_window"], "timeoutMs");
+        AssertToolHasProperty(toolsByName["send_window_keys"], "keys");
+        AssertToolHasProperty(toolsByName["assert_window_layout"], "positionTolerancePx");
+
+        JsonElement promptsResult = client.SendRequest(3, "prompts/list");
+        HashSet<string> promptNames = promptsResult
+            .GetProperty("prompts")
+            .EnumerateArray()
+            .Select(prompt => prompt.GetProperty("name").GetString() ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.IsTrue(promptNames.Contains("prepare_for_coding"));
+        Assert.IsTrue(promptNames.Contains("prepare_for_screen_sharing"));
+        Assert.IsTrue(promptNames.Contains("clean_up_distractions"));
+
+        JsonElement resourcesResult = client.SendRequest(4, "resources/list");
+        HashSet<string> resourceUris = resourcesResult
+            .GetProperty("resources")
+            .EnumerateArray()
+            .Select(resource => resource.GetProperty("uri").GetString() ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.IsTrue(resourceUris.Contains("desktop://control-targets"));
+        Assert.IsTrue(resourceUris.Contains("desktop://targets"));
+        Assert.IsTrue(resourceUris.Contains("desktop://snapshot/current"));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures named window targets round-trip through the MCP tool surface.
+    /// </summary>
+    public void McpServer_SaveAndGetWindowTarget_RoundTripsDefinition() {
+        string targetName = "McpServerTests-Window-" + Guid.NewGuid().ToString("N");
+        string path = DesktopStateStore.GetTargetPath(targetName);
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+                ["protocolVersion"] = "2025-06-18"
+            });
+
+            JsonElement saveResult = client.CallTool(2, "save_window_target", new Dictionary<string, object?> {
+                ["name"] = targetName,
+                ["description"] = "Editor center",
+                ["xRatio"] = 0.5,
+                ["yRatio"] = 0.5,
+                ["widthRatio"] = 0.8,
+                ["heightRatio"] = 0.6,
+                ["clientArea"] = true
+            });
+
+            Assert.AreEqual(targetName, saveResult.GetProperty("Name").GetString());
+            Assert.IsTrue(File.Exists(path));
+
+            JsonElement getResult = client.CallTool(3, "get_named_target", new Dictionary<string, object?> {
+                ["name"] = targetName
+            });
+
+            JsonElement target = getResult.GetProperty("Target");
+            Assert.AreEqual(targetName, getResult.GetProperty("Name").GetString());
+            Assert.AreEqual("Editor center", target.GetProperty("Description").GetString());
+            Assert.AreEqual(0.5d, target.GetProperty("XRatio").GetDouble(), 0.0001d);
+            Assert.AreEqual(0.5d, target.GetProperty("YRatio").GetDouble(), 0.0001d);
+            Assert.AreEqual(0.8d, target.GetProperty("WidthRatio").GetDouble(), 0.0001d);
+            Assert.AreEqual(0.6d, target.GetProperty("HeightRatio").GetDouble(), 0.0001d);
+            Assert.IsTrue(target.GetProperty("ClientArea").GetBoolean());
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures named control targets round-trip through the MCP tool surface.
+    /// </summary>
+    public void McpServer_SaveAndGetControlTarget_RoundTripsDefinition() {
+        string targetName = "McpServerTests-Control-" + Guid.NewGuid().ToString("N");
+        string path = DesktopStateStore.GetControlTargetPath(targetName);
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+                ["protocolVersion"] = "2025-06-18"
+            });
+
+            JsonElement saveResult = client.CallTool(2, "save_control_target", new Dictionary<string, object?> {
+                ["name"] = targetName,
+                ["description"] = "Address bar",
+                ["controlType"] = "Edit",
+                ["supportsBackgroundText"] = true,
+                ["uiAutomation"] = true
+            });
+
+            Assert.AreEqual(targetName, saveResult.GetProperty("Name").GetString());
+            Assert.IsTrue(File.Exists(path));
+
+            JsonElement getResult = client.CallTool(3, "get_named_control_target", new Dictionary<string, object?> {
+                ["name"] = targetName
+            });
+
+            JsonElement target = getResult.GetProperty("Target");
+            Assert.AreEqual(targetName, getResult.GetProperty("Name").GetString());
+            Assert.AreEqual("Address bar", target.GetProperty("Description").GetString());
+            Assert.AreEqual("Edit", target.GetProperty("ControlTypePattern").GetString());
+            Assert.IsTrue(target.GetProperty("SupportsBackgroundText").GetBoolean());
+            Assert.IsTrue(target.GetProperty("UseUiAutomation").GetBoolean());
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures MCP prompts resolve through the stdio transport with the expected guidance text.
+    /// </summary>
+    public void McpServer_GetPrompt_ReturnsExpectedInstructions() {
+        using var client = McpTestClient.Start();
+        client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement promptResult = client.SendRequest(2, "prompts/get", new Dictionary<string, object?> {
+            ["name"] = "prepare_for_coding",
+            ["arguments"] = new Dictionary<string, object?> {
+                ["layoutName"] = "PairingLayout"
+            }
+        });
+
+        Assert.AreEqual("Prepare the desktop for focused coding work.", promptResult.GetProperty("description").GetString());
+        JsonElement message = promptResult.GetProperty("messages")[0];
+        Assert.AreEqual("user", message.GetProperty("role").GetString());
+
+        JsonElement content = message.GetProperty("content");
+        Assert.AreEqual("text", content.GetProperty("type").GetString());
+        string text = content.GetProperty("text").GetString() ?? string.Empty;
+        StringAssert.Contains(text, "Preferred layout: PairingLayout.");
+        StringAssert.Contains(text, "Start by listing named layouts.");
+        StringAssert.Contains(text, "focus the main editor or terminal window.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures MCP resources read back the current saved target state and snapshot payloads.
+    /// </summary>
+    public void McpServer_ReadResources_ReturnsSavedTargetsAndSnapshot() {
+        string windowTargetName = "McpServerTests-Resource-Window-" + Guid.NewGuid().ToString("N");
+        string controlTargetName = "McpServerTests-Resource-Control-" + Guid.NewGuid().ToString("N");
+        string windowTargetPath = DesktopStateStore.GetTargetPath(windowTargetName);
+        string controlTargetPath = DesktopStateStore.GetControlTargetPath(controlTargetName);
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --allow-mutations");
+            client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+                ["protocolVersion"] = "2025-06-18"
+            });
+
+            client.CallTool(2, "save_window_target", new Dictionary<string, object?> {
+                ["name"] = windowTargetName,
+                ["description"] = "Resource test target",
+                ["xRatio"] = 0.5,
+                ["yRatio"] = 0.5,
+                ["widthRatio"] = 0.6,
+                ["heightRatio"] = 0.4
+            });
+            client.CallTool(3, "save_control_target", new Dictionary<string, object?> {
+                ["name"] = controlTargetName,
+                ["description"] = "Resource test control",
+                ["controlType"] = "Edit",
+                ["uiAutomation"] = true
+            });
+
+            JsonElement targetsResource = ReadResourceJson(client.SendRequest(4, "resources/read", new Dictionary<string, object?> {
+                ["uri"] = "desktop://targets"
+            }));
+            Assert.IsTrue(targetsResource.EnumerateArray().Any(item => string.Equals(item.GetString(), windowTargetName, StringComparison.Ordinal)));
+
+            JsonElement controlTargetsResource = ReadResourceJson(client.SendRequest(5, "resources/read", new Dictionary<string, object?> {
+                ["uri"] = "desktop://control-targets"
+            }));
+            Assert.IsTrue(controlTargetsResource.EnumerateArray().Any(item => string.Equals(item.GetString(), controlTargetName, StringComparison.Ordinal)));
+
+            JsonElement snapshotResource = ReadResourceJson(client.SendRequest(6, "resources/read", new Dictionary<string, object?> {
+                ["uri"] = "desktop://snapshot/current"
+            }));
+            Assert.IsTrue(snapshotResource.TryGetProperty("ActiveWindow", out _));
+            Assert.IsTrue(snapshotResource.TryGetProperty("Monitors", out _));
+            Assert.IsTrue(snapshotResource.TryGetProperty("Windows", out _));
+        } finally {
+            if (File.Exists(windowTargetPath)) {
+                File.Delete(windowTargetPath);
+            }
+
+            if (File.Exists(controlTargetPath)) {
+                File.Delete(controlTargetPath);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures MCP surfaces transport and tool errors without crashing the stdio server.
+    /// </summary>
+    public void McpServer_InvalidRequests_ReturnStructuredErrors() {
+        using var client = McpTestClient.Start("mcp serve --allow-mutations");
+        client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement resourceError = client.SendRequestExpectError(2, "resources/read", new Dictionary<string, object?> {
+            ["uri"] = "desktop://missing"
+        });
+        Assert.AreEqual(-32602, resourceError.GetProperty("code").GetInt32());
+        StringAssert.Contains(resourceError.GetProperty("message").GetString() ?? string.Empty, "Unknown resource");
+
+        JsonElement promptError = client.SendRequestExpectError(3, "prompts/get", new Dictionary<string, object?> {
+            ["name"] = "missing_prompt"
+        });
+        Assert.AreEqual(-32602, promptError.GetProperty("code").GetInt32());
+        StringAssert.Contains(promptError.GetProperty("message").GetString() ?? string.Empty, "Unknown prompt");
+
+        JsonElement toolError = client.CallToolExpectError(4, "launch_and_wait_for_window", new Dictionary<string, object?> {
+            ["filePath"] = @"C:\__DesktopManagerTests__\missing.exe",
+            ["timeoutMs"] = 500,
+            ["intervalMs"] = 50
+        });
+        StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "cannot find the file");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the default MCP server blocks mutating tool calls until mutation mode is explicitly enabled.
+    /// </summary>
+    public void McpServer_DefaultReadOnly_BlocksMutatingTools() {
+        string targetName = "McpServerTests-ReadOnly-" + Guid.NewGuid().ToString("N");
+        string path = DesktopStateStore.GetTargetPath(targetName);
+
+        try {
+            using var client = McpTestClient.Start();
+            client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+                ["protocolVersion"] = "2025-06-18"
+            });
+
+            JsonElement toolError = client.CallToolExpectError(2, "save_window_target", new Dictionary<string, object?> {
+                ["name"] = targetName,
+                ["xRatio"] = 0.5,
+                ["yRatio"] = 0.5
+            });
+
+            StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "read-only mode");
+            Assert.IsFalse(File.Exists(path));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures focused foreground-input fallback requires explicit MCP server opt-in.
+    /// </summary>
+    public void McpServer_ForegroundInputFallback_RequiresServerOptIn() {
+        using var client = McpTestClient.Start("mcp serve --allow-mutations");
+        client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement toolError = client.CallToolExpectError(2, "set_control_text", new Dictionary<string, object?> {
+            ["windowTitle"] = "*DesktopManagerTests*",
+            ["controlType"] = "Edit",
+            ["text"] = "Hello world",
+            ["allowForegroundInput"] = true
+        });
+
+        StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "--allow-foreground-input");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures dry-run mode returns a structured preview without mutating persistent state.
+    /// </summary>
+    public void McpServer_DryRun_PreviewsMutatingToolsWithoutWritingState() {
+        string targetName = "McpServerTests-DryRun-" + Guid.NewGuid().ToString("N");
+        string path = DesktopStateStore.GetTargetPath(targetName);
+
+        try {
+            using var client = McpTestClient.Start("mcp serve --dry-run");
+            JsonElement initializeResult = client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+                ["protocolVersion"] = "2025-06-18"
+            });
+            Assert.IsTrue(initializeResult.GetProperty("safetyPolicy").GetProperty("dryRun").GetBoolean());
+
+            JsonElement result = client.CallTool(2, "save_window_target", new Dictionary<string, object?> {
+                ["name"] = targetName,
+                ["xRatio"] = 0.5,
+                ["yRatio"] = 0.5
+            });
+
+            Assert.IsTrue(result.GetProperty("dryRun").GetBoolean());
+            Assert.IsFalse(result.GetProperty("applied").GetBoolean());
+            Assert.AreEqual("save_window_target", result.GetProperty("toolName").GetString());
+            Assert.IsFalse(File.Exists(path));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures process-scoped MCP filters reject mutating window tools that do not declare an explicit process target.
+    /// </summary>
+    public void McpServer_ProcessFilters_BlockUnscopedWindowMutations() {
+        using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process notepad");
+        JsonElement initializeResult = client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement safetyPolicy = initializeResult.GetProperty("safetyPolicy");
+        Assert.AreEqual(1, safetyPolicy.GetProperty("allowedProcesses").GetArrayLength());
+        Assert.AreEqual("notepad", safetyPolicy.GetProperty("allowedProcesses")[0].GetString());
+
+        JsonElement toolError = client.CallToolExpectError(2, "move_window", new Dictionary<string, object?> {
+            ["windowTitle"] = "*Notepad*",
+            ["x"] = 0,
+            ["y"] = 0,
+            ["width"] = 640,
+            ["height"] = 480
+        });
+
+        StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "explicit 'processName' selector");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures denied-process filters block launch requests before the executable is started.
+    /// </summary>
+    public void McpServer_DeniedProcessFilters_BlockLaunchRequests() {
+        using var client = McpTestClient.Start("mcp serve --allow-mutations --deny-process notepad");
+        client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement toolError = client.CallToolExpectError(2, "launch_process", new Dictionary<string, object?> {
+            ["filePath"] = "notepad.exe"
+        });
+
+        StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "denied-process policy");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures allowlisted process filters still permit dry-run previews for matching launch requests.
+    /// </summary>
+    public void McpServer_AllowedProcessFilters_PermitMatchingDryRunLaunchPreview() {
+        using var client = McpTestClient.Start("mcp serve --dry-run --allow-process notepad");
+        JsonElement initializeResult = client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+        Assert.IsTrue(initializeResult.GetProperty("safetyPolicy").GetProperty("dryRun").GetBoolean());
+
+        JsonElement result = client.CallTool(2, "launch_process", new Dictionary<string, object?> {
+            ["filePath"] = "notepad.exe"
+        });
+
+        Assert.IsTrue(result.GetProperty("dryRun").GetBoolean());
+        Assert.AreEqual("launch_process", result.GetProperty("toolName").GetString());
+        Assert.AreEqual(2, result.GetProperty("requestedProcesses").GetArrayLength());
+    }
+
+    private static JsonElement ReadResourceJson(JsonElement resourceResult) {
+        JsonElement contents = resourceResult.GetProperty("contents");
+        Assert.AreEqual(1, contents.GetArrayLength());
+
+        string text = contents[0].GetProperty("text").GetString() ?? string.Empty;
+        using JsonDocument document = JsonDocument.Parse(text);
+        return document.RootElement.Clone();
+    }
+
+    private static void AssertToolHasArtifactProperties(JsonElement tool) {
+        JsonElement properties = tool
+            .GetProperty("inputSchema")
+            .GetProperty("properties");
+
+        Assert.IsTrue(properties.TryGetProperty("captureBefore", out _));
+        Assert.IsTrue(properties.TryGetProperty("captureAfter", out _));
+        Assert.IsTrue(properties.TryGetProperty("artifactDirectory", out _));
+    }
+
+    private static void AssertToolHasProperty(JsonElement tool, string propertyName) {
+        JsonElement properties = tool
+            .GetProperty("inputSchema")
+            .GetProperty("properties");
+
+        Assert.IsTrue(properties.TryGetProperty(propertyName, out _));
+    }
+}

--- a/Sources/DesktopManager.Tests/McpTestClient.cs
+++ b/Sources/DesktopManager.Tests/McpTestClient.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+internal sealed class McpTestClient : IDisposable {
+    private static readonly byte[] HeaderSeparator = Encoding.ASCII.GetBytes("\r\n\r\n");
+    private readonly Process _process;
+
+    private McpTestClient(Process process) {
+        _process = process;
+    }
+
+    public static McpTestClient Start(string arguments = "mcp serve") {
+        string executablePath = FindCliExecutablePath();
+        var startInfo = new ProcessStartInfo(executablePath, arguments) {
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        Process? process = Process.Start(startInfo);
+        if (process == null) {
+            throw new InvalidOperationException("Failed to start the DesktopManager CLI MCP server.");
+        }
+
+        return new McpTestClient(process);
+    }
+
+    public JsonElement SendRequest(int id, string method, object? parameters = null) {
+        JsonDocument response = SendRequestCore(id, method, parameters);
+        try {
+            JsonElement root = response.RootElement;
+            Assert.AreEqual("2.0", root.GetProperty("jsonrpc").GetString());
+            Assert.AreEqual(id, root.GetProperty("id").GetInt32());
+            if (root.TryGetProperty("error", out JsonElement error)) {
+                Assert.Fail("MCP request failed: " + error.GetProperty("message").GetString());
+            }
+
+            return root.GetProperty("result").Clone();
+        } finally {
+            response.Dispose();
+        }
+    }
+
+    public JsonElement SendRequestExpectError(int id, string method, object? parameters = null) {
+        JsonDocument response = SendRequestCore(id, method, parameters);
+        try {
+            JsonElement root = response.RootElement;
+            Assert.AreEqual("2.0", root.GetProperty("jsonrpc").GetString());
+            Assert.AreEqual(id, root.GetProperty("id").GetInt32());
+            Assert.IsTrue(root.TryGetProperty("error", out JsonElement error), "Expected the MCP request to return an error.");
+            return error.Clone();
+        } finally {
+            response.Dispose();
+        }
+    }
+
+    public JsonElement CallTool(int id, string name, object arguments) {
+        JsonElement result = CallToolResponse(id, name, arguments);
+        if (result.TryGetProperty("isError", out JsonElement isErrorElement) && isErrorElement.GetBoolean()) {
+            string message = result.TryGetProperty("message", out JsonElement messageElement)
+                ? messageElement.GetString() ?? "Tool call failed."
+                : "Tool call failed.";
+            Assert.Fail(message);
+        }
+
+        return result.GetProperty("structuredContent").Clone();
+    }
+
+    public JsonElement CallToolExpectError(int id, string name, object arguments) {
+        JsonElement result = CallToolResponse(id, name, arguments);
+        Assert.IsTrue(result.TryGetProperty("isError", out JsonElement isErrorElement) && isErrorElement.GetBoolean(), "Expected the tool call to return an MCP tool error.");
+        return result.Clone();
+    }
+
+    private JsonDocument SendRequestCore(int id, string method, object? parameters = null) {
+        var request = parameters == null
+            ? new Dictionary<string, object?> {
+                ["jsonrpc"] = "2.0",
+                ["id"] = id,
+                ["method"] = method
+            }
+            : new Dictionary<string, object?> {
+                ["jsonrpc"] = "2.0",
+                ["id"] = id,
+                ["method"] = method,
+                ["params"] = parameters
+            };
+
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(request);
+        byte[] header = Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n");
+
+        _process.StandardInput.BaseStream.Write(header, 0, header.Length);
+        _process.StandardInput.BaseStream.Write(payload, 0, payload.Length);
+        _process.StandardInput.BaseStream.Flush();
+
+        return ReadResponse(_process.StandardOutput.BaseStream);
+    }
+
+    private JsonElement CallToolResponse(int id, string name, object arguments) {
+        JsonElement result = SendRequest(id, "tools/call", new Dictionary<string, object?> {
+            ["name"] = name,
+            ["arguments"] = arguments
+        });
+        return result.Clone();
+    }
+
+    public void Dispose() {
+        try {
+            if (!_process.HasExited) {
+                _process.StandardInput.Close();
+            }
+        } catch {
+            // Ignore shutdown failures while disposing the helper process.
+        }
+
+        try {
+            if (!_process.WaitForExit(2000)) {
+                _process.Kill();
+                _process.WaitForExit(2000);
+            }
+        } catch {
+            // Ignore cleanup failures in test teardown.
+        }
+
+        _process.Dispose();
+    }
+
+    private static JsonDocument ReadResponse(Stream stream) {
+        var headerBuffer = new List<byte>();
+        while (true) {
+            int value = stream.ReadByte();
+            if (value == -1) {
+                throw new EndOfStreamException("Unexpected end of stream while reading MCP headers.");
+            }
+
+            headerBuffer.Add((byte)value);
+            if (EndsWith(headerBuffer, HeaderSeparator)) {
+                break;
+            }
+        }
+
+        string headers = Encoding.ASCII.GetString(headerBuffer.ToArray());
+        int contentLength = 0;
+        foreach (string line in headers.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries)) {
+            if (!line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            string valueText = line.Substring("Content-Length:".Length).Trim();
+            if (!int.TryParse(valueText, out contentLength) || contentLength < 0) {
+                throw new InvalidDataException("Invalid Content-Length header.");
+            }
+        }
+
+        if (contentLength <= 0) {
+            throw new InvalidDataException("Missing Content-Length header.");
+        }
+
+        byte[] payload = new byte[contentLength];
+        int offset = 0;
+        while (offset < payload.Length) {
+            int read = stream.Read(payload, offset, payload.Length - offset);
+            if (read <= 0) {
+                throw new EndOfStreamException("Unexpected end of stream while reading an MCP message body.");
+            }
+
+            offset += read;
+        }
+
+        return JsonDocument.Parse(payload);
+    }
+
+    private static bool EndsWith(List<byte> source, byte[] suffix) {
+        if (source.Count < suffix.Length) {
+            return false;
+        }
+
+        for (int index = 0; index < suffix.Length; index++) {
+            if (source[source.Count - suffix.Length + index] != suffix[index]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string FindCliExecutablePath() {
+        DirectoryInfo? current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null) {
+            string candidate = Path.Combine(current.FullName, "Sources", "DesktopManager.Cli", "bin", "Debug", "net8.0-windows", "DesktopManager.Cli.exe");
+            if (File.Exists(candidate)) {
+                return candidate;
+            }
+
+            string releaseCandidate = Path.Combine(current.FullName, "Sources", "DesktopManager.Cli", "bin", "Release", "net8.0-windows", "DesktopManager.Cli.exe");
+            if (File.Exists(releaseCandidate)) {
+                return releaseCandidate;
+            }
+
+            current = current.Parent;
+        }
+
+        Assert.Inconclusive("DesktopManager.Cli.exe was not found. Build the CLI project before running MCP transport tests.");
+        return string.Empty;
+    }
+}

--- a/Sources/DesktopManager.Tests/TestHelper.cs
+++ b/Sources/DesktopManager.Tests/TestHelper.cs
@@ -150,6 +150,19 @@ internal static class TestHelper {
     }
 
     /// <summary>
+    /// Skips experimental desktop-changing tests unless explicitly enabled.
+    /// </summary>
+    public static void RequireExperimentalDesktopChanges() {
+        RequireDesktopChanges();
+        if (Environment.GetEnvironmentVariable("RUN_EXPERIMENTAL_UI_TESTS") == "true" ||
+            Environment.GetEnvironmentVariable("DESKTOPMANAGER_RUN_EXPERIMENTAL_UI_TESTS") == "true") {
+            return;
+        }
+
+        Assert.Inconclusive("Experimental desktop-changing UI tests skipped. Set RUN_EXPERIMENTAL_UI_TESTS=true (or DESKTOPMANAGER_RUN_EXPERIMENTAL_UI_TESTS=true) to run.");
+    }
+
+    /// <summary>
     /// Safely kills a process.
     /// </summary>
     public static void SafeKillProcess(Process? process) {

--- a/Sources/DesktopManager.Tests/UiAutomationControlServiceTests.cs
+++ b/Sources/DesktopManager.Tests/UiAutomationControlServiceTests.cs
@@ -170,4 +170,44 @@ public class UiAutomationControlServiceTests {
 
         Assert.IsTrue(score >= 80, $"Expected a strong score for a near-identical control, but got {score}.");
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures editable UIA controls can opt into explicit foreground fallback even when focusability metadata is missing.
+    /// </summary>
+    public void SupportsForegroundFallback_EditableControlWithoutHandle_ReturnsTrue() {
+        bool supported = UiAutomationControlService.SupportsForegroundFallback(
+            hasNativeHandle: false,
+            isKeyboardFocusable: null,
+            isEnabled: true,
+            controlType: "Edit",
+            className: "Chrome_RenderWidgetHostHWND");
+
+        Assert.IsTrue(supported);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures disabled controls do not advertise explicit foreground fallback.
+    /// </summary>
+    public void SupportsForegroundFallback_DisabledControl_ReturnsFalse() {
+        bool supported = UiAutomationControlService.SupportsForegroundFallback(
+            hasNativeHandle: false,
+            isKeyboardFocusable: true,
+            isEnabled: false,
+            controlType: "Edit",
+            className: "TextBox");
+
+        Assert.IsFalse(supported);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures obvious editable control shapes are detected for modern-app fallback heuristics.
+    /// </summary>
+    public void IsLikelyEditableControl_EditAndTextBoxShapes_ReturnTrue() {
+        Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl("Edit", string.Empty));
+        Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl("Document", string.Empty));
+        Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl(string.Empty, "InputTextBox"));
+    }
 }

--- a/Sources/DesktopManager/DesktopAutomationModels.cs
+++ b/Sources/DesktopManager/DesktopAutomationModels.cs
@@ -435,6 +435,26 @@ public sealed class DesktopWindowTargetDefinition {
     public double? YRatio { get; set; }
 
     /// <summary>
+    /// Gets or sets the optional target area width in pixels.
+    /// </summary>
+    public int? Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional target area height in pixels.
+    /// </summary>
+    public int? Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional target area width ratio from 0 to 1.
+    /// </summary>
+    public double? WidthRatio { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional target area height ratio from 0 to 1.
+    /// </summary>
+    public double? HeightRatio { get; set; }
+
+    /// <summary>
     /// Gets or sets whether the target is relative to the client area.
     /// </summary>
     public bool ClientArea { get; set; }
@@ -565,6 +585,16 @@ public sealed class DesktopResolvedWindowTarget {
     public int RelativeY { get; set; }
 
     /// <summary>
+    /// Gets or sets the resolved width relative to the selected bounds when the target defines an area.
+    /// </summary>
+    public int? RelativeWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolved height relative to the selected bounds when the target defines an area.
+    /// </summary>
+    public int? RelativeHeight { get; set; }
+
+    /// <summary>
     /// Gets or sets the resolved screen-space X coordinate.
     /// </summary>
     public int ScreenX { get; set; }
@@ -573,6 +603,16 @@ public sealed class DesktopResolvedWindowTarget {
     /// Gets or sets the resolved screen-space Y coordinate.
     /// </summary>
     public int ScreenY { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolved screen-space width when the target defines an area.
+    /// </summary>
+    public int? ScreenWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolved screen-space height when the target defines an area.
+    /// </summary>
+    public int? ScreenHeight { get; set; }
 }
 
 /// <summary>

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -192,6 +192,27 @@ public sealed class DesktopAutomationService {
     }
 
     /// <summary>
+    /// Sends keys to matching windows.
+    /// </summary>
+    public IReadOnlyList<WindowInfo> SendWindowKeys(WindowQueryOptions options, IReadOnlyList<VirtualKey> keys, bool activate, bool all = false) {
+        if (keys == null) {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Count == 0) {
+            throw new ArgumentException("No keys specified.", nameof(keys));
+        }
+
+        IReadOnlyList<WindowInfo> windows = ResolveWindows(options, all);
+        foreach (WindowInfo window in windows) {
+            _windowManager.SendKeys(window, keys, new WindowInputOptions {
+                ActivateWindow = activate
+            });
+        }
+
+        return RefreshWindows(windows);
+    }
+
+    /// <summary>
     /// Clicks a point relative to each matching window.
     /// </summary>
     public IReadOnlyList<WindowInfo> ClickWindowPoint(WindowQueryOptions options, int x, int y, MouseButton button, bool activate, bool all = false) {
@@ -479,6 +500,28 @@ public sealed class DesktopAutomationService {
     public IReadOnlyList<DesktopResolvedWindowTarget> ResolveWindowTargets(WindowQueryOptions options, string targetName, bool all = false) {
         DesktopWindowTargetDefinition definition = GetWindowTarget(targetName);
         return ResolveWindowTargets(options, targetName, definition, all);
+    }
+
+    /// <summary>
+    /// Captures the area described by a named window target against a matching window.
+    /// </summary>
+    public DesktopCapture CaptureWindowTarget(WindowQueryOptions options, string targetName) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        DesktopResolvedWindowTarget target = ResolveWindowTargets(options, targetName, all: false).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Named target '{targetName}' could not be resolved against a matching window.");
+        if (!target.ScreenWidth.HasValue || !target.ScreenHeight.HasValue) {
+            throw new InvalidOperationException($"Named target '{targetName}' does not define a capture area. Save it with width/height or widthRatio/heightRatio.");
+        }
+
+        return new DesktopCapture {
+            Kind = "window-target",
+            Bitmap = ScreenshotService.CaptureRegion(target.ScreenX, target.ScreenY, target.ScreenWidth.Value, target.ScreenHeight.Value),
+            Window = target.Geometry.Window,
+            Geometry = target.Geometry
+        };
     }
 
     /// <summary>
@@ -1302,6 +1345,8 @@ public sealed class DesktopAutomationService {
 
     private static DesktopResolvedWindowTarget ResolveWindowTarget(string targetName, DesktopWindowTargetDefinition definition, DesktopWindowGeometry geometry) {
         (int relativeX, int relativeY) = ResolveRelativePoint(geometry, definition.X, definition.Y, definition.XRatio, definition.YRatio, definition.ClientArea);
+        int? relativeWidth = ResolveOptionalAxisSize(geometry, definition.Width, definition.WidthRatio, definition.ClientArea, horizontal: true, nameof(definition.Width), nameof(definition.WidthRatio));
+        int? relativeHeight = ResolveOptionalAxisSize(geometry, definition.Height, definition.HeightRatio, definition.ClientArea, horizontal: false, nameof(definition.Height), nameof(definition.HeightRatio));
         int screenX = definition.ClientArea ? geometry.ClientLeft + relativeX : geometry.WindowLeft + relativeX;
         int screenY = definition.ClientArea ? geometry.ClientTop + relativeY : geometry.WindowTop + relativeY;
 
@@ -1313,13 +1358,21 @@ public sealed class DesktopAutomationService {
                 Y = definition.Y,
                 XRatio = definition.XRatio,
                 YRatio = definition.YRatio,
+                Width = definition.Width,
+                Height = definition.Height,
+                WidthRatio = definition.WidthRatio,
+                HeightRatio = definition.HeightRatio,
                 ClientArea = definition.ClientArea
             },
             Geometry = geometry,
             RelativeX = relativeX,
             RelativeY = relativeY,
+            RelativeWidth = relativeWidth,
+            RelativeHeight = relativeHeight,
             ScreenX = screenX,
-            ScreenY = screenY
+            ScreenY = screenY,
+            ScreenWidth = relativeWidth,
+            ScreenHeight = relativeHeight
         };
     }
 
@@ -1349,6 +1402,8 @@ public sealed class DesktopAutomationService {
     private static void ValidateWindowTargetDefinition(DesktopWindowTargetDefinition definition) {
         ValidateTargetAxis(definition.X, definition.XRatio, nameof(definition.X), nameof(definition.XRatio));
         ValidateTargetAxis(definition.Y, definition.YRatio, nameof(definition.Y), nameof(definition.YRatio));
+        ValidateOptionalTargetSizeAxis(definition.Width, definition.WidthRatio, nameof(definition.Width), nameof(definition.WidthRatio));
+        ValidateOptionalTargetSizeAxis(definition.Height, definition.HeightRatio, nameof(definition.Height), nameof(definition.HeightRatio));
     }
 
     private static void ValidateControlTargetDefinition(DesktopControlTargetDefinition definition) {
@@ -1407,6 +1462,31 @@ public sealed class DesktopAutomationService {
         double ratioValue = ratio!.Value;
         if (ratioValue < 0 || ratioValue > 1) {
             throw new ArgumentOutOfRangeException(ratioName, $"{ratioName} must be between 0 and 1.");
+        }
+    }
+
+    private static void ValidateOptionalTargetSizeAxis(int? size, double? ratio, string sizeName, string ratioName) {
+        bool hasSize = size.HasValue;
+        bool hasRatio = ratio.HasValue;
+        if (!hasSize && !hasRatio) {
+            return;
+        }
+
+        if (hasSize == hasRatio) {
+            throw new ArgumentException($"Provide either {sizeName} or {ratioName}, but not both.");
+        }
+
+        if (hasSize) {
+            if (size!.Value <= 0) {
+                throw new ArgumentOutOfRangeException(sizeName, $"{sizeName} must be greater than zero.");
+            }
+
+            return;
+        }
+
+        double ratioValue = ratio!.Value;
+        if (ratioValue <= 0 || ratioValue > 1) {
+            throw new ArgumentOutOfRangeException(ratioName, $"{ratioName} must be greater than 0 and less than or equal to 1.");
         }
     }
 
@@ -1490,6 +1570,36 @@ public sealed class DesktopAutomationService {
         int height = clientArea ? geometry.ClientHeight : geometry.WindowHeight;
 
         return (ResolveAxisCoordinate(x, xRatio, width, nameof(x), nameof(xRatio)), ResolveAxisCoordinate(y, yRatio, height, nameof(y), nameof(yRatio)));
+    }
+
+    private static int? ResolveOptionalAxisSize(DesktopWindowGeometry geometry, int? size, double? ratio, bool clientArea, bool horizontal, string sizeName, string ratioName) {
+        bool hasSize = size.HasValue;
+        bool hasRatio = ratio.HasValue;
+        if (!hasSize && !hasRatio) {
+            return null;
+        }
+
+        int boundsSize = horizontal
+            ? clientArea ? geometry.ClientWidth : geometry.WindowWidth
+            : clientArea ? geometry.ClientHeight : geometry.WindowHeight;
+        if (hasSize) {
+            if (size!.Value <= 0) {
+                throw new ArgumentOutOfRangeException(sizeName, $"{sizeName} must be greater than zero.");
+            }
+
+            return size.Value;
+        }
+
+        double ratioValue = ratio!.Value;
+        if (ratioValue <= 0 || ratioValue > 1) {
+            throw new ArgumentOutOfRangeException(ratioName, $"{ratioName} must be greater than 0 and less than or equal to 1.");
+        }
+
+        if (boundsSize <= 0) {
+            throw new InvalidOperationException("The target bounds do not expose a usable size.");
+        }
+
+        return Math.Max(1, (int)Math.Round(boundsSize * ratioValue, MidpointRounding.AwayFromZero));
     }
 
     private static int ResolveAxisCoordinate(int? coordinate, double? ratio, int size, string coordinateName, string ratioName) {

--- a/Sources/DesktopManager/UiAutomationControlService.cs
+++ b/Sources/DesktopManager/UiAutomationControlService.cs
@@ -10,6 +10,9 @@ namespace DesktopManager;
 internal sealed class UiAutomationControlService {
     private const int EnumeratedControlsCacheMilliseconds = 750;
     private const int ActionMatchCacheMilliseconds = 5000;
+    private const int ForegroundTextVerificationMilliseconds = 1000;
+    private const int ForegroundTextVerificationIntervalMilliseconds = 50;
+    private const int ForegroundInputSettleMilliseconds = 75;
     private static readonly ConcurrentDictionary<IntPtr, IntPtr> PreferredSearchRoots = new();
     private static readonly ConcurrentDictionary<string, CachedControlCollection> EnumeratedControlsCache = new();
     private static readonly ConcurrentDictionary<string, CachedActionMatch> ActionMatchCache = new();
@@ -440,9 +443,19 @@ internal sealed class UiAutomationControlService {
             return false;
         }
 
+        if (TryReplaceFocusedTextWithPaste(window, control, value)) {
+            return true;
+        }
+
         KeyboardInputService.SendToForeground(VirtualKey.VK_CONTROL, VirtualKey.VK_A);
-        KeyboardInputService.SendTextToForeground(value);
-        return true;
+        Thread.Sleep(ForegroundInputSettleMilliseconds);
+        if (value.Length == 0) {
+            KeyboardInputService.SendToForeground(VirtualKey.VK_DELETE);
+        } else {
+            KeyboardInputService.SendTextToForeground(value);
+        }
+
+        return WaitForResolvedValue(window, control, value);
     }
 
     private bool TrySendKeysCore(WindowInfo window, WindowControlInfo control, IReadOnlyList<VirtualKey> keys, bool ensureForegroundWindow) {
@@ -1034,7 +1047,7 @@ internal sealed class UiAutomationControlService {
             SupportsBackgroundClick = hasNativeHandle || hasInvokeAction,
             SupportsBackgroundText = hasNativeHandle || hasDirectTextAction,
             SupportsBackgroundKeys = hasNativeHandle,
-            SupportsForegroundInputFallback = !hasNativeHandle && (isKeyboardFocusable ?? false),
+            SupportsForegroundInputFallback = SupportsForegroundFallback(hasNativeHandle, isKeyboardFocusable, isEnabled, controlType, className),
             Left = left,
             Top = top,
             Width = width,
@@ -1048,6 +1061,65 @@ internal sealed class UiAutomationControlService {
             ReadPatternValue(element, "System.Windows.Automation.RangeValuePattern") ??
             ReadPatternValue(element, "System.Windows.Automation.LegacyIAccessiblePattern") ??
             string.Empty;
+    }
+
+    private bool TryReplaceFocusedTextWithPaste(WindowInfo window, WindowControlInfo control, string value) {
+        string clipboardBackup = string.Empty;
+        bool restoreClipboard = false;
+
+        try {
+            restoreClipboard = ClipboardHelper.TryGetText(out clipboardBackup);
+            ClipboardHelper.SetText(value);
+        } catch {
+            return false;
+        }
+
+        try {
+            KeyboardInputService.SendToForeground(VirtualKey.VK_CONTROL, VirtualKey.VK_A);
+            Thread.Sleep(ForegroundInputSettleMilliseconds);
+            KeyboardInputService.SendToForeground(VirtualKey.VK_CONTROL, VirtualKey.VK_V);
+            return WaitForResolvedValue(window, control, value);
+        } finally {
+            if (restoreClipboard) {
+                try {
+                    ClipboardHelper.SetText(clipboardBackup);
+                } catch {
+                    // Preserve the successful input result even if clipboard restoration fails.
+                }
+            }
+        }
+    }
+
+    private bool WaitForResolvedValue(WindowInfo window, WindowControlInfo control, string expectedValue) {
+        DateTime deadlineUtc = DateTime.UtcNow.AddMilliseconds(ForegroundTextVerificationMilliseconds);
+        while (DateTime.UtcNow <= deadlineUtc) {
+            string? currentValue = TryReadResolvedValue(window, control);
+            if (currentValue != null && string.Equals(currentValue, expectedValue, StringComparison.Ordinal)) {
+                control.Value = expectedValue;
+                if (string.IsNullOrWhiteSpace(control.Text) || IsLikelyEditableControl(control.ControlType, control.ClassName)) {
+                    control.Text = expectedValue;
+                }
+
+                return true;
+            }
+
+            Thread.Sleep(ForegroundTextVerificationIntervalMilliseconds);
+        }
+
+        return false;
+    }
+
+    private string? TryReadResolvedValue(WindowInfo window, WindowControlInfo control) {
+        UiAutomationElementMatchResult refreshedMatch = ResolveMatchingElement(window.Handle, control);
+        if (refreshedMatch.Element == null) {
+            return null;
+        }
+
+        try {
+            return ReadValue(refreshedMatch.Element);
+        } catch {
+            return null;
+        }
     }
 
     private bool HasPattern(object element, string patternTypeName) {
@@ -1094,6 +1166,30 @@ internal sealed class UiAutomationControlService {
 
     private static string ReadString(object instance, string propertyName) {
         return instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)?.GetValue(instance) as string ?? string.Empty;
+    }
+
+    internal static bool SupportsForegroundFallback(bool hasNativeHandle, bool? isKeyboardFocusable, bool? isEnabled, string controlType, string className) {
+        if (hasNativeHandle) {
+            return false;
+        }
+
+        if (isEnabled.HasValue && !isEnabled.Value) {
+            return false;
+        }
+
+        if (isKeyboardFocusable.HasValue) {
+            return isKeyboardFocusable.Value;
+        }
+
+        return IsLikelyEditableControl(controlType, className);
+    }
+
+    internal static bool IsLikelyEditableControl(string controlType, string className) {
+        return string.Equals(controlType, "Edit", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(controlType, "Document", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(controlType, "ComboBox", StringComparison.OrdinalIgnoreCase) ||
+            className.IndexOf("Edit", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            className.IndexOf("TextBox", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static int ReadInt32(object instance, string propertyName) {

--- a/Sources/DesktopManager/WindowInputService.cs
+++ b/Sources/DesktopManager/WindowInputService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -115,6 +116,53 @@ public static class WindowInputService {
         }
 
         EnsureTextApplied(window, text);
+
+        if (settings.RestoreFocus && previousForeground != IntPtr.Zero && previousForeground != window.Handle) {
+            MonitorNativeMethods.SetForegroundWindow(previousForeground);
+        }
+    }
+
+    /// <summary>
+    /// Sends one or more keys to the specified window.
+    /// </summary>
+    /// <param name="window">Target window.</param>
+    /// <param name="keys">Keys to send.</param>
+    public static void SendKeys(WindowInfo window, params VirtualKey[] keys) {
+        SendKeys(window, keys, null);
+    }
+
+    /// <summary>
+    /// Sends one or more keys to the specified window using input options.
+    /// </summary>
+    /// <param name="window">Target window.</param>
+    /// <param name="keys">Keys to send.</param>
+    /// <param name="options">Input options.</param>
+    public static void SendKeys(WindowInfo window, IReadOnlyList<VirtualKey> keys, WindowInputOptions? options) {
+        ValidateWindow(window);
+        if (keys == null) {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Count == 0) {
+            throw new ArgumentException("No keys specified", nameof(keys));
+        }
+
+        WindowInputOptions settings = options ?? new WindowInputOptions();
+        NormalizeOptions(settings);
+
+        IntPtr previousForeground = IntPtr.Zero;
+        if (settings.ActivateWindow || settings.RestoreFocus) {
+            previousForeground = MonitorNativeMethods.GetForegroundWindow();
+        }
+
+        if (settings.ActivateWindow) {
+            TryActivateWindow(window.Handle, settings.ActivationRetryCount, settings.ActivationRetryDelayMilliseconds);
+        }
+
+        if (MonitorNativeMethods.GetForegroundWindow() != window.Handle) {
+            throw new InvalidOperationException("Window must own the foreground before sending window-level keys.");
+        }
+
+        KeyboardInputService.SendToForeground(keys is VirtualKey[] keyArray ? keyArray : keys.ToArray());
 
         if (settings.RestoreFocus && previousForeground != IntPtr.Zero && previousForeground != window.Handle) {
             MonitorNativeMethods.SetForegroundWindow(previousForeground);

--- a/Sources/DesktopManager/WindowManager.Layout.cs
+++ b/Sources/DesktopManager/WindowManager.Layout.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 
@@ -43,6 +44,25 @@ public partial class WindowManager
         /// <param name="options">Input options.</param>
         public void TypeText(WindowInfo windowInfo, string text, WindowInputOptions options) {
             WindowInputService.TypeText(windowInfo, text, options);
+        }
+
+        /// <summary>
+        /// Sends keys to the specified window.
+        /// </summary>
+        /// <param name="windowInfo">The target window.</param>
+        /// <param name="keys">Keys to send.</param>
+        public void SendKeys(WindowInfo windowInfo, params VirtualKey[] keys) {
+            WindowInputService.SendKeys(windowInfo, keys);
+        }
+
+        /// <summary>
+        /// Sends keys to the specified window using input options.
+        /// </summary>
+        /// <param name="windowInfo">The target window.</param>
+        /// <param name="keys">Keys to send.</param>
+        /// <param name="options">Input options.</param>
+        public void SendKeys(WindowInfo windowInfo, IReadOnlyList<VirtualKey> keys, WindowInputOptions options) {
+            WindowInputService.SendKeys(windowInfo, keys, options);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- move more desktop automation behavior into shared CLI/MCP workflows and mutation plumbing
- add MCP safety policy, richer artifact-first results, and higher-level assertions/workflows
- expand MCP coverage with black-box transport tests and live net8 desktop end-to-end harnesses for Notepad plus experimental Chromium diagnostics

## What changed
- improved shared desktop automation reliability for modern UIA text entry and added whole-window key sending
- added named window/control target workflows, layout assertions, process launch-and-wait, and workflow commands for coding/screen-sharing cleanup
- hardened MCP transport/server behavior with read-only-by-default policy, mutation opt-in, foreground-input opt-in, process allow/deny filters, and dry-run support
- updated CLI/MCP docs and agent skills to match the current surface

## Verification
- dotnet build Sources/DesktopManager.sln --nologo
- dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --nologo --filter McpServerTests
- RUN_UI_TESTS=true RUN_DESTRUCTIVE_UI_TESTS=true dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --nologo --filter "McpServer_NotepadRoundTrip|McpServer_NotepadTargetAreaRoundTrip|McpServer_NotepadWindowMutationRoundTrip|McpServer_NotepadWorkflowRoundTrip|McpServer_NotepadAllowedProcessPolicy|McpServer_NotepadDeniedProcessPolicy|McpServer_NotepadDryRunPolicy"
- RUN_UI_TESTS=true RUN_DESTRUCTIVE_UI_TESTS=true RUN_EXPERIMENTAL_UI_TESTS=true dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --nologo --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn now finishes as an evidence-preserving experimental skip when Chromium navigation does not complete reliably in-session