### PR TITLE
fix(testing): 🐛 isolate desktop UI tests and harden CLI contracts

### DIFF
--- a/Docs/DesktopManager.Cli.md
+++ b/Docs/DesktopManager.Cli.md
@@ -84,6 +84,7 @@ desktopmanager mcp serve --dry-run
 - `process start` launches a desktop application and can optionally wait for input idle and for a launched window to appear.
 - `process start` can now also validate the launched window by title or class and optionally require that a real matching window be found before returning.
 - `process start-and-wait` now packages the safer unattended launch flow: start the app, bind the follow-up wait to the launched process, return the resolved window result, and optionally capture before/after evidence.
+- `process start-and-wait --follow-process-family` is an explicit opt-in for apps that surface their visible window from a same-name helper or broker process after launch-time correlation finishes.
 - `window wait` polls for a matching window and returns when one appears.
 - `window exists` and `window active-matches` provide non-mutating verification commands.
 - `control exists` and `control wait` provide the same inspect-first verification model for controls.

--- a/Sources/DesktopManager.Cli/CliApplication.cs
+++ b/Sources/DesktopManager.Cli/CliApplication.cs
@@ -1,13 +1,18 @@
 using System;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
 internal static class CliApplication {
     public static int Run(string[] args) {
+        return Run(args, Console.Out, Console.Error);
+    }
+
+    internal static int Run(string[] args, TextWriter output, TextWriter error) {
         try {
             var parsed = CommandLineArguments.Parse(args);
             if (parsed.IsEmpty || parsed.HasFlag("help")) {
-                Console.WriteLine(HelpText.GetGeneralHelp());
+                output.WriteLine(HelpText.GetGeneralHelp());
                 return 0;
             }
 
@@ -26,23 +31,22 @@ internal static class CliApplication {
                 "snapshot" => SnapshotCommands.Run(action, parsed),
                 "workflow" => WorkflowCommands.Run(action, parsed),
                 "mcp" => McpCommands.Run(action, parsed),
-                "help" => ShowGroupHelp(parsed),
+                "help" => ShowGroupHelp(parsed, output),
                 _ => throw new CommandLineException($"Unknown command group '{group}'.")
             };
         } catch (CommandLineException ex) {
-            Console.Error.WriteLine($"Error: {ex.Message}");
-            Console.Error.WriteLine();
-            Console.Error.WriteLine(HelpText.GetGeneralHelp());
+            error.WriteLine($"Error: {ex.Message}");
+            error.WriteLine();
+            error.WriteLine(HelpText.GetGeneralHelp());
             return 1;
         } catch (Exception ex) {
-            Console.Error.WriteLine($"Unhandled error: {ex.Message}");
+            error.WriteLine($"Unhandled error: {ex.Message}");
             return 1;
         }
     }
 
-    private static int ShowGroupHelp(CommandLineArguments parsed) {
-        string topic = parsed.GetCommandPart(1)?.ToLowerInvariant() ?? string.Empty;
-        string help = topic switch {
+    internal static string GetHelpText(string? topic) {
+        return topic?.ToLowerInvariant() switch {
             "window" => HelpText.GetWindowHelp(),
             "control" => HelpText.GetControlHelp(),
             "monitor" => HelpText.GetMonitorHelp(),
@@ -56,8 +60,13 @@ internal static class CliApplication {
             "mcp" => HelpText.GetMcpHelp(),
             _ => HelpText.GetGeneralHelp()
         };
+    }
 
-        Console.WriteLine(help);
+    private static int ShowGroupHelp(CommandLineArguments parsed, TextWriter output) {
+        string? topic = parsed.GetCommandPart(1);
+        string help = GetHelpText(topic);
+
+        output.WriteLine(help);
         return 0;
     }
 }

--- a/Sources/DesktopManager.Cli/ControlCommands.cs
+++ b/Sources/DesktopManager.Cli/ControlCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -38,11 +39,14 @@ internal static class ControlCommands {
         }
 
         if (controls.Count == 0) {
-            Console.WriteLine("No matching controls found.");
-            return 0;
+            return WriteNoMatchingControls(Console.Out);
         }
 
-        var rows = controls
+        return WriteControlListResults(controls, Console.Out);
+    }
+
+    internal static int WriteControlListResults(IReadOnlyList<ControlResult> controls, TextWriter writer) {
+        IReadOnlyList<IReadOnlyList<string>> rows = controls
             .Select(control => (IReadOnlyList<string>)new[] {
                 control.ParentWindow.ProcessId.ToString(),
                 control.Id.ToString(),
@@ -67,7 +71,18 @@ internal static class ControlCommands {
                 control.ParentWindow.Title
             })
             .ToArray();
-        OutputFormatter.WriteTable(new[] { "PID", "Id", "Handle", "Source", "Type", "X", "Y", "Width", "Height", "Enabled", "Focusable", "Offscreen", "BgClick", "BgText", "BgKeys", "FgFallback", "AutomationId", "Class", "Text", "Value", "Window" }, rows);
+
+        OutputFormatter.WriteTable(writer, new[] { "PID", "Id", "Handle", "Source", "Type", "X", "Y", "Width", "Height", "Enabled", "Focusable", "Offscreen", "BgClick", "BgText", "BgKeys", "FgFallback", "AutomationId", "Class", "Text", "Value", "Window" }, rows);
+        return 0;
+    }
+
+    internal static int WriteNoMatchingControls(TextWriter writer) {
+        writer.WriteLine("No matching controls found.");
+        return 0;
+    }
+
+    internal static int WriteNoMatchingDiagnosticWindows(TextWriter writer) {
+        writer.WriteLine("No matching windows found for control diagnostics.");
         return 0;
     }
 
@@ -108,33 +123,10 @@ internal static class ControlCommands {
         }
 
         if (diagnostics.Count == 0) {
-            Console.WriteLine("No matching windows found for control diagnostics.");
-            return 0;
+            return WriteNoMatchingDiagnosticWindows(Console.Out);
         }
 
-        foreach (ControlDiagnosticResult diagnostic in diagnostics) {
-            Console.WriteLine($"window: {diagnostic.Window.Title} ({diagnostic.Window.Handle})");
-            Console.WriteLine($"effective-source: {diagnostic.EffectiveSource}");
-            Console.WriteLine($"elapsed-ms: {diagnostic.ElapsedMilliseconds}");
-            Console.WriteLine($"uia: required={diagnostic.RequiresUiAutomation} available={diagnostic.UiAutomationAvailable} requested={diagnostic.UseUiAutomation} include={diagnostic.IncludeUiAutomation}");
-            Console.WriteLine($"preparation: attempted={diagnostic.PreparationAttempted} succeeded={diagnostic.PreparationSucceeded} ensureForeground={diagnostic.EnsureForegroundWindow}");
-            Console.WriteLine($"fallback-roots: count={diagnostic.UiAutomationFallbackRootCount} used={diagnostic.UsedUiAutomationFallbackRoots} cached={diagnostic.UsedCachedUiAutomationControls} preferred={diagnostic.PreferredUiAutomationRootHandle} reused={diagnostic.UsedPreferredUiAutomationRoot}");
-            Console.WriteLine($"counts: win32={diagnostic.Win32ControlCount} uia={diagnostic.UiAutomationControlCount} effective={diagnostic.EffectiveControlCount} matched={diagnostic.MatchedControlCount}");
-            if (diagnostic.UiAutomationActionProbe != null) {
-                Console.WriteLine($"action-probe: attempted={diagnostic.UiAutomationActionProbe.Attempted} resolved={diagnostic.UiAutomationActionProbe.Resolved} cached={diagnostic.UiAutomationActionProbe.UsedCachedActionMatch} preferred={diagnostic.UiAutomationActionProbe.UsedPreferredRoot} root={diagnostic.UiAutomationActionProbe.RootHandle} score={diagnostic.UiAutomationActionProbe.Score} mode={diagnostic.UiAutomationActionProbe.SearchMode} elapsed-ms={diagnostic.UiAutomationActionProbe.ElapsedMilliseconds}");
-            }
-            foreach (UiAutomationRootDiagnosticResult root in diagnostic.UiAutomationRoots) {
-                Console.WriteLine($"root[{root.Order}]: handle={root.Handle} class={root.ClassName} primary={root.IsPrimaryRoot} preferred={root.IsPreferredRoot} cached={root.UsedCachedControls} includeRoot={root.IncludeRoot} elementResolved={root.ElementResolved} count={root.ControlCount} error={root.Error ?? string.Empty}");
-                foreach (ControlResult sample in root.SampleControls) {
-                    Console.WriteLine($"  * {sample.Source} {sample.ControlType} {sample.AutomationId} {sample.Text}");
-                }
-            }
-            foreach (ControlResult sample in diagnostic.SampleControls) {
-                Console.WriteLine($"- {sample.Source} {sample.ControlType} {sample.AutomationId} {sample.Text}");
-            }
-            Console.WriteLine();
-        }
-
+        WriteDiagnosticResults(diagnostics, Console.Out);
         return 0;
     }
 
@@ -160,11 +152,7 @@ internal static class ControlCommands {
             return 0;
         }
 
-        Console.WriteLine($"wait: {result.Count} control(s) after {result.ElapsedMilliseconds}ms");
-        foreach (ControlResult control in result.Controls) {
-            Console.WriteLine($"- {control.ControlType} {control.Text} in {control.ParentWindow.Title}");
-        }
-        return 0;
+        return WriteWaitResult(result, Console.Out);
     }
 
     private static int AssertValue(CommandLineArguments arguments) {
@@ -193,12 +181,7 @@ internal static class ControlCommands {
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(result);
         } else {
-            Console.WriteLine(result.Matched ? "Control value assertion passed." : "Control value assertion failed.");
-            Console.WriteLine($"assertion: {result.PropertyName} {result.MatchMode} \"{result.Expected}\"");
-            Console.WriteLine($"matched: {result.MatchedCount}/{result.Count}");
-            foreach (ControlResult control in result.Controls) {
-                Console.WriteLine($"- {control.ControlType} value=\"{control.Value}\" text=\"{control.Text}\" in {control.ParentWindow.Title}");
-            }
+            return WriteValueAssertionResult(result, Console.Out);
         }
 
         return result.Matched ? 0 : 2;
@@ -281,23 +264,84 @@ internal static class ControlCommands {
             return 0;
         }
 
-        Console.WriteLine($"{result.Action}: {result.Count} control(s) success={result.Success} safety={result.SafetyMode} elapsed-ms={result.ElapsedMilliseconds}");
+        return WriteActionResult(result, Console.Out);
+    }
+
+    internal static int WriteActionResult(ControlActionResult result, TextWriter writer) {
+        writer.WriteLine($"{result.Action}: {result.Count} control(s) success={result.Success} safety={result.SafetyMode} elapsed-ms={result.ElapsedMilliseconds}");
         if (!string.IsNullOrWhiteSpace(result.TargetName)) {
-            Console.WriteLine($"target: {result.TargetKind ?? "selector"} {result.TargetName}");
+            writer.WriteLine($"target: {result.TargetKind ?? "selector"} {result.TargetName}");
         }
 
         if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
-            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+            writer.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
         }
 
         foreach (string warning in result.ArtifactWarnings) {
-            Console.WriteLine($"warning: {warning}");
+            writer.WriteLine($"warning: {warning}");
         }
 
         foreach (ControlResult control in result.Controls) {
-            Console.WriteLine($"- {control.ClassName} [{control.Id}] in {control.ParentWindow.Title}");
+            writer.WriteLine($"- {control.ClassName} [{control.Id}] in {control.ParentWindow.Title}");
         }
         return 0;
+    }
+
+    internal static int WriteWaitResult(WaitForControlResult result, TextWriter writer) {
+        writer.WriteLine($"wait: {result.Count} control(s) after {result.ElapsedMilliseconds}ms");
+        foreach (ControlResult control in result.Controls) {
+            writer.WriteLine($"- {control.ControlType} {control.Text} in {control.ParentWindow.Title}");
+        }
+
+        return 0;
+    }
+
+    internal static int WriteValueAssertionResult(ControlValueAssertionResult result, TextWriter writer) {
+        writer.WriteLine(result.Matched ? "Control value assertion passed." : "Control value assertion failed.");
+        writer.WriteLine($"assertion: {result.PropertyName} {result.MatchMode} \"{result.Expected}\"");
+        writer.WriteLine($"matched: {result.MatchedCount}/{result.Count}");
+        foreach (ControlResult control in result.Controls) {
+            writer.WriteLine($"- {control.ControlType} value=\"{control.Value}\" text=\"{control.Text}\" in {control.ParentWindow.Title}");
+        }
+
+        return result.Matched ? 0 : 2;
+    }
+
+    internal static int WriteAssertionResult(ControlAssertionResult result, string successText, string failureText, TextWriter writer) {
+        writer.WriteLine(result.Matched ? successText : failureText);
+        foreach (ControlResult control in result.Controls) {
+            writer.WriteLine($"- {control.ControlType} {control.Text} in {control.ParentWindow.Title}");
+        }
+
+        return result.Matched ? 0 : 2;
+    }
+
+    internal static void WriteDiagnosticResults(IReadOnlyList<ControlDiagnosticResult> diagnostics, TextWriter writer) {
+        foreach (ControlDiagnosticResult diagnostic in diagnostics) {
+            writer.WriteLine($"window: {diagnostic.Window.Title} ({diagnostic.Window.Handle})");
+            writer.WriteLine($"effective-source: {diagnostic.EffectiveSource}");
+            writer.WriteLine($"elapsed-ms: {diagnostic.ElapsedMilliseconds}");
+            writer.WriteLine($"uia: required={diagnostic.RequiresUiAutomation} available={diagnostic.UiAutomationAvailable} requested={diagnostic.UseUiAutomation} include={diagnostic.IncludeUiAutomation}");
+            writer.WriteLine($"preparation: attempted={diagnostic.PreparationAttempted} succeeded={diagnostic.PreparationSucceeded} ensureForeground={diagnostic.EnsureForegroundWindow}");
+            writer.WriteLine($"fallback-roots: count={diagnostic.UiAutomationFallbackRootCount} used={diagnostic.UsedUiAutomationFallbackRoots} cached={diagnostic.UsedCachedUiAutomationControls} preferred={diagnostic.PreferredUiAutomationRootHandle} reused={diagnostic.UsedPreferredUiAutomationRoot}");
+            writer.WriteLine($"counts: win32={diagnostic.Win32ControlCount} uia={diagnostic.UiAutomationControlCount} effective={diagnostic.EffectiveControlCount} matched={diagnostic.MatchedControlCount}");
+            if (diagnostic.UiAutomationActionProbe != null) {
+                writer.WriteLine($"action-probe: attempted={diagnostic.UiAutomationActionProbe.Attempted} resolved={diagnostic.UiAutomationActionProbe.Resolved} cached={diagnostic.UiAutomationActionProbe.UsedCachedActionMatch} preferred={diagnostic.UiAutomationActionProbe.UsedPreferredRoot} root={diagnostic.UiAutomationActionProbe.RootHandle} score={diagnostic.UiAutomationActionProbe.Score} mode={diagnostic.UiAutomationActionProbe.SearchMode} elapsed-ms={diagnostic.UiAutomationActionProbe.ElapsedMilliseconds}");
+            }
+
+            foreach (UiAutomationRootDiagnosticResult root in diagnostic.UiAutomationRoots) {
+                writer.WriteLine($"root[{root.Order}]: handle={root.Handle} class={root.ClassName} primary={root.IsPrimaryRoot} preferred={root.IsPreferredRoot} cached={root.UsedCachedControls} includeRoot={root.IncludeRoot} elementResolved={root.ElementResolved} count={root.ControlCount} error={root.Error ?? string.Empty}");
+                foreach (ControlResult sample in root.SampleControls) {
+                    writer.WriteLine($"  * {sample.Source} {sample.ControlType} {sample.AutomationId} {sample.Text}");
+                }
+            }
+
+            foreach (ControlResult sample in diagnostic.SampleControls) {
+                writer.WriteLine($"- {sample.Source} {sample.ControlType} {sample.AutomationId} {sample.Text}");
+            }
+
+            writer.WriteLine();
+        }
     }
 
     private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
@@ -319,16 +363,13 @@ internal static class ControlCommands {
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(result);
         } else {
-            Console.WriteLine(result.Matched ? successText : failureText);
-            foreach (ControlResult control in result.Controls) {
-                Console.WriteLine($"- {control.ControlType} {control.Text} in {control.ParentWindow.Title}");
-            }
+            return WriteAssertionResult(result, successText, failureText, Console.Out);
         }
 
         return result.Matched ? 0 : 2;
     }
 
-    private static WindowSelectionCriteria CreateWindowCriteria(CommandLineArguments arguments) {
+    internal static WindowSelectionCriteria CreateWindowCriteria(CommandLineArguments arguments) {
         return new WindowSelectionCriteria {
             TitlePattern = arguments.GetOption("window-title") ?? arguments.GetOption("title") ?? "*",
             ProcessNamePattern = arguments.GetOption("window-process") ?? arguments.GetOption("process") ?? "*",
@@ -343,7 +384,7 @@ internal static class ControlCommands {
         };
     }
 
-    private static ControlSelectionCriteria CreateControlCriteria(CommandLineArguments arguments) {
+    internal static ControlSelectionCriteria CreateControlCriteria(CommandLineArguments arguments) {
         return new ControlSelectionCriteria {
             ClassNamePattern = arguments.GetOption("class") ?? "*",
             TextPattern = arguments.GetOption("text-pattern") ?? "*",

--- a/Sources/DesktopManager.Cli/ControlTargetCommands.cs
+++ b/Sources/DesktopManager.Cli/ControlTargetCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -26,9 +27,7 @@ internal static class ControlTargetCommands {
             return 0;
         }
 
-        Console.WriteLine($"save: {result.Name}");
-        Console.WriteLine(result.Path);
-        return 0;
+        return WriteSavedTargetResult(result, Console.Out);
     }
 
     private static int Get(CommandLineArguments arguments) {
@@ -38,21 +37,7 @@ internal static class ControlTargetCommands {
             return 0;
         }
 
-        Console.WriteLine(result.Name);
-        Console.WriteLine($"- Path: {result.Path}");
-        Console.WriteLine($"- Class: {result.Target.ClassNamePattern}");
-        Console.WriteLine($"- Text: {result.Target.TextPattern}");
-        Console.WriteLine($"- Value: {result.Target.ValuePattern}");
-        Console.WriteLine($"- ControlType: {result.Target.ControlTypePattern}");
-        Console.WriteLine($"- AutomationId: {result.Target.AutomationIdPattern}");
-        Console.WriteLine($"- BackgroundClick: {result.Target.SupportsBackgroundClick?.ToString() ?? "-"}");
-        Console.WriteLine($"- BackgroundText: {result.Target.SupportsBackgroundText?.ToString() ?? "-"}");
-        Console.WriteLine($"- BackgroundKeys: {result.Target.SupportsBackgroundKeys?.ToString() ?? "-"}");
-        Console.WriteLine($"- ForegroundFallback: {result.Target.SupportsForegroundInputFallback?.ToString() ?? "-"}");
-        if (!string.IsNullOrWhiteSpace(result.Target.Description)) {
-            Console.WriteLine($"- Description: {result.Target.Description}");
-        }
-        return 0;
+        return WriteTargetResult(result, Console.Out);
     }
 
     private static int List(CommandLineArguments arguments) {
@@ -62,16 +47,7 @@ internal static class ControlTargetCommands {
             return 0;
         }
 
-        if (names.Count == 0) {
-            Console.WriteLine("No named control targets found.");
-            return 0;
-        }
-
-        foreach (string name in names.OrderBy(value => value, StringComparer.OrdinalIgnoreCase)) {
-            Console.WriteLine(name);
-        }
-
-        return 0;
+        return WriteTargetNames(names, Console.Out);
     }
 
     private static int Resolve(CommandLineArguments arguments) {
@@ -85,18 +61,58 @@ internal static class ControlTargetCommands {
             return 0;
         }
 
+        return WriteResolvedTargets(results, Console.Out);
+    }
+
+    internal static int WriteSavedTargetResult(ControlTargetResult result, TextWriter writer) {
+        writer.WriteLine($"save: {result.Name}");
+        writer.WriteLine(result.Path);
+        return 0;
+    }
+
+    internal static int WriteTargetResult(ControlTargetResult result, TextWriter writer) {
+        writer.WriteLine(result.Name);
+        writer.WriteLine($"- Path: {result.Path}");
+        writer.WriteLine($"- Class: {result.Target.ClassNamePattern}");
+        writer.WriteLine($"- Text: {result.Target.TextPattern}");
+        writer.WriteLine($"- Value: {result.Target.ValuePattern}");
+        writer.WriteLine($"- ControlType: {result.Target.ControlTypePattern}");
+        writer.WriteLine($"- AutomationId: {result.Target.AutomationIdPattern}");
+        writer.WriteLine($"- BackgroundClick: {result.Target.SupportsBackgroundClick?.ToString() ?? "-"}");
+        writer.WriteLine($"- BackgroundText: {result.Target.SupportsBackgroundText?.ToString() ?? "-"}");
+        writer.WriteLine($"- BackgroundKeys: {result.Target.SupportsBackgroundKeys?.ToString() ?? "-"}");
+        writer.WriteLine($"- ForegroundFallback: {result.Target.SupportsForegroundInputFallback?.ToString() ?? "-"}");
+        if (!string.IsNullOrWhiteSpace(result.Target.Description)) {
+            writer.WriteLine($"- Description: {result.Target.Description}");
+        }
+        return 0;
+    }
+
+    internal static int WriteTargetNames(IReadOnlyList<string> names, TextWriter writer) {
+        if (names.Count == 0) {
+            writer.WriteLine("No named control targets found.");
+            return 0;
+        }
+
+        foreach (string name in names.OrderBy(value => value, StringComparer.OrdinalIgnoreCase)) {
+            writer.WriteLine(name);
+        }
+        return 0;
+    }
+
+    internal static int WriteResolvedTargets(IReadOnlyList<ResolvedControlTargetResult> results, TextWriter writer) {
         foreach (ResolvedControlTargetResult result in results) {
-            Console.WriteLine($"{result.Name}: {result.Window.Title} ({result.Window.Handle})");
-            Console.WriteLine($"- Control: {result.Control.ControlType} {result.Control.Text}");
-            Console.WriteLine($"- Handle: {result.Control.Handle}");
-            Console.WriteLine($"- BackgroundText: {result.Control.SupportsBackgroundText}");
-            Console.WriteLine($"- ForegroundFallback: {result.Control.SupportsForegroundInputFallback}");
+            writer.WriteLine($"{result.Name}: {result.Window.Title} ({result.Window.Handle})");
+            writer.WriteLine($"- Control: {result.Control.ControlType} {result.Control.Text}");
+            writer.WriteLine($"- Handle: {result.Control.Handle}");
+            writer.WriteLine($"- BackgroundText: {result.Control.SupportsBackgroundText}");
+            writer.WriteLine($"- ForegroundFallback: {result.Control.SupportsForegroundInputFallback}");
         }
 
         return 0;
     }
 
-    private static WindowSelectionCriteria CreateWindowCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
+    internal static WindowSelectionCriteria CreateWindowCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
         return new WindowSelectionCriteria {
             TitlePattern = arguments.GetOption("title") ?? "*",
             ProcessNamePattern = arguments.GetOption("process") ?? "*",
@@ -112,7 +128,7 @@ internal static class ControlTargetCommands {
         };
     }
 
-    private static ControlSelectionCriteria CreateControlCriteria(CommandLineArguments arguments) {
+    internal static ControlSelectionCriteria CreateControlCriteria(CommandLineArguments arguments) {
         return new ControlSelectionCriteria {
             ClassNamePattern = arguments.GetOption("class") ?? "*",
             TextPattern = arguments.GetOption("text-pattern") ?? "*",

--- a/Sources/DesktopManager.Cli/DesktopManager.Cli.csproj
+++ b/Sources/DesktopManager.Cli/DesktopManager.Cli.csproj
@@ -13,4 +13,10 @@
     <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DesktopManager.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/Sources/DesktopManager.Cli/DesktopModels.cs
+++ b/Sources/DesktopManager.Cli/DesktopModels.cs
@@ -329,6 +329,49 @@ internal sealed class ScreenshotResult {
     public WindowGeometryResult? Geometry { get; set; }
 }
 
+internal sealed class DesktopScreenshotCommandOptions {
+    public int? MonitorIndex { get; set; }
+    public string? DeviceId { get; set; }
+    public string? DeviceName { get; set; }
+    public int? Left { get; set; }
+    public int? Top { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+    public string? OutputPath { get; set; }
+}
+
+internal sealed class ProcessStartCommandOptions {
+    public string FilePath { get; set; } = string.Empty;
+    public string? Arguments { get; set; }
+    public string? WorkingDirectory { get; set; }
+    public int? WaitForInputIdleMilliseconds { get; set; }
+    public int? WaitForWindowMilliseconds { get; set; }
+    public int? WaitForWindowIntervalMilliseconds { get; set; }
+    public string? WindowTitlePattern { get; set; }
+    public string? WindowClassNamePattern { get; set; }
+    public bool RequireWindow { get; set; }
+}
+
+internal sealed class LaunchAndWaitCommandOptions {
+    public string FilePath { get; set; } = string.Empty;
+    public string? Arguments { get; set; }
+    public string? WorkingDirectory { get; set; }
+    public int? WaitForInputIdleMilliseconds { get; set; }
+    public int? LaunchWaitForWindowMilliseconds { get; set; }
+    public int? LaunchWaitForWindowIntervalMilliseconds { get; set; }
+    public string? LaunchWindowTitlePattern { get; set; }
+    public string? LaunchWindowClassNamePattern { get; set; }
+    public string? WindowTitlePattern { get; set; }
+    public string? WindowClassNamePattern { get; set; }
+    public bool IncludeHidden { get; set; }
+    public bool IncludeEmpty { get; set; }
+    public bool All { get; set; }
+    public bool FollowProcessFamily { get; set; }
+    public int TimeoutMilliseconds { get; set; }
+    public int IntervalMilliseconds { get; set; }
+    public MutationArtifactOptions? ArtifactOptions { get; set; }
+}
+
 internal sealed class ProcessLaunchResult {
     public string FilePath { get; set; } = string.Empty;
     public string? Arguments { get; set; }
@@ -345,12 +388,22 @@ internal sealed class LaunchAndWaitResult {
     public int ElapsedMilliseconds { get; set; }
     public int WaitTimeoutMilliseconds { get; set; }
     public int WaitIntervalMilliseconds { get; set; }
+    public string WaitBinding { get; set; } = string.Empty;
+    public int? BoundProcessId { get; set; }
+    public string? BoundProcessName { get; set; }
     public ProcessLaunchResult Launch { get; set; } = new();
     public WaitForWindowResult WindowWait { get; set; } = new();
     public IReadOnlyList<string> Notes { get; set; } = new List<string>();
     public IReadOnlyList<ScreenshotResult> BeforeScreenshots { get; set; } = new List<ScreenshotResult>();
     public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
     public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
+}
+
+internal sealed class LaunchWaitBindingPlan {
+    public WindowSelectionCriteria Criteria { get; set; } = new();
+    public string WaitBinding { get; set; } = string.Empty;
+    public int? BoundProcessId { get; set; }
+    public string? BoundProcessName { get; set; }
 }
 
 internal sealed class WaitForWindowResult {

--- a/Sources/DesktopManager.Cli/DesktopOperations.ProcessWorkflows.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.ProcessWorkflows.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
 internal static partial class DesktopOperations {
-    public static LaunchAndWaitResult LaunchAndWaitForWindow(string filePath, string? arguments, string? workingDirectory, int? waitForInputIdleMilliseconds, int? launchWaitForWindowMilliseconds, int? launchWaitForWindowIntervalMilliseconds, string? launchWindowTitlePattern, string? launchWindowClassNamePattern, string? windowTitlePattern, string? windowClassNamePattern, bool includeHidden, bool includeEmpty, bool all, int timeoutMilliseconds, int intervalMilliseconds, MutationArtifactOptions? artifactOptions = null) {
+    public static LaunchAndWaitResult LaunchAndWaitForWindow(string filePath, string? arguments, string? workingDirectory, int? waitForInputIdleMilliseconds, int? launchWaitForWindowMilliseconds, int? launchWaitForWindowIntervalMilliseconds, string? launchWindowTitlePattern, string? launchWindowClassNamePattern, string? windowTitlePattern, string? windowClassNamePattern, bool includeHidden, bool includeEmpty, bool all, bool followProcessFamily, int timeoutMilliseconds, int intervalMilliseconds, MutationArtifactOptions? artifactOptions = null) {
         if (string.IsNullOrWhiteSpace(filePath)) {
             throw new CommandLineException("Process path is required.");
         }
@@ -39,23 +40,33 @@ internal static partial class DesktopOperations {
                 launchWindowClassNamePattern,
                 requireWindow: false);
 
-            int processId = launch.ResolvedProcessId ?? launch.ProcessId;
-            notes.Add($"Launched process {processId} from '{launch.FilePath}'.");
+            LaunchWaitBindingPlan waitPlan = CreateLaunchWaitBindingPlan(
+                launch,
+                launchWindowTitlePattern,
+                launchWindowClassNamePattern,
+                windowTitlePattern,
+                windowClassNamePattern,
+                includeHidden,
+                includeEmpty,
+                all,
+                followProcessFamily);
+            WindowSelectionCriteria waitCriteria = waitPlan.Criteria;
 
-            var waitCriteria = new WindowSelectionCriteria {
-                TitlePattern = windowTitlePattern ?? launchWindowTitlePattern ?? "*",
-                ClassNamePattern = windowClassNamePattern ?? launchWindowClassNamePattern ?? "*",
-                ProcessId = processId,
-                IncludeHidden = includeHidden,
-                IncludeCloaked = false,
-                IncludeOwned = true,
-                IncludeEmptyTitles = includeEmpty,
-                All = all
-            };
-            notes.Add($"Wait selector: processId={processId}, title='{waitCriteria.TitlePattern}', class='{waitCriteria.ClassNamePattern}'.");
+            notes.Add($"Launched process {launch.ProcessId} from '{launch.FilePath}'.");
+            if (launch.ResolvedProcessId.HasValue && launch.ResolvedProcessId.Value != launch.ProcessId) {
+                notes.Add($"Launch-time window correlation resolved process {launch.ResolvedProcessId.Value}.");
+            }
+
+            if (waitPlan.BoundProcessId.HasValue) {
+                notes.Add($"Wait selector bound to processId={waitPlan.BoundProcessId.Value}, title='{waitCriteria.TitlePattern}', class='{waitCriteria.ClassNamePattern}'.");
+            } else {
+                notes.Add($"Wait selector bound to processName='{waitPlan.BoundProcessName}', title='{waitCriteria.TitlePattern}', class='{waitCriteria.ClassNamePattern}'.");
+            }
 
             WaitForWindowResult waitResult = WaitForWindow(waitCriteria, timeoutMilliseconds, intervalMilliseconds);
-            notes.Add($"Resolved {waitResult.Count} window(s) for process {processId}.");
+            notes.Add(waitPlan.BoundProcessId.HasValue
+                ? $"Resolved {waitResult.Count} window(s) for process {waitPlan.BoundProcessId.Value}."
+                : $"Resolved {waitResult.Count} window(s) for process family '{waitPlan.BoundProcessName}'.");
 
             IReadOnlyList<ScreenshotResult> afterScreenshots;
             if (options.CaptureAfter) {
@@ -78,6 +89,9 @@ internal static partial class DesktopOperations {
                 ElapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds,
                 WaitTimeoutMilliseconds = timeoutMilliseconds,
                 WaitIntervalMilliseconds = intervalMilliseconds,
+                WaitBinding = waitPlan.WaitBinding,
+                BoundProcessId = waitPlan.BoundProcessId,
+                BoundProcessName = waitPlan.BoundProcessName,
                 Launch = launch,
                 WindowWait = waitResult,
                 Notes = notes,
@@ -86,5 +100,90 @@ internal static partial class DesktopOperations {
                 ArtifactWarnings = warnings
             };
         });
+    }
+
+    internal static LaunchWaitBindingPlan CreateLaunchWaitBindingPlan(ProcessLaunchResult launch, string? launchWindowTitlePattern, string? launchWindowClassNamePattern, string? windowTitlePattern, string? windowClassNamePattern, bool includeHidden, bool includeEmpty, bool all, bool followProcessFamily) {
+        var criteria = new WindowSelectionCriteria {
+            TitlePattern = windowTitlePattern ?? launchWindowTitlePattern ?? "*",
+            ClassNamePattern = windowClassNamePattern ?? launchWindowClassNamePattern ?? "*",
+            IncludeHidden = includeHidden,
+            IncludeCloaked = false,
+            IncludeOwned = true,
+            IncludeEmptyTitles = includeEmpty,
+            All = all
+        };
+
+        if (launch.ResolvedProcessId.HasValue) {
+            return new LaunchWaitBindingPlan {
+                Criteria = {
+                    TitlePattern = criteria.TitlePattern,
+                    ClassNamePattern = criteria.ClassNamePattern,
+                    IncludeHidden = criteria.IncludeHidden,
+                    IncludeCloaked = criteria.IncludeCloaked,
+                    IncludeOwned = criteria.IncludeOwned,
+                    IncludeEmptyTitles = criteria.IncludeEmptyTitles,
+                    All = criteria.All,
+                    ProcessId = launch.ResolvedProcessId.Value
+                },
+                WaitBinding = "resolved-process-id",
+                BoundProcessId = launch.ResolvedProcessId.Value
+            };
+        }
+
+        if (!followProcessFamily) {
+            return new LaunchWaitBindingPlan {
+                Criteria = {
+                    TitlePattern = criteria.TitlePattern,
+                    ClassNamePattern = criteria.ClassNamePattern,
+                    IncludeHidden = criteria.IncludeHidden,
+                    IncludeCloaked = criteria.IncludeCloaked,
+                    IncludeOwned = criteria.IncludeOwned,
+                    IncludeEmptyTitles = criteria.IncludeEmptyTitles,
+                    All = criteria.All,
+                    ProcessId = launch.ProcessId
+                },
+                WaitBinding = "launcher-process-id",
+                BoundProcessId = launch.ProcessId
+            };
+        }
+
+        string? processNameHint = GetProcessNameHint(launch.FilePath);
+        if (string.IsNullOrWhiteSpace(processNameHint)) {
+            return new LaunchWaitBindingPlan {
+                Criteria = {
+                    TitlePattern = criteria.TitlePattern,
+                    ClassNamePattern = criteria.ClassNamePattern,
+                    IncludeHidden = criteria.IncludeHidden,
+                    IncludeCloaked = criteria.IncludeCloaked,
+                    IncludeOwned = criteria.IncludeOwned,
+                    IncludeEmptyTitles = criteria.IncludeEmptyTitles,
+                    All = criteria.All,
+                    ProcessId = launch.ProcessId
+                },
+                WaitBinding = "launcher-process-id",
+                BoundProcessId = launch.ProcessId
+            };
+        }
+
+        return new LaunchWaitBindingPlan {
+            Criteria = {
+                TitlePattern = criteria.TitlePattern,
+                ClassNamePattern = criteria.ClassNamePattern,
+                IncludeHidden = criteria.IncludeHidden,
+                IncludeCloaked = criteria.IncludeCloaked,
+                IncludeOwned = criteria.IncludeOwned,
+                IncludeEmptyTitles = criteria.IncludeEmptyTitles,
+                All = criteria.All,
+                ProcessNamePattern = processNameHint
+            },
+            WaitBinding = "process-name-family",
+            BoundProcessName = processNameHint
+        };
+    }
+
+    private static string? GetProcessNameHint(string filePath) {
+        string trimmed = filePath.Trim().Trim('"');
+        string executableName = Path.GetFileNameWithoutExtension(trimmed);
+        return string.IsNullOrWhiteSpace(executableName) ? null : executableName;
     }
 }

--- a/Sources/DesktopManager.Cli/DesktopOperations.Workflows.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.Workflows.cs
@@ -204,22 +204,38 @@ internal static partial class DesktopOperations {
                 : Array.Empty<ScreenshotResult>();
 
             stopwatch.Stop();
-            return new WorkflowResult {
-                Action = action,
-                Success = outcome.Success,
-                ElapsedMilliseconds = (int)stopwatch.ElapsedMilliseconds,
-                LayoutName = layoutName,
-                LayoutApplied = outcome.LayoutApplied,
-                MinimizedCount = outcome.MinimizedWindows.Count,
-                MinimizedWindows = outcome.MinimizedWindows,
-                ResolvedWindow = outcome.ResolvedWindow,
-                FocusedWindow = outcome.FocusedWindow,
-                Notes = notes,
-                BeforeScreenshots = beforeScreenshots,
-                AfterScreenshots = afterScreenshots,
-                ArtifactWarnings = warnings
-            };
+            return BuildWorkflowResult(
+                action,
+                outcome.Success,
+                (int)stopwatch.ElapsedMilliseconds,
+                layoutName,
+                outcome.LayoutApplied,
+                outcome.MinimizedWindows,
+                outcome.ResolvedWindow,
+                outcome.FocusedWindow,
+                notes,
+                beforeScreenshots,
+                afterScreenshots,
+                warnings);
         });
+    }
+
+    internal static WorkflowResult BuildWorkflowResult(string action, bool success, int elapsedMilliseconds, string? layoutName, bool layoutApplied, IReadOnlyList<WindowResult> minimizedWindows, WindowResult? resolvedWindow, WindowResult? focusedWindow, IReadOnlyList<string> notes, IReadOnlyList<ScreenshotResult> beforeScreenshots, IReadOnlyList<ScreenshotResult> afterScreenshots, IReadOnlyList<string> artifactWarnings) {
+        return new WorkflowResult {
+            Action = action,
+            Success = success,
+            ElapsedMilliseconds = elapsedMilliseconds,
+            LayoutName = layoutName,
+            LayoutApplied = layoutApplied,
+            MinimizedCount = minimizedWindows.Count,
+            MinimizedWindows = minimizedWindows,
+            ResolvedWindow = resolvedWindow,
+            FocusedWindow = focusedWindow,
+            Notes = notes,
+            BeforeScreenshots = beforeScreenshots,
+            AfterScreenshots = afterScreenshots,
+            ArtifactWarnings = artifactWarnings
+        };
     }
 
     private static IReadOnlyList<ScreenshotResult> CaptureDesktopArtifacts(string action, string phase, MutationArtifactOptions options, List<string> warnings) {

--- a/Sources/DesktopManager.Cli/DesktopOperations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.cs
@@ -554,15 +554,7 @@ internal static partial class DesktopOperations {
                 RequireWindow = requireWindow
             });
 
-            return new ProcessLaunchResult {
-                FilePath = result.FilePath,
-                Arguments = result.Arguments,
-                WorkingDirectory = result.WorkingDirectory,
-                ProcessId = result.ProcessId,
-                ResolvedProcessId = result.ResolvedProcessId,
-                HasExited = result.HasExited,
-                MainWindow = result.MainWindow == null ? null : MapWindow(result.MainWindow)
-            };
+            return BuildProcessLaunchResult(result);
         });
     }
 
@@ -652,6 +644,18 @@ internal static partial class DesktopOperations {
         };
     }
 
+    internal static ProcessLaunchResult BuildProcessLaunchResult(DesktopProcessLaunchInfo result) {
+        return new ProcessLaunchResult {
+            FilePath = result.FilePath,
+            Arguments = result.Arguments,
+            WorkingDirectory = result.WorkingDirectory,
+            ProcessId = result.ProcessId,
+            ResolvedProcessId = result.ResolvedProcessId,
+            HasExited = result.HasExited,
+            MainWindow = result.MainWindow == null ? null : MapWindow(result.MainWindow)
+        };
+    }
+
     private static WindowResult MapWindow(WindowInfo window) {
         return new WindowResult {
             Title = window.Title,
@@ -670,7 +674,7 @@ internal static partial class DesktopOperations {
         };
     }
 
-    private static WindowGeometryResult MapWindowGeometry(DesktopWindowGeometry geometry) {
+    internal static WindowGeometryResult MapWindowGeometry(DesktopWindowGeometry geometry) {
         return new WindowGeometryResult {
             Window = MapWindow(geometry.Window),
             WindowLeft = geometry.WindowLeft,
@@ -740,7 +744,7 @@ internal static partial class DesktopOperations {
         };
     }
 
-    private static ResolvedWindowTargetResult MapResolvedWindowTarget(DesktopResolvedWindowTarget target) {
+    internal static ResolvedWindowTargetResult MapResolvedWindowTarget(DesktopResolvedWindowTarget target) {
         return new ResolvedWindowTargetResult {
             Name = target.Name,
             Target = MapWindowTargetDefinition(target.Definition),
@@ -757,7 +761,7 @@ internal static partial class DesktopOperations {
         };
     }
 
-    private static ResolvedControlTargetResult MapResolvedControlTarget(DesktopResolvedControlTarget target) {
+    internal static ResolvedControlTargetResult MapResolvedControlTarget(DesktopResolvedControlTarget target) {
         return new ResolvedControlTargetResult {
             Name = target.Name,
             Target = MapControlTargetDefinition(target.Definition),
@@ -796,7 +800,7 @@ internal static partial class DesktopOperations {
         };
     }
 
-    private static ControlDiagnosticResult MapControlDiagnostics(DesktopControlDiscoveryDiagnostics diagnostics) {
+    internal static ControlDiagnosticResult MapControlDiagnostics(DesktopControlDiscoveryDiagnostics diagnostics) {
         return new ControlDiagnosticResult {
             Window = MapWindow(diagnostics.Window),
             RequiresUiAutomation = diagnostics.RequiresUiAutomation,
@@ -937,7 +941,7 @@ internal static partial class DesktopOperations {
             !string.IsNullOrWhiteSpace(criteria.Handle);
     }
 
-    private static WindowQueryOptions CreateWindowQuery(WindowSelectionCriteria criteria) {
+    internal static WindowQueryOptions CreateWindowQuery(WindowSelectionCriteria criteria) {
         return new WindowQueryOptions {
             TitlePattern = criteria.TitlePattern,
             ProcessNamePattern = criteria.ProcessNamePattern,
@@ -952,7 +956,7 @@ internal static partial class DesktopOperations {
         };
     }
 
-    private static WindowControlQueryOptions CreateControlQuery(ControlSelectionCriteria criteria) {
+    internal static WindowControlQueryOptions CreateControlQuery(ControlSelectionCriteria criteria) {
         return new WindowControlQueryOptions {
             ClassNamePattern = criteria.ClassNamePattern,
             TextPattern = criteria.TextPattern,

--- a/Sources/DesktopManager.Cli/HelpText.cs
+++ b/Sources/DesktopManager.Cli/HelpText.cs
@@ -297,13 +297,14 @@ Examples:
         return """
 Process commands:
   desktopmanager process start <file> [--arguments <text>] [--working-directory <path>] [--wait-for-input-idle-ms <value>] [--wait-for-window-ms <value>] [--wait-for-window-interval-ms <value>] [--window-title <pattern>] [--window-class <pattern>] [--require-window] [--json]
-  desktopmanager process start-and-wait <file> [--arguments <text>] [--working-directory <path>] [--wait-for-input-idle-ms <value>] [--launch-wait-for-window-ms <value>] [--launch-wait-for-window-interval-ms <value>] [--launch-window-title <pattern>] [--launch-window-class <pattern>] [--window-title <pattern>] [--window-class <pattern>] [--include-hidden] [--include-empty] [--timeout-ms <value>] [--interval-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager process start-and-wait <file> [--arguments <text>] [--working-directory <path>] [--wait-for-input-idle-ms <value>] [--launch-wait-for-window-ms <value>] [--launch-wait-for-window-interval-ms <value>] [--launch-window-title <pattern>] [--launch-window-class <pattern>] [--window-title <pattern>] [--window-class <pattern>] [--include-hidden] [--include-empty] [--follow-process-family] [--timeout-ms <value>] [--interval-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
 
 Examples:
   desktopmanager process start notepad.exe --wait-for-input-idle-ms 1000
   desktopmanager process start notepad.exe --wait-for-window-ms 5000
   desktopmanager process start notepad.exe --wait-for-window-ms 5000 --window-title "Untitled - Notepad" --require-window
   desktopmanager process start-and-wait notepad.exe --window-title "*Notepad*" --timeout-ms 5000 --capture-after --json
+  desktopmanager process start-and-wait msedge.exe --window-title "*Edge*" --follow-process-family --timeout-ms 10000 --json
   desktopmanager process start code --arguments "." --working-directory C:\Support\GitHub\DesktopManager
 """;
     }

--- a/Sources/DesktopManager.Cli/LayoutCommands.cs
+++ b/Sources/DesktopManager.Cli/LayoutCommands.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -31,15 +33,7 @@ internal static class LayoutCommands {
             return 0;
         }
 
-        if (names.Count == 0) {
-            Console.WriteLine("No named layouts found.");
-            return 0;
-        }
-
-        foreach (string name in names.OrderBy(value => value)) {
-            Console.WriteLine(name);
-        }
-        return 0;
+        return WriteLayoutNames(names, Console.Out);
     }
 
     private static int Assert(CommandLineArguments arguments) {
@@ -57,25 +51,7 @@ internal static class LayoutCommands {
             return result.Matched ? 0 : 2;
         }
 
-        Console.WriteLine($"assert-layout: matched={result.Matched} expected={result.ExpectedCount} matched-count={result.MatchedCount} missing={result.MissingCount} mismatched={result.MismatchCount}");
-        Console.WriteLine(result.Path);
-        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
-            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
-        }
-
-        foreach (SavedWindowLayoutEntryResult window in result.MissingWindows) {
-            Console.WriteLine($"missing: {window.Title} [PID {window.ProcessId}]");
-        }
-
-        foreach (WindowLayoutMismatchResult mismatch in result.MismatchedWindows) {
-            Console.WriteLine($"mismatch: {mismatch.Expected.Title} [PID {mismatch.Expected.ProcessId}] left={mismatch.LeftDelta} top={mismatch.TopDelta} width={mismatch.WidthDelta} height={mismatch.HeightDelta} state={mismatch.StateMatched}");
-        }
-
-        foreach (string warning in result.ArtifactWarnings) {
-            Console.WriteLine($"warning: {warning}");
-        }
-
-        return result.Matched ? 0 : 2;
+        return WriteLayoutAssertionResult(result, Console.Out);
     }
 
     private static int WritePathResult(CommandLineArguments arguments, NamedStateResult payload) {
@@ -84,8 +60,46 @@ internal static class LayoutCommands {
             return 0;
         }
 
-        Console.WriteLine($"{payload.Action}: {payload.Name}");
-        Console.WriteLine(payload.Path);
+        return WritePathResult(payload, Console.Out);
+    }
+
+    internal static int WriteLayoutNames(IReadOnlyList<string> names, TextWriter writer) {
+        if (names.Count == 0) {
+            writer.WriteLine("No named layouts found.");
+            return 0;
+        }
+
+        foreach (string name in names.OrderBy(value => value)) {
+            writer.WriteLine(name);
+        }
+        return 0;
+    }
+
+    internal static int WriteLayoutAssertionResult(WindowLayoutAssertionResult result, TextWriter writer) {
+        writer.WriteLine($"assert-layout: matched={result.Matched} expected={result.ExpectedCount} matched-count={result.MatchedCount} missing={result.MissingCount} mismatched={result.MismatchCount}");
+        writer.WriteLine(result.Path);
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            writer.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (SavedWindowLayoutEntryResult window in result.MissingWindows) {
+            writer.WriteLine($"missing: {window.Title} [PID {window.ProcessId}]");
+        }
+
+        foreach (WindowLayoutMismatchResult mismatch in result.MismatchedWindows) {
+            writer.WriteLine($"mismatch: {mismatch.Expected.Title} [PID {mismatch.Expected.ProcessId}] left={mismatch.LeftDelta} top={mismatch.TopDelta} width={mismatch.WidthDelta} height={mismatch.HeightDelta} state={mismatch.StateMatched}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            writer.WriteLine($"warning: {warning}");
+        }
+
+        return result.Matched ? 0 : 2;
+    }
+
+    internal static int WritePathResult(NamedStateResult payload, TextWriter writer) {
+        writer.WriteLine($"{payload.Action}: {payload.Name}");
+        writer.WriteLine(payload.Path);
         return 0;
     }
 

--- a/Sources/DesktopManager.Cli/McpCatalog.cs
+++ b/Sources/DesktopManager.Cli/McpCatalog.cs
@@ -605,6 +605,7 @@ internal static class McpCatalog {
                     ["windowClass"] = CreateStringSchema("Optional final window class filter."),
                     ["includeHidden"] = CreateBooleanSchema("Include hidden windows while waiting."),
                     ["includeEmpty"] = CreateBooleanSchema("Include windows with empty titles while waiting."),
+                    ["followProcessFamily"] = CreateBooleanSchema("When launch-time correlation did not resolve a concrete window process, allow the final wait to follow the launched app's same-name process family."),
                     ["all"] = CreateBooleanSchema("Return all matching windows instead of the first match."),
                     ["timeoutMs"] = CreateIntegerSchema("Maximum time to wait for the final window in milliseconds."),
                     ["intervalMs"] = CreateIntegerSchema("Polling interval while waiting for the final window.")
@@ -893,6 +894,7 @@ internal static class McpCatalog {
                     ReadBool(arguments, "includeHidden"),
                     ReadBool(arguments, "includeEmpty"),
                     ReadBool(arguments, "all"),
+                    ReadBool(arguments, "followProcessFamily"),
                     ReadInt(arguments, "timeoutMs") ?? 10000,
                     ReadInt(arguments, "intervalMs") ?? 200,
                     ReadMutationArtifactOptions(arguments)),

--- a/Sources/DesktopManager.Cli/MonitorCommands.cs
+++ b/Sources/DesktopManager.Cli/MonitorCommands.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -22,7 +23,11 @@ internal static class MonitorCommands {
             return 0;
         }
 
-        var rows = results
+        return WriteMonitorResults(results, Console.Out);
+    }
+
+    internal static int WriteMonitorResults(IReadOnlyList<MonitorResult> results, TextWriter writer) {
+        IReadOnlyList<IReadOnlyList<string>> rows = results
             .Select(monitor => (IReadOnlyList<string>)new[] {
                 monitor.Index.ToString(),
                 monitor.IsPrimary ? "Yes" : "No",
@@ -33,7 +38,7 @@ internal static class MonitorCommands {
             })
             .ToArray();
 
-        OutputFormatter.WriteTable(new[] { "Idx", "Primary", "Connected", "Bounds", "DeviceName", "Device" }, rows);
+        OutputFormatter.WriteTable(writer, new[] { "Idx", "Primary", "Connected", "Bounds", "DeviceName", "Device" }, rows);
         return 0;
     }
 }

--- a/Sources/DesktopManager.Cli/OutputFormatter.cs
+++ b/Sources/DesktopManager.Cli/OutputFormatter.cs
@@ -1,15 +1,24 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
 
 internal static class OutputFormatter {
     public static void WriteJson(object value) {
-        Console.WriteLine(JsonUtilities.Serialize(value));
+        WriteJson(Console.Out, value);
+    }
+
+    public static void WriteJson(TextWriter writer, object value) {
+        writer.WriteLine(JsonUtilities.Serialize(value));
     }
 
     public static void WriteTable(IReadOnlyList<string> headers, IReadOnlyList<IReadOnlyList<string>> rows) {
+        WriteTable(Console.Out, headers, rows);
+    }
+
+    public static void WriteTable(TextWriter writer, IReadOnlyList<string> headers, IReadOnlyList<IReadOnlyList<string>> rows) {
         int[] widths = new int[headers.Count];
         for (int index = 0; index < headers.Count; index++) {
             widths[index] = headers[index].Length;
@@ -21,10 +30,10 @@ internal static class OutputFormatter {
             }
         }
 
-        Console.WriteLine(FormatRow(headers, widths));
-        Console.WriteLine(FormatSeparator(widths));
+        writer.WriteLine(FormatRow(headers, widths));
+        writer.WriteLine(FormatSeparator(widths));
         foreach (IReadOnlyList<string> row in rows) {
-            Console.WriteLine(FormatRow(row, widths));
+            writer.WriteLine(FormatRow(row, widths));
         }
     }
 

--- a/Sources/DesktopManager.Cli/ProcessCommands.cs
+++ b/Sources/DesktopManager.Cli/ProcessCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
@@ -12,91 +13,92 @@ internal static class ProcessCommands {
     }
 
     private static int Start(CommandLineArguments arguments) {
+        ProcessStartCommandOptions options = CreateStartOptions(arguments);
         ProcessLaunchResult result = DesktopOperations.LaunchProcess(
-            arguments.GetRequiredCommandPart(2, "process path"),
-            arguments.GetOption("arguments"),
-            arguments.GetOption("working-directory"),
-            arguments.GetIntOption("wait-for-input-idle-ms"),
-            arguments.GetIntOption("wait-for-window-ms"),
-            arguments.GetIntOption("wait-for-window-interval-ms"),
-            arguments.GetOption("window-title"),
-            arguments.GetOption("window-class"),
-            arguments.GetBoolFlag("require-window"));
+            options.FilePath,
+            options.Arguments,
+            options.WorkingDirectory,
+            options.WaitForInputIdleMilliseconds,
+            options.WaitForWindowMilliseconds,
+            options.WaitForWindowIntervalMilliseconds,
+            options.WindowTitlePattern,
+            options.WindowClassNamePattern,
+            options.RequireWindow);
 
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(result);
             return 0;
         }
 
-        Console.WriteLine($"start: PID {result.ProcessId}");
-        if (result.ResolvedProcessId.HasValue && result.ResolvedProcessId.Value != result.ProcessId) {
-            Console.WriteLine($"- ResolvedPID: {result.ResolvedProcessId.Value}");
-        }
-        Console.WriteLine($"- File: {result.FilePath}");
-        if (!string.IsNullOrWhiteSpace(result.Arguments)) {
-            Console.WriteLine($"- Arguments: {result.Arguments}");
-        }
-        if (!string.IsNullOrWhiteSpace(result.WorkingDirectory)) {
-            Console.WriteLine($"- WorkingDirectory: {result.WorkingDirectory}");
-        }
-        if (result.MainWindow != null) {
-            Console.WriteLine($"- Window: {result.MainWindow.Title}");
-        }
-        return 0;
+        return WriteStartResult(result, Console.Out);
     }
 
     private static int StartAndWait(CommandLineArguments arguments) {
+        LaunchAndWaitCommandOptions options = CreateStartAndWaitOptions(arguments);
         LaunchAndWaitResult result = DesktopOperations.LaunchAndWaitForWindow(
-            arguments.GetRequiredCommandPart(2, "process path"),
-            arguments.GetOption("arguments"),
-            arguments.GetOption("working-directory"),
-            arguments.GetIntOption("wait-for-input-idle-ms"),
-            arguments.GetIntOption("launch-wait-for-window-ms"),
-            arguments.GetIntOption("launch-wait-for-window-interval-ms"),
-            arguments.GetOption("launch-window-title"),
-            arguments.GetOption("launch-window-class"),
-            arguments.GetOption("window-title"),
-            arguments.GetOption("window-class"),
-            arguments.GetBoolFlag("include-hidden"),
-            arguments.GetBoolFlag("include-empty"),
-            arguments.GetBoolFlag("all"),
-            arguments.GetIntOption("timeout-ms") ?? 10000,
-            arguments.GetIntOption("interval-ms") ?? 200,
-            CreateArtifactOptions(arguments));
+            options.FilePath,
+            options.Arguments,
+            options.WorkingDirectory,
+            options.WaitForInputIdleMilliseconds,
+            options.LaunchWaitForWindowMilliseconds,
+            options.LaunchWaitForWindowIntervalMilliseconds,
+            options.LaunchWindowTitlePattern,
+            options.LaunchWindowClassNamePattern,
+            options.WindowTitlePattern,
+            options.WindowClassNamePattern,
+            options.IncludeHidden,
+            options.IncludeEmpty,
+            options.All,
+            options.FollowProcessFamily,
+            options.TimeoutMilliseconds,
+            options.IntervalMilliseconds,
+            options.ArtifactOptions);
 
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(result);
             return result.Success ? 0 : 2;
         }
 
-        Console.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
-        Console.WriteLine($"- PID: {result.Launch.ProcessId}");
-        if (result.Launch.ResolvedProcessId.HasValue && result.Launch.ResolvedProcessId.Value != result.Launch.ProcessId) {
-            Console.WriteLine($"- ResolvedPID: {result.Launch.ResolvedProcessId.Value}");
-        }
-        Console.WriteLine($"- File: {result.Launch.FilePath}");
-        Console.WriteLine($"- WaitCount: {result.WindowWait.Count}");
-        Console.WriteLine($"- WaitElapsedMs: {result.WindowWait.ElapsedMilliseconds}");
-        foreach (WindowResult window in result.WindowWait.Windows) {
-            Console.WriteLine($"- Window: {window.Title} [PID {window.ProcessId}]");
-        }
-
-        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
-            Console.WriteLine($"- Artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
-        }
-
-        foreach (string warning in result.ArtifactWarnings) {
-            Console.WriteLine($"- Warning: {warning}");
-        }
-
-        foreach (string note in result.Notes) {
-            Console.WriteLine($"- Note: {note}");
-        }
-
-        return result.Success ? 0 : 2;
+        return WriteStartAndWaitResult(result, Console.Out);
     }
 
-    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+    internal static ProcessStartCommandOptions CreateStartOptions(CommandLineArguments arguments) {
+        return new ProcessStartCommandOptions {
+            FilePath = arguments.GetRequiredCommandPart(2, "process path"),
+            Arguments = arguments.GetOption("arguments"),
+            WorkingDirectory = arguments.GetOption("working-directory"),
+            WaitForInputIdleMilliseconds = arguments.GetIntOption("wait-for-input-idle-ms"),
+            WaitForWindowMilliseconds = arguments.GetIntOption("wait-for-window-ms"),
+            WaitForWindowIntervalMilliseconds = arguments.GetIntOption("wait-for-window-interval-ms"),
+            WindowTitlePattern = arguments.GetOption("window-title"),
+            WindowClassNamePattern = arguments.GetOption("window-class"),
+            RequireWindow = arguments.GetBoolFlag("require-window")
+        };
+    }
+
+    internal static LaunchAndWaitCommandOptions CreateStartAndWaitOptions(CommandLineArguments arguments) {
+        return new LaunchAndWaitCommandOptions {
+            FilePath = arguments.GetRequiredCommandPart(2, "process path"),
+            Arguments = arguments.GetOption("arguments"),
+            WorkingDirectory = arguments.GetOption("working-directory"),
+            WaitForInputIdleMilliseconds = arguments.GetIntOption("wait-for-input-idle-ms"),
+            LaunchWaitForWindowMilliseconds = arguments.GetIntOption("launch-wait-for-window-ms"),
+            LaunchWaitForWindowIntervalMilliseconds = arguments.GetIntOption("launch-wait-for-window-interval-ms"),
+            LaunchWindowTitlePattern = arguments.GetOption("launch-window-title"),
+            LaunchWindowClassNamePattern = arguments.GetOption("launch-window-class"),
+            WindowTitlePattern = arguments.GetOption("window-title"),
+            WindowClassNamePattern = arguments.GetOption("window-class"),
+            IncludeHidden = arguments.GetBoolFlag("include-hidden"),
+            IncludeEmpty = arguments.GetBoolFlag("include-empty"),
+            All = arguments.GetBoolFlag("all"),
+            FollowProcessFamily = arguments.GetBoolFlag("follow-process-family"),
+            TimeoutMilliseconds = arguments.GetIntOption("timeout-ms") ?? 10000,
+            IntervalMilliseconds = arguments.GetIntOption("interval-ms") ?? 200,
+            ArtifactOptions = CreateArtifactOptions(arguments)
+        };
+    }
+
+    internal static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
         bool captureBefore = arguments.GetBoolFlag("capture-before");
         bool captureAfter = arguments.GetBoolFlag("capture-after");
         string? artifactDirectory = arguments.GetOption("artifact-directory");
@@ -109,5 +111,59 @@ internal static class ProcessCommands {
             CaptureAfter = captureAfter,
             ArtifactDirectory = artifactDirectory
         };
+    }
+
+    internal static int WriteStartAndWaitResult(LaunchAndWaitResult result, TextWriter writer) {
+        writer.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
+        writer.WriteLine($"- PID: {result.Launch.ProcessId}");
+        if (result.Launch.ResolvedProcessId.HasValue && result.Launch.ResolvedProcessId.Value != result.Launch.ProcessId) {
+            writer.WriteLine($"- ResolvedPID: {result.Launch.ResolvedProcessId.Value}");
+        }
+        writer.WriteLine($"- File: {result.Launch.FilePath}");
+        writer.WriteLine($"- WaitBinding: {result.WaitBinding}");
+        if (result.BoundProcessId.HasValue) {
+            writer.WriteLine($"- BoundProcessId: {result.BoundProcessId.Value}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.BoundProcessName)) {
+            writer.WriteLine($"- BoundProcessName: {result.BoundProcessName}");
+        }
+        writer.WriteLine($"- WaitCount: {result.WindowWait.Count}");
+        writer.WriteLine($"- WaitElapsedMs: {result.WindowWait.ElapsedMilliseconds}");
+        foreach (WindowResult window in result.WindowWait.Windows) {
+            writer.WriteLine($"- Window: {window.Title} [PID {window.ProcessId}]");
+        }
+
+        if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
+            writer.WriteLine($"- Artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+        }
+
+        foreach (string warning in result.ArtifactWarnings) {
+            writer.WriteLine($"- Warning: {warning}");
+        }
+
+        foreach (string note in result.Notes) {
+            writer.WriteLine($"- Note: {note}");
+        }
+
+        return result.Success ? 0 : 2;
+    }
+
+    internal static int WriteStartResult(ProcessLaunchResult result, TextWriter writer) {
+        writer.WriteLine($"start: PID {result.ProcessId}");
+        if (result.ResolvedProcessId.HasValue && result.ResolvedProcessId.Value != result.ProcessId) {
+            writer.WriteLine($"- ResolvedPID: {result.ResolvedProcessId.Value}");
+        }
+        writer.WriteLine($"- File: {result.FilePath}");
+        if (!string.IsNullOrWhiteSpace(result.Arguments)) {
+            writer.WriteLine($"- Arguments: {result.Arguments}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.WorkingDirectory)) {
+            writer.WriteLine($"- WorkingDirectory: {result.WorkingDirectory}");
+        }
+        if (result.MainWindow != null) {
+            writer.WriteLine($"- Window: {result.MainWindow.Title}");
+        }
+
+        return 0;
     }
 }

--- a/Sources/DesktopManager.Cli/ScreenshotCommands.cs
+++ b/Sources/DesktopManager.Cli/ScreenshotCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
@@ -13,15 +14,16 @@ internal static class ScreenshotCommands {
     }
 
     private static int Desktop(CommandLineArguments arguments) {
+        DesktopScreenshotCommandOptions options = CreateDesktopOptions(arguments);
         ScreenshotResult result = DesktopOperations.CaptureDesktopScreenshot(
-            arguments.GetIntOption("monitor"),
-            arguments.GetOption("device-id"),
-            arguments.GetOption("device-name"),
-            arguments.GetIntOption("left"),
-            arguments.GetIntOption("top"),
-            arguments.GetIntOption("width"),
-            arguments.GetIntOption("height"),
-            arguments.GetOption("output"));
+            options.MonitorIndex,
+            options.DeviceId,
+            options.DeviceName,
+            options.Left,
+            options.Top,
+            options.Width,
+            options.Height,
+            options.OutputPath);
         return WriteScreenshotResult(arguments, result);
     }
 
@@ -29,54 +31,21 @@ internal static class ScreenshotCommands {
         string? targetName = arguments.GetOption("target");
         if (!string.IsNullOrWhiteSpace(targetName)) {
             ScreenshotResult targetResult = DesktopOperations.CaptureWindowTargetScreenshot(
-                new WindowSelectionCriteria {
-                    TitlePattern = arguments.GetOption("title") ?? "*",
-                    ProcessNamePattern = arguments.GetOption("process") ?? "*",
-                    ClassNamePattern = arguments.GetOption("class") ?? "*",
-                    ProcessId = arguments.GetIntOption("pid"),
-                    Handle = arguments.GetOption("handle"),
-                    Active = arguments.GetBoolFlag("active"),
-                    IncludeHidden = true,
-                    IncludeCloaked = true,
-                    IncludeOwned = true,
-                    IncludeEmptyTitles = true
-                },
+                CreateWindowCriteria(arguments),
                 targetName,
                 arguments.GetOption("output"));
             return WriteScreenshotResult(arguments, targetResult);
         }
 
         ScreenshotResult result = DesktopOperations.CaptureWindowScreenshot(
-            new WindowSelectionCriteria {
-                TitlePattern = arguments.GetOption("title") ?? "*",
-                ProcessNamePattern = arguments.GetOption("process") ?? "*",
-                ClassNamePattern = arguments.GetOption("class") ?? "*",
-                ProcessId = arguments.GetIntOption("pid"),
-                Handle = arguments.GetOption("handle"),
-                Active = arguments.GetBoolFlag("active"),
-                IncludeHidden = true,
-                IncludeCloaked = true,
-                IncludeOwned = true,
-                IncludeEmptyTitles = true
-            },
+            CreateWindowCriteria(arguments),
             arguments.GetOption("output"));
         return WriteScreenshotResult(arguments, result);
     }
 
     private static int Target(CommandLineArguments arguments) {
         ScreenshotResult result = DesktopOperations.CaptureWindowTargetScreenshot(
-            new WindowSelectionCriteria {
-                TitlePattern = arguments.GetOption("title") ?? "*",
-                ProcessNamePattern = arguments.GetOption("process") ?? "*",
-                ClassNamePattern = arguments.GetOption("class") ?? "*",
-                ProcessId = arguments.GetIntOption("pid"),
-                Handle = arguments.GetOption("handle"),
-                Active = arguments.GetBoolFlag("active"),
-                IncludeHidden = true,
-                IncludeCloaked = true,
-                IncludeOwned = true,
-                IncludeEmptyTitles = true
-            },
+            CreateWindowCriteria(arguments),
             arguments.GetRequiredCommandPart(2, "target name"),
             arguments.GetOption("output"));
         return WriteScreenshotResult(arguments, result);
@@ -88,18 +57,50 @@ internal static class ScreenshotCommands {
             return 0;
         }
 
-        Console.WriteLine($"screenshot: {result.Kind}");
-        Console.WriteLine($"- Path: {result.Path}");
-        Console.WriteLine($"- Size: {result.Width}x{result.Height}");
+        return WriteScreenshotResult(result, Console.Out);
+    }
+
+    internal static int WriteScreenshotResult(ScreenshotResult result, TextWriter writer) {
+        writer.WriteLine($"screenshot: {result.Kind}");
+        writer.WriteLine($"- Path: {result.Path}");
+        writer.WriteLine($"- Size: {result.Width}x{result.Height}");
         if (result.Window != null) {
-            Console.WriteLine($"- Window: {result.Window.Title}");
+            writer.WriteLine($"- Window: {result.Window.Title}");
         }
         if (result.Geometry != null) {
-            Console.WriteLine($"- Client: {result.Geometry.ClientWidth}x{result.Geometry.ClientHeight} at offset {result.Geometry.ClientOffsetLeft},{result.Geometry.ClientOffsetTop}");
+            writer.WriteLine($"- Client: {result.Geometry.ClientWidth}x{result.Geometry.ClientHeight} at offset {result.Geometry.ClientOffsetLeft},{result.Geometry.ClientOffsetTop}");
         }
         if (result.MonitorIndex.HasValue) {
-            Console.WriteLine($"- Monitor: {result.MonitorIndex}");
+            writer.WriteLine($"- Monitor: {result.MonitorIndex}");
         }
         return 0;
+    }
+
+    internal static WindowSelectionCriteria CreateWindowCriteria(CommandLineArguments arguments) {
+        return new WindowSelectionCriteria {
+            TitlePattern = arguments.GetOption("title") ?? "*",
+            ProcessNamePattern = arguments.GetOption("process") ?? "*",
+            ClassNamePattern = arguments.GetOption("class") ?? "*",
+            ProcessId = arguments.GetIntOption("pid"),
+            Handle = arguments.GetOption("handle"),
+            Active = arguments.GetBoolFlag("active"),
+            IncludeHidden = true,
+            IncludeCloaked = true,
+            IncludeOwned = true,
+            IncludeEmptyTitles = true
+        };
+    }
+
+    internal static DesktopScreenshotCommandOptions CreateDesktopOptions(CommandLineArguments arguments) {
+        return new DesktopScreenshotCommandOptions {
+            MonitorIndex = arguments.GetIntOption("monitor"),
+            DeviceId = arguments.GetOption("device-id"),
+            DeviceName = arguments.GetOption("device-name"),
+            Left = arguments.GetIntOption("left"),
+            Top = arguments.GetIntOption("top"),
+            Width = arguments.GetIntOption("width"),
+            Height = arguments.GetIntOption("height"),
+            OutputPath = arguments.GetOption("output")
+        };
     }
 }

--- a/Sources/DesktopManager.Cli/SnapshotCommands.cs
+++ b/Sources/DesktopManager.Cli/SnapshotCommands.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -30,15 +32,7 @@ internal static class SnapshotCommands {
             return 0;
         }
 
-        if (names.Count == 0) {
-            Console.WriteLine("No named snapshots found.");
-            return 0;
-        }
-
-        foreach (string name in names.OrderBy(value => value)) {
-            Console.WriteLine(name);
-        }
-        return 0;
+        return WriteSnapshotNames(names, Console.Out);
     }
 
     private static int WritePathResult(CommandLineArguments arguments, NamedStateResult payload) {
@@ -47,10 +41,26 @@ internal static class SnapshotCommands {
             return 0;
         }
 
-        Console.WriteLine($"{payload.Action}: {payload.Name}");
-        Console.WriteLine(payload.Path);
+        return WritePathResult(payload, Console.Out);
+    }
+
+    internal static int WriteSnapshotNames(IReadOnlyList<string> names, TextWriter writer) {
+        if (names.Count == 0) {
+            writer.WriteLine("No named snapshots found.");
+            return 0;
+        }
+
+        foreach (string name in names.OrderBy(value => value)) {
+            writer.WriteLine(name);
+        }
+        return 0;
+    }
+
+    internal static int WritePathResult(NamedStateResult payload, TextWriter writer) {
+        writer.WriteLine($"{payload.Action}: {payload.Name}");
+        writer.WriteLine(payload.Path);
         if (!string.IsNullOrWhiteSpace(payload.Scope)) {
-            Console.WriteLine($"scope: {payload.Scope}");
+            writer.WriteLine($"scope: {payload.Scope}");
         }
         return 0;
     }

--- a/Sources/DesktopManager.Cli/TargetCommands.cs
+++ b/Sources/DesktopManager.Cli/TargetCommands.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
@@ -33,9 +35,7 @@ internal static class TargetCommands {
             return 0;
         }
 
-        Console.WriteLine($"save: {result.Name}");
-        Console.WriteLine(result.Path);
-        return 0;
+        return WriteSavedTargetResult(result, Console.Out);
     }
 
     private static int Get(CommandLineArguments arguments) {
@@ -45,21 +45,7 @@ internal static class TargetCommands {
             return 0;
         }
 
-        Console.WriteLine(result.Name);
-        Console.WriteLine($"- Path: {result.Path}");
-        Console.WriteLine($"- ClientArea: {(result.Target.ClientArea ? "Yes" : "No")}");
-        Console.WriteLine($"- X: {result.Target.X?.ToString() ?? "-"}");
-        Console.WriteLine($"- Y: {result.Target.Y?.ToString() ?? "-"}");
-        Console.WriteLine($"- XRatio: {result.Target.XRatio?.ToString() ?? "-"}");
-        Console.WriteLine($"- YRatio: {result.Target.YRatio?.ToString() ?? "-"}");
-        Console.WriteLine($"- Width: {result.Target.Width?.ToString() ?? "-"}");
-        Console.WriteLine($"- Height: {result.Target.Height?.ToString() ?? "-"}");
-        Console.WriteLine($"- WidthRatio: {result.Target.WidthRatio?.ToString() ?? "-"}");
-        Console.WriteLine($"- HeightRatio: {result.Target.HeightRatio?.ToString() ?? "-"}");
-        if (!string.IsNullOrWhiteSpace(result.Target.Description)) {
-            Console.WriteLine($"- Description: {result.Target.Description}");
-        }
-        return 0;
+        return WriteTargetResult(result, Console.Out);
     }
 
     private static int List(CommandLineArguments arguments) {
@@ -69,15 +55,7 @@ internal static class TargetCommands {
             return 0;
         }
 
-        if (names.Count == 0) {
-            Console.WriteLine("No named targets found.");
-            return 0;
-        }
-
-        foreach (string name in names.OrderBy(value => value, StringComparer.OrdinalIgnoreCase)) {
-            Console.WriteLine(name);
-        }
-        return 0;
+        return WriteTargetNames(names, Console.Out);
     }
 
     private static int Resolve(CommandLineArguments arguments) {
@@ -90,19 +68,59 @@ internal static class TargetCommands {
             return 0;
         }
 
-        foreach (ResolvedWindowTargetResult result in results) {
-            Console.WriteLine($"{result.Name}: {result.Window.Title} ({result.Window.Handle})");
-            Console.WriteLine($"- Relative: {result.RelativeX},{result.RelativeY}");
-            Console.WriteLine($"- Screen: {result.ScreenX},{result.ScreenY}");
-            if (result.ScreenWidth.HasValue && result.ScreenHeight.HasValue) {
-                Console.WriteLine($"- Area: {result.ScreenWidth}x{result.ScreenHeight}");
-            }
-            Console.WriteLine($"- ClientArea: {(result.Target.ClientArea ? "Yes" : "No")}");
+        return WriteResolvedTargets(results, Console.Out);
+    }
+
+    internal static int WriteTargetResult(WindowTargetResult result, TextWriter writer) {
+        writer.WriteLine(result.Name);
+        writer.WriteLine($"- Path: {result.Path}");
+        writer.WriteLine($"- ClientArea: {(result.Target.ClientArea ? "Yes" : "No")}");
+        writer.WriteLine($"- X: {result.Target.X?.ToString() ?? "-"}");
+        writer.WriteLine($"- Y: {result.Target.Y?.ToString() ?? "-"}");
+        writer.WriteLine($"- XRatio: {result.Target.XRatio?.ToString() ?? "-"}");
+        writer.WriteLine($"- YRatio: {result.Target.YRatio?.ToString() ?? "-"}");
+        writer.WriteLine($"- Width: {result.Target.Width?.ToString() ?? "-"}");
+        writer.WriteLine($"- Height: {result.Target.Height?.ToString() ?? "-"}");
+        writer.WriteLine($"- WidthRatio: {result.Target.WidthRatio?.ToString() ?? "-"}");
+        writer.WriteLine($"- HeightRatio: {result.Target.HeightRatio?.ToString() ?? "-"}");
+        if (!string.IsNullOrWhiteSpace(result.Target.Description)) {
+            writer.WriteLine($"- Description: {result.Target.Description}");
         }
         return 0;
     }
 
-    private static WindowSelectionCriteria CreateCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
+    internal static int WriteSavedTargetResult(WindowTargetResult result, TextWriter writer) {
+        writer.WriteLine($"save: {result.Name}");
+        writer.WriteLine(result.Path);
+        return 0;
+    }
+
+    internal static int WriteTargetNames(IReadOnlyList<string> names, TextWriter writer) {
+        if (names.Count == 0) {
+            writer.WriteLine("No named targets found.");
+            return 0;
+        }
+
+        foreach (string name in names.OrderBy(value => value, StringComparer.OrdinalIgnoreCase)) {
+            writer.WriteLine(name);
+        }
+        return 0;
+    }
+
+    internal static int WriteResolvedTargets(IReadOnlyList<ResolvedWindowTargetResult> results, TextWriter writer) {
+        foreach (ResolvedWindowTargetResult result in results) {
+            writer.WriteLine($"{result.Name}: {result.Window.Title} ({result.Window.Handle})");
+            writer.WriteLine($"- Relative: {result.RelativeX},{result.RelativeY}");
+            writer.WriteLine($"- Screen: {result.ScreenX},{result.ScreenY}");
+            if (result.ScreenWidth.HasValue && result.ScreenHeight.HasValue) {
+                writer.WriteLine($"- Area: {result.ScreenWidth}x{result.ScreenHeight}");
+            }
+            writer.WriteLine($"- ClientArea: {(result.Target.ClientArea ? "Yes" : "No")}");
+        }
+        return 0;
+    }
+
+    internal static WindowSelectionCriteria CreateCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
         return new WindowSelectionCriteria {
             TitlePattern = arguments.GetOption("title") ?? "*",
             ProcessNamePattern = arguments.GetOption("process") ?? "*",

--- a/Sources/DesktopManager.Cli/WindowCommands.cs
+++ b/Sources/DesktopManager.Cli/WindowCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DesktopManager.Cli;
@@ -31,7 +32,7 @@ internal static class WindowCommands {
             if (arguments.GetBoolFlag("json")) {
                 OutputFormatter.WriteJson(Array.Empty<object>());
             } else {
-                Console.WriteLine("No matching windows found.");
+                WriteNoMatchingWindows(Console.Out);
             }
             return 0;
         }
@@ -41,7 +42,11 @@ internal static class WindowCommands {
             return 0;
         }
 
-        var rows = windows
+        return WriteWindowListResults(windows, Console.Out);
+    }
+
+    internal static int WriteWindowListResults(IReadOnlyList<WindowResult> windows, TextWriter writer) {
+        IReadOnlyList<IReadOnlyList<string>> rows = windows
             .Select(window => (IReadOnlyList<string>)new[] {
                 window.ProcessId.ToString(),
                 window.Handle.Replace("0x", string.Empty, StringComparison.OrdinalIgnoreCase),
@@ -51,7 +56,8 @@ internal static class WindowCommands {
                 window.Title
             })
             .ToArray();
-        OutputFormatter.WriteTable(new[] { "PID", "Handle", "Mon", "Visible", "State", "Title" }, rows);
+
+        OutputFormatter.WriteTable(writer, new[] { "PID", "Handle", "Mon", "Visible", "State", "Title" }, rows);
         return 0;
     }
 
@@ -68,17 +74,10 @@ internal static class WindowCommands {
         }
 
         if (geometries.Count == 0) {
-            Console.WriteLine("No matching windows found.");
-            return 0;
+            return WriteNoMatchingWindows(Console.Out);
         }
 
-        foreach (WindowGeometryResult geometry in geometries) {
-            Console.WriteLine($"window: {geometry.Window.Title} ({geometry.Window.Handle})");
-            Console.WriteLine($"- Window: {geometry.WindowLeft},{geometry.WindowTop} {geometry.WindowWidth}x{geometry.WindowHeight}");
-            Console.WriteLine($"- Client: {geometry.ClientLeft},{geometry.ClientTop} {geometry.ClientWidth}x{geometry.ClientHeight}");
-            Console.WriteLine($"- ClientOffset: {geometry.ClientOffsetLeft},{geometry.ClientOffsetTop}");
-        }
-        return 0;
+        return WriteWindowGeometryResults(geometries, Console.Out);
     }
 
     private static int ActiveMatches(CommandLineArguments arguments) {
@@ -244,11 +243,7 @@ internal static class WindowCommands {
             return 0;
         }
 
-        Console.WriteLine($"wait: {result.Count} window(s) after {result.ElapsedMilliseconds}ms");
-        foreach (WindowResult window in result.Windows) {
-            Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
-        }
-        return 0;
+        return WriteWaitResult(result, Console.Out);
     }
 
     private static int WriteWindowMutationResult(CommandLineArguments arguments, WindowChangeResult payload) {
@@ -257,22 +252,46 @@ internal static class WindowCommands {
             return 0;
         }
 
-        Console.WriteLine($"{payload.Action}: {payload.Count} window(s) success={payload.Success} safety={payload.SafetyMode} elapsed-ms={payload.ElapsedMilliseconds}");
+        return WriteWindowMutationResult(payload, Console.Out);
+    }
+
+    internal static int WriteWindowMutationResult(WindowChangeResult payload, TextWriter writer) {
+        writer.WriteLine($"{payload.Action}: {payload.Count} window(s) success={payload.Success} safety={payload.SafetyMode} elapsed-ms={payload.ElapsedMilliseconds}");
         if (!string.IsNullOrWhiteSpace(payload.TargetName)) {
-            Console.WriteLine($"target: {payload.TargetKind ?? "selector"} {payload.TargetName}");
+            writer.WriteLine($"target: {payload.TargetKind ?? "selector"} {payload.TargetName}");
         }
 
         if (payload.BeforeScreenshots.Count > 0 || payload.AfterScreenshots.Count > 0) {
-            Console.WriteLine($"artifacts: before={payload.BeforeScreenshots.Count} after={payload.AfterScreenshots.Count}");
+            writer.WriteLine($"artifacts: before={payload.BeforeScreenshots.Count} after={payload.AfterScreenshots.Count}");
         }
 
         foreach (string warning in payload.ArtifactWarnings) {
-            Console.WriteLine($"warning: {warning}");
+            writer.WriteLine($"warning: {warning}");
         }
 
         foreach (WindowResult window in payload.Windows) {
-            Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
+            writer.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
         }
+
+        return 0;
+    }
+
+    internal static int WriteWindowGeometryResults(IReadOnlyList<WindowGeometryResult> geometries, TextWriter writer) {
+        foreach (WindowGeometryResult geometry in geometries) {
+            writer.WriteLine($"window: {geometry.Window.Title} ({geometry.Window.Handle})");
+            writer.WriteLine($"- Window: {geometry.WindowLeft},{geometry.WindowTop} {geometry.WindowWidth}x{geometry.WindowHeight}");
+            writer.WriteLine($"- Client: {geometry.ClientLeft},{geometry.ClientTop} {geometry.ClientWidth}x{geometry.ClientHeight}");
+            writer.WriteLine($"- ClientOffset: {geometry.ClientOffsetLeft},{geometry.ClientOffsetTop}");
+        }
+        return 0;
+    }
+
+    internal static int WriteWaitResult(WaitForWindowResult result, TextWriter writer) {
+        writer.WriteLine($"wait: {result.Count} window(s) after {result.ElapsedMilliseconds}ms");
+        foreach (WindowResult window in result.Windows) {
+            writer.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
+        }
+
         return 0;
     }
 
@@ -295,20 +314,31 @@ internal static class WindowCommands {
         if (arguments.GetBoolFlag("json")) {
             OutputFormatter.WriteJson(payload);
         } else {
-            Console.WriteLine(payload.Matched ? successText : failureText);
-            if (payload.ActiveWindow != null) {
-                Console.WriteLine($"Active: {payload.ActiveWindow.Title} [PID {payload.ActiveWindow.ProcessId}]");
-            }
-
-            foreach (WindowResult window in payload.Windows) {
-                Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
-            }
+            return WriteAssertionResult(payload, successText, failureText, Console.Out);
         }
 
         return payload.Matched ? 0 : 2;
     }
 
-    private static WindowSelectionCriteria CreateCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
+    internal static int WriteAssertionResult(WindowAssertionResult payload, string successText, string failureText, TextWriter writer) {
+        writer.WriteLine(payload.Matched ? successText : failureText);
+        if (payload.ActiveWindow != null) {
+            writer.WriteLine($"Active: {payload.ActiveWindow.Title} [PID {payload.ActiveWindow.ProcessId}]");
+        }
+
+        foreach (WindowResult window in payload.Windows) {
+            writer.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
+        }
+
+        return payload.Matched ? 0 : 2;
+    }
+
+    internal static int WriteNoMatchingWindows(TextWriter writer) {
+        writer.WriteLine("No matching windows found.");
+        return 0;
+    }
+
+    internal static WindowSelectionCriteria CreateCriteria(CommandLineArguments arguments, bool includeEmptyDefault) {
         return new WindowSelectionCriteria {
             TitlePattern = arguments.GetOption("title") ?? "*",
             ProcessNamePattern = arguments.GetOption("process") ?? "*",

--- a/Sources/DesktopManager.Cli/WorkflowCommands.cs
+++ b/Sources/DesktopManager.Cli/WorkflowCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace DesktopManager.Cli;
 
@@ -38,42 +39,46 @@ internal static class WorkflowCommands {
             return result.Success ? 0 : 2;
         }
 
-        Console.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
+        return WriteWorkflowResult(result, Console.Out);
+    }
+
+    internal static int WriteWorkflowResult(WorkflowResult result, TextWriter writer) {
+        writer.WriteLine($"{result.Action}: success={result.Success} elapsed-ms={result.ElapsedMilliseconds}");
         if (result.LayoutApplied && !string.IsNullOrWhiteSpace(result.LayoutName)) {
-            Console.WriteLine($"layout: applied {result.LayoutName}");
+            writer.WriteLine($"layout: applied {result.LayoutName}");
         } else if (!string.IsNullOrWhiteSpace(result.LayoutName)) {
-            Console.WriteLine($"layout: not-applied {result.LayoutName}");
+            writer.WriteLine($"layout: not-applied {result.LayoutName}");
         }
 
         if (result.FocusedWindow != null) {
-            Console.WriteLine($"focused: {result.FocusedWindow.Title} [PID {result.FocusedWindow.ProcessId}]");
+            writer.WriteLine($"focused: {result.FocusedWindow.Title} [PID {result.FocusedWindow.ProcessId}]");
         } else if (result.ResolvedWindow != null) {
-            Console.WriteLine($"resolved: {result.ResolvedWindow.Title} [PID {result.ResolvedWindow.ProcessId}]");
+            writer.WriteLine($"resolved: {result.ResolvedWindow.Title} [PID {result.ResolvedWindow.ProcessId}]");
         }
 
         if (result.MinimizedWindows.Count > 0) {
-            Console.WriteLine($"minimized: {result.MinimizedWindows.Count} window(s)");
+            writer.WriteLine($"minimized: {result.MinimizedWindows.Count} window(s)");
             foreach (WindowResult window in result.MinimizedWindows) {
-                Console.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
+                writer.WriteLine($"- {window.Title} [PID {window.ProcessId}]");
             }
         }
 
         if (result.BeforeScreenshots.Count > 0 || result.AfterScreenshots.Count > 0) {
-            Console.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
+            writer.WriteLine($"artifacts: before={result.BeforeScreenshots.Count} after={result.AfterScreenshots.Count}");
         }
 
         foreach (string warning in result.ArtifactWarnings) {
-            Console.WriteLine($"warning: {warning}");
+            writer.WriteLine($"warning: {warning}");
         }
 
         foreach (string note in result.Notes) {
-            Console.WriteLine($"note: {note}");
+            writer.WriteLine($"note: {note}");
         }
 
         return result.Success ? 0 : 2;
     }
 
-    private static WindowSelectionCriteria CreateFocusCriteria(CommandLineArguments arguments) {
+    internal static WindowSelectionCriteria CreateFocusCriteria(CommandLineArguments arguments) {
         return new WindowSelectionCriteria {
             TitlePattern = arguments.GetOption("title") ?? "*",
             ProcessNamePattern = arguments.GetOption("process") ?? "*",
@@ -89,7 +94,7 @@ internal static class WorkflowCommands {
         };
     }
 
-    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+    internal static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
         bool captureBefore = arguments.GetBoolFlag("capture-before");
         bool captureAfter = arguments.GetBoolFlag("capture-after");
         string? artifactDirectory = arguments.GetOption("artifact-directory");

--- a/Sources/DesktopManager.TestApp/AssemblyInfo.Platform.cs
+++ b/Sources/DesktopManager.TestApp/AssemblyInfo.Platform.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/Sources/DesktopManager.TestApp/DesktopManager.TestApp.csproj
+++ b/Sources/DesktopManager.TestApp/DesktopManager.TestApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Sources/DesktopManager.TestApp/MainForm.cs
+++ b/Sources/DesktopManager.TestApp/MainForm.cs
@@ -1,0 +1,155 @@
+using System.Drawing;
+using System.Windows.Forms.Integration;
+using WinFormsLabel = System.Windows.Forms.Label;
+using WinFormsTextBox = System.Windows.Forms.TextBox;
+using WpfKey = System.Windows.Input.Key;
+using WpfKeyEventArgs = System.Windows.Input.KeyEventArgs;
+using WpfTextBox = System.Windows.Controls.TextBox;
+
+namespace DesktopManager.TestApp;
+
+internal sealed class MainForm : Form {
+    private readonly string _baseTitle;
+    private readonly WinFormsTextBox _editorTextBox;
+    private readonly ElementHost _commandBarHost;
+    private readonly WpfTextBox _commandBarTextBox;
+    private readonly WinFormsLabel _statusLabel;
+
+    public MainForm(TestAppOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        _baseTitle = options.Title;
+        Text = options.Title;
+        Name = "DesktopManagerMcpTestApp";
+        StartPosition = FormStartPosition.CenterScreen;
+        Width = 960;
+        Height = 720;
+        MinimumSize = new Size(640, 480);
+        bool useCommandBarSurface = string.Equals(options.Surface, "commandbar", StringComparison.OrdinalIgnoreCase);
+
+        var titleLabel = new WinFormsLabel {
+            AutoSize = true,
+            Text = "DesktopManager MCP Test App",
+            Font = new Font(SystemFonts.MessageBoxFont ?? Font, FontStyle.Bold),
+            Margin = new Padding(0, 0, 0, 8)
+        };
+
+        var hintLabel = new WinFormsLabel {
+            AutoSize = true,
+            Text = "This window is used by automated end-to-end tests.",
+            Margin = new Padding(0, 0, 0, 12)
+        };
+
+        _statusLabel = new WinFormsLabel {
+            AutoSize = true,
+            Name = "StatusLabel",
+            AccessibleName = "StatusLabel",
+            Text = useCommandBarSurface
+                ? "Type a value into the command bar and press Enter."
+                : "Editor surface ready.",
+            Margin = new Padding(0, 0, 0, 12)
+        };
+
+        _editorTextBox = new WinFormsTextBox {
+            Name = "EditorTextBox",
+            AccessibleName = "Editor",
+            Multiline = true,
+            AcceptsReturn = true,
+            AcceptsTab = true,
+            ScrollBars = ScrollBars.Both,
+            WordWrap = false,
+            Dock = DockStyle.Fill,
+            Text = options.InitialText
+        };
+
+        _commandBarTextBox = new WpfTextBox {
+            Name = "CommandBarTextBox",
+            Text = options.InitialText,
+            MinWidth = 480,
+            MinHeight = 30
+        };
+        _commandBarTextBox.KeyDown += CommandBarTextBox_KeyDown;
+
+        var commandBarPanel = new System.Windows.Controls.StackPanel {
+            Orientation = System.Windows.Controls.Orientation.Horizontal
+        };
+        commandBarPanel.Children.Add(new System.Windows.Controls.Label {
+            Content = "Command",
+            VerticalAlignment = System.Windows.VerticalAlignment.Center,
+            Padding = new System.Windows.Thickness(0, 0, 8, 0)
+        });
+        commandBarPanel.Children.Add(_commandBarTextBox);
+
+        _commandBarHost = new ElementHost {
+            Name = "CommandBarHost",
+            Dock = DockStyle.Top,
+            Height = 42,
+            Child = commandBarPanel,
+            Visible = useCommandBarSurface
+        };
+
+        var closeButton = new Button {
+            Name = "CloseButton",
+            Text = "Close",
+            AutoSize = true,
+            Anchor = AnchorStyles.Right
+        };
+        closeButton.Click += (_, _) => Close();
+
+        var buttonPanel = new FlowLayoutPanel {
+            Dock = DockStyle.Bottom,
+            FlowDirection = FlowDirection.RightToLeft,
+            AutoSize = true,
+            WrapContents = false,
+            Padding = new Padding(0, 12, 0, 0)
+        };
+        buttonPanel.Controls.Add(closeButton);
+
+        var contentPanel = new TableLayoutPanel {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 3,
+            Padding = new Padding(16)
+        };
+        contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        contentPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+        contentPanel.Controls.Add(titleLabel, 0, 0);
+        contentPanel.Controls.Add(hintLabel, 0, 1);
+        contentPanel.Controls.Add(_statusLabel, 0, 2);
+        contentPanel.Controls.Add(_editorTextBox, 0, 3);
+
+        Controls.Add(_commandBarHost);
+        Controls.Add(contentPanel);
+        Controls.Add(buttonPanel);
+
+        Shown += (_, _) => {
+            if (useCommandBarSurface) {
+                _commandBarTextBox.Focus();
+                _commandBarTextBox.Select(_commandBarTextBox.Text.Length, 0);
+            } else {
+                _editorTextBox.Focus();
+                _editorTextBox.SelectionStart = _editorTextBox.TextLength;
+                _editorTextBox.SelectionLength = 0;
+            }
+        };
+    }
+
+    private void CommandBarTextBox_KeyDown(object? sender, WpfKeyEventArgs e) {
+        if (e.Key != WpfKey.Return) {
+            return;
+        }
+
+        string command = _commandBarTextBox.Text.Trim();
+        _statusLabel.Text = string.IsNullOrWhiteSpace(command)
+            ? "Accepted empty command."
+            : "Accepted command: " + command;
+        Text = string.IsNullOrWhiteSpace(command)
+            ? _baseTitle + " - Accepted"
+            : _baseTitle + " - Accepted - " + command;
+        e.Handled = true;
+    }
+}

--- a/Sources/DesktopManager.TestApp/Program.cs
+++ b/Sources/DesktopManager.TestApp/Program.cs
@@ -1,0 +1,10 @@
+namespace DesktopManager.TestApp;
+
+internal static class Program {
+    [STAThread]
+    private static void Main(string[] args) {
+        ApplicationConfiguration.Initialize();
+        TestAppOptions options = TestAppOptions.Parse(args);
+        Application.Run(new MainForm(options));
+    }
+}

--- a/Sources/DesktopManager.TestApp/TestAppOptions.cs
+++ b/Sources/DesktopManager.TestApp/TestAppOptions.cs
@@ -1,0 +1,44 @@
+namespace DesktopManager.TestApp;
+
+internal sealed class TestAppOptions {
+    private const string DefaultTitle = "DesktopManager-McpTestApp";
+    private const string DefaultInitialText = "seed";
+    private const string DefaultSurface = "editor";
+
+    private TestAppOptions(string title, string initialText, string surface) {
+        Title = title;
+        InitialText = initialText;
+        Surface = surface;
+    }
+
+    public string Title { get; }
+
+    public string InitialText { get; }
+
+    public string Surface { get; }
+
+    public static TestAppOptions Parse(string[] args) {
+        string title = DefaultTitle;
+        string initialText = DefaultInitialText;
+        string surface = DefaultSurface;
+
+        for (int index = 0; index < args.Length; index++) {
+            string argument = args[index];
+            if (string.Equals(argument, "--title", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
+                title = args[++index];
+                continue;
+            }
+
+            if (string.Equals(argument, "--text", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
+                initialText = args[++index];
+                continue;
+            }
+
+            if (string.Equals(argument, "--surface", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
+                surface = args[++index];
+            }
+        }
+
+        return new TestAppOptions(title, initialText, surface);
+    }
+}

--- a/Sources/DesktopManager.Tests/CliApplicationTests.cs
+++ b/Sources/DesktopManager.Tests/CliApplicationTests.cs
@@ -1,0 +1,208 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI entrypoint help and dispatch behavior.
+/// </summary>
+public class CliApplicationTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the CLI prints general help when invoked without arguments.
+    /// </summary>
+    public void Run_WithNoArguments_WritesGeneralHelpToStandardOutput() {
+        (int exitCode, string standardOutput, string standardError) = RunCli();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(standardOutput, "desktopmanager - Windows desktop automation CLI");
+        StringAssert.Contains(standardOutput, "Groups:");
+        Assert.AreEqual(string.Empty, standardError);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures group help routes to the requested topic instead of the general help text.
+    /// </summary>
+    public void Run_WithHelpTopic_WritesGroupHelpToStandardOutput() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("help", "window");
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(standardOutput, "Window commands:");
+        Assert.AreEqual(string.Empty, standardError);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the shared help flag returns the general help text before command dispatch.
+    /// </summary>
+    public void Run_WithHelpFlag_WritesGeneralHelpToStandardOutput() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("window", "list", "--help");
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(standardOutput, "desktopmanager - Windows desktop automation CLI");
+        Assert.AreEqual(string.Empty, standardError);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures unknown command groups fail with an error and include the general help text on standard error.
+    /// </summary>
+    public void Run_WithUnknownGroup_WritesErrorAndGeneralHelpToStandardError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("unknown-group");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Unknown command group 'unknown-group'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [DataTestMethod]
+    [DataRow("window")]
+    [DataRow("control")]
+    [DataRow("monitor")]
+    [DataRow("process")]
+    [DataRow("screenshot")]
+    [DataRow("target")]
+    [DataRow("control-target")]
+    [DataRow("layout")]
+    [DataRow("snapshot")]
+    [DataRow("workflow")]
+    [DataRow("mcp")]
+    /// <summary>
+    /// Ensures known groups return a consistent command-line error when the action is unknown.
+    /// </summary>
+    public void Run_WithUnknownActionForKnownGroup_WritesGroupSpecificErrorAndGeneralHelp(string group) {
+        (int exitCode, string standardOutput, string standardError) = RunCli(group, "unknown-action");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, $"Error: Unknown {group} command 'unknown-action'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [DataTestMethod]
+    [DataRow("window")]
+    [DataRow("control")]
+    [DataRow("monitor")]
+    [DataRow("process")]
+    [DataRow("screenshot")]
+    [DataRow("target")]
+    [DataRow("control-target")]
+    [DataRow("layout")]
+    [DataRow("snapshot")]
+    [DataRow("workflow")]
+    [DataRow("mcp")]
+    /// <summary>
+    /// Ensures known groups fail consistently when the action is omitted entirely.
+    /// </summary>
+    public void Run_WithMissingActionForKnownGroup_WritesEmptyActionErrorAndGeneralHelp(string group) {
+        (int exitCode, string standardOutput, string standardError) = RunCli(group);
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, $"Error: Unknown {group} command ''.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures process start reports a missing process path through the CLI entrypoint.
+    /// </summary>
+    public void Run_ProcessStartWithoutPath_WritesMissingProcessPathError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("process", "start");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Missing required process path.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target get reports a missing target name through the CLI entrypoint.
+    /// </summary>
+    public void Run_TargetGetWithoutName_WritesMissingTargetNameError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("target", "get");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Missing required target name.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window snap reports a missing required option through the CLI entrypoint.
+    /// </summary>
+    public void Run_WindowSnapWithoutPosition_WritesMissingRequiredOptionError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("window", "snap");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Missing required option '--position'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures malformed empty option names are reported through the CLI entrypoint.
+    /// </summary>
+    public void Run_WithMalformedEmptyOptionName_WritesParseError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("--");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Encountered an empty option name.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures invalid integer values are reported through the CLI entrypoint before command execution.
+    /// </summary>
+    public void Run_ProcessStartWithInvalidIntegerOption_WritesIntegerError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("process", "start", "notepad.exe", "--wait-for-input-idle-ms", "abc");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Option '--wait-for-input-idle-ms' expects an integer value.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures invalid numeric values are reported through the CLI entrypoint before command execution.
+    /// </summary>
+    public void Run_TargetSaveWithInvalidNumericOption_WritesNumericError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("target", "save", "editor-center", "--x-ratio", "not-a-number", "--y-ratio", "0.5");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Option '--x-ratio' expects a numeric value.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures invalid assertion tolerances are reported through the CLI entrypoint before layout checks run.
+    /// </summary>
+    public void Run_LayoutAssertWithInvalidTolerance_WritesIntegerError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("layout", "assert", "coding", "--position-tolerance-px", "oops");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Option '--position-tolerance-px' expects an integer value.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunCli(params string[] args) {
+        using var standardOutput = new StringWriter();
+        using var standardError = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.CliApplication.Run(args, standardOutput, standardError);
+        return (exitCode, standardOutput.ToString(), standardError.ToString());
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/CommandLineArgumentsTests.cs
+++ b/Sources/DesktopManager.Tests/CommandLineArgumentsTests.cs
@@ -1,0 +1,97 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for shared CLI command-line argument parsing.
+/// </summary>
+public class CommandLineArgumentsTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures command parts, repeated options, and boolean flags are parsed consistently.
+    /// </summary>
+    public void Parse_SeparatesCommandPartsOptionsAndFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start",
+            "notepad.exe",
+            "--arguments", "first",
+            "--arguments", "second",
+            "--json",
+            "--capture-after"
+        });
+
+        Assert.IsFalse(arguments.IsEmpty);
+        Assert.AreEqual("process", arguments.GetCommandPart(0));
+        Assert.AreEqual("start", arguments.GetCommandPart(1));
+        Assert.AreEqual("notepad.exe", arguments.GetRequiredCommandPart(2, "process path"));
+        Assert.AreEqual("second", arguments.GetOption("arguments"));
+        CollectionAssert.AreEqual(new[] { "first", "second" }, arguments.GetOptions("arguments").ToArray());
+        Assert.IsTrue(arguments.GetBoolFlag("json"));
+        Assert.IsTrue(arguments.GetBoolFlag("capture-after"));
+        Assert.IsNull(arguments.GetCommandPart(3));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures flags without explicit values are stored as true and missing options return null or empty collections.
+    /// </summary>
+    public void Parse_UsesTrueForFlagsAndEmptyForMissingOptions() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "--json"
+        });
+
+        Assert.IsFalse(arguments.IsEmpty);
+        Assert.IsTrue(arguments.HasFlag("json"));
+        Assert.IsTrue(arguments.GetBoolFlag("json"));
+        Assert.AreEqual("true", arguments.GetOption("json"));
+        Assert.IsNull(arguments.GetOption("missing"));
+        Assert.AreEqual(0, arguments.GetOptions("missing").Count);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures integer and double parsing use invariant culture and required integer lookups work.
+    /// </summary>
+    public void NumericAccessors_ParseInvariantValues() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "--count", "42",
+            "--ratio", "1.5",
+            "--large", "1,024"
+        });
+
+        Assert.AreEqual(42, arguments.GetIntOption("count"));
+        Assert.AreEqual(42, arguments.GetRequiredIntOption("count"));
+        Assert.AreEqual(1.5d, arguments.GetDoubleOption("ratio"));
+        Assert.AreEqual(1024d, arguments.GetDoubleOption("large"));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures required and invalid value paths throw clear command-line exceptions.
+    /// </summary>
+    public void Accessors_ThrowForMissingOrInvalidValues() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "list",
+            "--count", "abc",
+            "--ratio", "not-a-number"
+        });
+
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() => arguments.GetRequiredOption("missing"));
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() => arguments.GetRequiredCommandPart(5, "action"));
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() => arguments.GetIntOption("count"));
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() => arguments.GetRequiredIntOption("missing-int"));
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() => arguments.GetDoubleOption("ratio"));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures malformed option names are rejected during parsing.
+    /// </summary>
+    public void Parse_ThrowsForEmptyOptionName() {
+        Assert.ThrowsException<global::DesktopManager.Cli.CommandLineException>(() =>
+            global::DesktopManager.Cli.CommandLineArguments.Parse(new[] { "--" }));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlAssertionCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlAssertionCommandOutputTests.cs
@@ -1,0 +1,119 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control wait and assertion text output.
+/// </summary>
+public class ControlAssertionCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures control wait text output includes elapsed timing and matched control details.
+    /// </summary>
+    public void WriteWaitResult_WritesMatchedControls() {
+        var result = new global::DesktopManager.Cli.WaitForControlResult {
+            ElapsedMilliseconds = 420,
+            Count = 2,
+            Controls = new[] {
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Edit",
+                    Text = "Search",
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Test App"
+                    }
+                },
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Button",
+                    Text = "Run",
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Command Surface"
+                    }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteWaitResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "wait: 2 control(s) after 420ms");
+        StringAssert.Contains(output, "- Edit Search in DesktopManager Test App");
+        StringAssert.Contains(output, "- Button Run in DesktopManager Command Surface");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control value assertion text output includes the expected predicate and matched controls.
+    /// </summary>
+    public void WriteValueAssertionResult_WritesPassingAssertionSummary() {
+        var result = new global::DesktopManager.Cli.ControlValueAssertionResult {
+            Matched = true,
+            PropertyName = "Value",
+            MatchMode = "contains",
+            Expected = "DesktopManager",
+            Count = 2,
+            MatchedCount = 1,
+            Controls = new[] {
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Edit",
+                    Value = "DesktopManager MCP E2E",
+                    Text = string.Empty,
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Test App"
+                    }
+                },
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Edit",
+                    Value = "Other value",
+                    Text = string.Empty,
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Secondary"
+                    }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteValueAssertionResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "Control value assertion passed.");
+        StringAssert.Contains(output, "assertion: Value contains \"DesktopManager\"");
+        StringAssert.Contains(output, "matched: 1/2");
+        StringAssert.Contains(output, "- Edit value=\"DesktopManager MCP E2E\" text=\"\" in DesktopManager Test App");
+        StringAssert.Contains(output, "- Edit value=\"Other value\" text=\"\" in DesktopManager Secondary");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control value assertion text output reports failures cleanly when no controls match.
+    /// </summary>
+    public void WriteValueAssertionResult_WritesFailingAssertionSummary() {
+        var result = new global::DesktopManager.Cli.ControlValueAssertionResult {
+            Matched = false,
+            PropertyName = "Text",
+            MatchMode = "equals",
+            Expected = "Run",
+            Count = 0,
+            MatchedCount = 0
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteValueAssertionResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "Control value assertion failed.");
+        StringAssert.Contains(output, "assertion: Text equals \"Run\"");
+        StringAssert.Contains(output, "matched: 0/0");
+        Assert.IsFalse(output.Contains(" in "));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlCommandCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/ControlCommandCriteriaTests.cs
@@ -1,0 +1,172 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control command criteria mapping.
+/// </summary>
+public class ControlCommandCriteriaTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures control command window criteria map window-scoped flags and keep the broad control defaults.
+    /// </summary>
+    public void CreateWindowCriteria_MapsWindowScopedFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "control",
+            "list",
+            "--window-title", "*Editor*",
+            "--window-process", "DesktopManager.TestApp",
+            "--window-class", "TestWindowClass",
+            "--window-pid", "321",
+            "--window-handle", "0x1234",
+            "--window-active"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.ControlCommands.CreateWindowCriteria(arguments);
+
+        Assert.AreEqual("*Editor*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("TestWindowClass", criteria.ClassNamePattern);
+        Assert.AreEqual(321, criteria.ProcessId);
+        Assert.AreEqual("0x1234", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsTrue(criteria.IncludeCloaked);
+        Assert.IsTrue(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control command control criteria map selector and capability flags.
+    /// </summary>
+    public void CreateControlCriteria_MapsSelectorAndCapabilityFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "control",
+            "list",
+            "--class", "Edit",
+            "--text-pattern", "*Desktop*",
+            "--value-pattern", "DesktopManager",
+            "--id", "101",
+            "--handle", "0x2222",
+            "--automation-id", "EditorTextBox",
+            "--control-type", "Edit",
+            "--framework-id", "WinForms",
+            "--enabled",
+            "--focusable",
+            "--background-click",
+            "--background-text",
+            "--background-keys",
+            "--foreground-fallback",
+            "--ensure-foreground",
+            "--allow-foreground-input",
+            "--uia",
+            "--include-uia",
+            "--all"
+        });
+
+        global::DesktopManager.Cli.ControlSelectionCriteria criteria = global::DesktopManager.Cli.ControlCommands.CreateControlCriteria(arguments);
+
+        Assert.AreEqual("Edit", criteria.ClassNamePattern);
+        Assert.AreEqual("*Desktop*", criteria.TextPattern);
+        Assert.AreEqual("DesktopManager", criteria.ValuePattern);
+        Assert.AreEqual(101, criteria.Id);
+        Assert.AreEqual("0x2222", criteria.Handle);
+        Assert.AreEqual("EditorTextBox", criteria.AutomationIdPattern);
+        Assert.AreEqual("Edit", criteria.ControlTypePattern);
+        Assert.AreEqual("WinForms", criteria.FrameworkIdPattern);
+        Assert.AreEqual(true, criteria.IsEnabled);
+        Assert.AreEqual(true, criteria.IsKeyboardFocusable);
+        Assert.AreEqual(true, criteria.SupportsBackgroundClick);
+        Assert.AreEqual(true, criteria.SupportsBackgroundText);
+        Assert.AreEqual(true, criteria.SupportsBackgroundKeys);
+        Assert.AreEqual(true, criteria.SupportsForegroundInputFallback);
+        Assert.IsTrue(criteria.EnsureForegroundWindow);
+        Assert.IsTrue(criteria.AllowForegroundInputFallback);
+        Assert.IsTrue(criteria.UiAutomation);
+        Assert.IsTrue(criteria.IncludeUiAutomation);
+        Assert.IsTrue(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control-target window criteria respect include-empty defaults and window-selection flags.
+    /// </summary>
+    public void ControlTargetCreateWindowCriteria_MapsIncludeEmptyAndWindowFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "control-target",
+            "resolve",
+            "--title", "*Command*",
+            "--process", "DesktopManager.TestApp",
+            "--class", "Chrome_WidgetWin_1",
+            "--pid", "654",
+            "--handle", "0x5678",
+            "--active",
+            "--include-hidden",
+            "--exclude-cloaked",
+            "--exclude-owned",
+            "--all-windows"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.ControlTargetCommands.CreateWindowCriteria(arguments, includeEmptyDefault: true);
+
+        Assert.AreEqual("*Command*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("Chrome_WidgetWin_1", criteria.ClassNamePattern);
+        Assert.AreEqual(654, criteria.ProcessId);
+        Assert.AreEqual("0x5678", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsFalse(criteria.IncludeCloaked);
+        Assert.IsFalse(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsTrue(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control-target criteria map disabled and not-focusable flags plus saved capability hints.
+    /// </summary>
+    public void ControlTargetCreateControlCriteria_MapsSelectorHints() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "control-target",
+            "save",
+            "--class", "Button",
+            "--text-pattern", "Save",
+            "--value-pattern", "",
+            "--id", "7",
+            "--handle", "0x7777",
+            "--automation-id", "SaveButton",
+            "--control-type", "Button",
+            "--framework-id", "WPF",
+            "--disabled",
+            "--not-focusable",
+            "--background-click",
+            "--foreground-fallback",
+            "--ensure-foreground",
+            "--uia",
+            "--include-uia",
+            "--all"
+        });
+
+        global::DesktopManager.Cli.ControlSelectionCriteria criteria = global::DesktopManager.Cli.ControlTargetCommands.CreateControlCriteria(arguments);
+
+        Assert.AreEqual("Button", criteria.ClassNamePattern);
+        Assert.AreEqual("Save", criteria.TextPattern);
+        Assert.AreEqual(string.Empty, criteria.ValuePattern);
+        Assert.AreEqual(7, criteria.Id);
+        Assert.AreEqual("0x7777", criteria.Handle);
+        Assert.AreEqual("SaveButton", criteria.AutomationIdPattern);
+        Assert.AreEqual("Button", criteria.ControlTypePattern);
+        Assert.AreEqual("WPF", criteria.FrameworkIdPattern);
+        Assert.AreEqual(false, criteria.IsEnabled);
+        Assert.AreEqual(false, criteria.IsKeyboardFocusable);
+        Assert.AreEqual(true, criteria.SupportsBackgroundClick);
+        Assert.AreEqual(true, criteria.SupportsForegroundInputFallback);
+        Assert.IsTrue(criteria.EnsureForegroundWindow);
+        Assert.IsTrue(criteria.UiAutomation);
+        Assert.IsTrue(criteria.IncludeUiAutomation);
+        Assert.IsTrue(criteria.All);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlCommandOutputTests.cs
@@ -1,0 +1,90 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control command text output.
+/// </summary>
+public class ControlCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures control mutation text output includes target, artifact, warning, and matched control details.
+    /// </summary>
+    public void WriteActionResult_WritesRichControlMutationSummary() {
+        var result = new global::DesktopManager.Cli.ControlActionResult {
+            Action = "send-control-keys",
+            Success = true,
+            Count = 2,
+            ElapsedMilliseconds = 187,
+            SafetyMode = "foreground-input-fallback",
+            TargetName = "CommandBar",
+            TargetKind = "control-target",
+            BeforeScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            AfterScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult(),
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            ArtifactWarnings = new[] { "Foreground input requested explicitly." },
+            Controls = new[] {
+                new global::DesktopManager.Cli.ControlResult {
+                    ClassName = "WindowsForms10.EDIT.app.0.1",
+                    Id = 101,
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Test App"
+                    }
+                },
+                new global::DesktopManager.Cli.ControlResult {
+                    ClassName = "HwndWrapper[DesktopManager.TestApp;;123456]",
+                    Id = 0,
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Command Surface"
+                    }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteActionResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "send-control-keys: 2 control(s) success=True safety=foreground-input-fallback elapsed-ms=187");
+        StringAssert.Contains(output, "target: control-target CommandBar");
+        StringAssert.Contains(output, "artifacts: before=1 after=2");
+        StringAssert.Contains(output, "warning: Foreground input requested explicitly.");
+        StringAssert.Contains(output, "- WindowsForms10.EDIT.app.0.1 [101] in DesktopManager Test App");
+        StringAssert.Contains(output, "- HwndWrapper[DesktopManager.TestApp;;123456] [0] in DesktopManager Command Surface");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control mutation text output omits optional sections when they are empty.
+    /// </summary>
+    public void WriteActionResult_OmitsEmptyOptionalSections() {
+        var result = new global::DesktopManager.Cli.ControlActionResult {
+            Action = "set-control-text",
+            Success = false,
+            Count = 0,
+            ElapsedMilliseconds = 44,
+            SafetyMode = "uia-direct-value"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteActionResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "set-control-text: 0 control(s) success=False safety=uia-direct-value elapsed-ms=44");
+        Assert.IsFalse(output.Contains("target:"));
+        Assert.IsFalse(output.Contains("artifacts:"));
+        Assert.IsFalse(output.Contains("warning:"));
+        Assert.IsFalse(output.Contains(" in "));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlDiagnosticCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlDiagnosticCommandOutputTests.cs
@@ -1,0 +1,121 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control diagnostic text output.
+/// </summary>
+public class ControlDiagnosticCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the empty diagnostics message stays explicit.
+    /// </summary>
+    public void WriteNoMatchingDiagnosticWindows_WritesExpectedMessage() {
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteNoMatchingDiagnosticWindows(writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "No matching windows found for control diagnostics.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control diagnostic text output includes action-probe, root, and sample control details.
+    /// </summary>
+    public void WriteDiagnosticResults_WritesRichDiagnosticSummary() {
+        var diagnostics = new[] {
+            new global::DesktopManager.Cli.ControlDiagnosticResult {
+                Window = new global::DesktopManager.Cli.WindowResult {
+                    Title = "DesktopManager Test App",
+                    Handle = "0x00123456"
+                },
+                EffectiveSource = "uia",
+                ElapsedMilliseconds = 87,
+                RequiresUiAutomation = true,
+                UiAutomationAvailable = true,
+                UseUiAutomation = true,
+                IncludeUiAutomation = true,
+                PreparationAttempted = true,
+                PreparationSucceeded = true,
+                EnsureForegroundWindow = false,
+                UiAutomationFallbackRootCount = 2,
+                UsedUiAutomationFallbackRoots = true,
+                UsedCachedUiAutomationControls = false,
+                PreferredUiAutomationRootHandle = "0x00ABCDEF",
+                UsedPreferredUiAutomationRoot = true,
+                Win32ControlCount = 1,
+                UiAutomationControlCount = 4,
+                EffectiveControlCount = 4,
+                MatchedControlCount = 2,
+                UiAutomationActionProbe = new global::DesktopManager.Cli.UiAutomationActionDiagnosticResult {
+                    Attempted = true,
+                    Resolved = true,
+                    UsedCachedActionMatch = false,
+                    UsedPreferredRoot = true,
+                    RootHandle = "0x00ABCDEF",
+                    Score = 92,
+                    SearchMode = "preferred-root",
+                    ElapsedMilliseconds = 12
+                },
+                UiAutomationRoots = new[] {
+                    new global::DesktopManager.Cli.UiAutomationRootDiagnosticResult {
+                        Order = 0,
+                        Handle = "0x00ABCDEF",
+                        ClassName = "Chrome_RenderWidgetHostHWND",
+                        IsPrimaryRoot = true,
+                        IsPreferredRoot = true,
+                        UsedCachedControls = false,
+                        IncludeRoot = true,
+                        ElementResolved = true,
+                        ControlCount = 4,
+                        Error = null,
+                        SampleControls = new[] {
+                            new global::DesktopManager.Cli.ControlResult {
+                                Source = "uia",
+                                ControlType = "Edit",
+                                AutomationId = "EditorTextBox",
+                                Text = "DesktopManager"
+                            }
+                        }
+                    }
+                },
+                SampleControls = new[] {
+                    new global::DesktopManager.Cli.ControlResult {
+                        Source = "uia",
+                        ControlType = "Edit",
+                        AutomationId = "EditorTextBox",
+                        Text = "DesktopManager"
+                    },
+                    new global::DesktopManager.Cli.ControlResult {
+                        Source = "win32",
+                        ControlType = "Button",
+                        AutomationId = string.Empty,
+                        Text = "Run"
+                    }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        global::DesktopManager.Cli.ControlCommands.WriteDiagnosticResults(diagnostics, writer);
+        string output = writer.ToString();
+
+        StringAssert.Contains(output, "window: DesktopManager Test App (0x00123456)");
+        StringAssert.Contains(output, "effective-source: uia");
+        StringAssert.Contains(output, "uia: required=True available=True requested=True include=True");
+        StringAssert.Contains(output, "preparation: attempted=True succeeded=True ensureForeground=False");
+        StringAssert.Contains(output, "fallback-roots: count=2 used=True cached=False preferred=0x00ABCDEF reused=True");
+        StringAssert.Contains(output, "counts: win32=1 uia=4 effective=4 matched=2");
+        StringAssert.Contains(output, "action-probe: attempted=True resolved=True cached=False preferred=True root=0x00ABCDEF score=92 mode=preferred-root elapsed-ms=12");
+        StringAssert.Contains(output, "root[0]: handle=0x00ABCDEF class=Chrome_RenderWidgetHostHWND primary=True preferred=True cached=False includeRoot=True elementResolved=True count=4 error=");
+        StringAssert.Contains(output, "  * uia Edit EditorTextBox DesktopManager");
+        StringAssert.Contains(output, "- uia Edit EditorTextBox DesktopManager");
+        StringAssert.Contains(output, "- win32 Button  Run");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlEnumeratorTests.cs
+++ b/Sources/DesktopManager.Tests/ControlEnumeratorTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -14,31 +14,24 @@ public class ControlEnumeratorTests {
     
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
-    public void Enumerate_NotepadControls_ReturnsEdit() {
+    public void Enumerate_WinFormsControls_ReturnsEdit() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form form = new() { Text = "Control Enumerator Form", ShowInTaskbar = false };
+        using TextBox textBox = new() { Text = "DesktopManager" };
+        form.Controls.Add(textBox);
+        form.Show();
+        textBox.CreateControl();
+        Application.DoEvents();
 
-        Process? process = null;
-        
-        try {
-            process = TestHelper.StartHiddenNotepad();
-            if (process == null) {
-                Assert.Inconclusive("Failed to start Notepad");
-            }
+        var enumerator = new ControlEnumerator();
+        var controls = enumerator.EnumerateControls(form.Handle);
 
-            var manager = new WindowManager();
-            var window = manager.WaitWindow("*Notepad*", 10000);
-            var enumerator = new ControlEnumerator();
-            var controls = enumerator.EnumerateControls(window.Handle);
-            Assert.IsTrue(controls.Any(c => c.ClassName == "Edit"));
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        WindowControlInfo? textBoxControl = controls.FirstOrDefault(c => c.Handle == textBox.Handle);
+        Assert.IsNotNull(textBoxControl);
+        StringAssert.Contains(textBoxControl.ClassName, "EDIT", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Sources/DesktopManager.Tests/ControlExistsCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlExistsCommandOutputTests.cs
@@ -1,0 +1,68 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control exists text output.
+/// </summary>
+public class ControlExistsCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures control exists text output reports matches and lists matching controls.
+    /// </summary>
+    public void WriteAssertionResult_WritesMatchingControls() {
+        var result = new global::DesktopManager.Cli.ControlAssertionResult {
+            Matched = true,
+            Count = 2,
+            Controls = new[] {
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Edit",
+                    Text = "Search",
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Test App"
+                    }
+                },
+                new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Button",
+                    Text = "Run",
+                    ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                        Title = "DesktopManager Command Surface"
+                    }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteAssertionResult(result, "Matching control found.", "No matching controls found.", writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "Matching control found.");
+        StringAssert.Contains(output, "- Edit Search in DesktopManager Test App");
+        StringAssert.Contains(output, "- Button Run in DesktopManager Command Surface");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control exists text output reports failures cleanly when no controls match.
+    /// </summary>
+    public void WriteAssertionResult_WritesFailureWithoutControlLines() {
+        var result = new global::DesktopManager.Cli.ControlAssertionResult {
+            Matched = false,
+            Count = 0
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteAssertionResult(result, "Matching control found.", "No matching controls found.", writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "No matching controls found.");
+        Assert.IsFalse(output.Contains(" in "));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlListCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlListCommandOutputTests.cs
@@ -1,0 +1,119 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control list text output.
+/// </summary>
+public class ControlListCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures control list output renders the expected table headers and row values.
+    /// </summary>
+    public void WriteControlListResults_WritesControlTable() {
+        var controls = new List<global::DesktopManager.Cli.ControlResult> {
+            new() {
+                Id = 101,
+                Handle = "0x1234",
+                Source = "Win32",
+                ControlType = "Edit",
+                Left = 10,
+                Top = 20,
+                Width = 300,
+                Height = 24,
+                IsEnabled = true,
+                IsKeyboardFocusable = true,
+                IsOffscreen = false,
+                SupportsBackgroundClick = true,
+                SupportsBackgroundText = true,
+                SupportsBackgroundKeys = false,
+                SupportsForegroundInputFallback = false,
+                AutomationId = "EditorTextBox",
+                ClassName = "Edit",
+                Text = "DesktopManager",
+                Value = "DesktopManager",
+                ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                    ProcessId = 321,
+                    Title = "DesktopManager Test App"
+                }
+            },
+            new() {
+                Id = 0,
+                Handle = "0x0",
+                Source = "UiAutomation",
+                ControlType = "Button",
+                Left = 400,
+                Top = 40,
+                Width = 90,
+                Height = 30,
+                IsEnabled = true,
+                IsKeyboardFocusable = true,
+                IsOffscreen = false,
+                SupportsBackgroundClick = false,
+                SupportsBackgroundText = false,
+                SupportsBackgroundKeys = false,
+                SupportsForegroundInputFallback = true,
+                AutomationId = "SaveButton",
+                ClassName = "Button",
+                Text = "Save",
+                Value = string.Empty,
+                ParentWindow = new global::DesktopManager.Cli.WindowResult {
+                    ProcessId = 654,
+                    Title = "DesktopManager Command Surface"
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteControlListResults(controls, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "PID");
+        StringAssert.Contains(output, "Id");
+        StringAssert.Contains(output, "Handle");
+        StringAssert.Contains(output, "Source");
+        StringAssert.Contains(output, "Type");
+        StringAssert.Contains(output, "BgClick");
+        StringAssert.Contains(output, "BgText");
+        StringAssert.Contains(output, "BgKeys");
+        StringAssert.Contains(output, "FgFallback");
+        StringAssert.Contains(output, "AutomationId");
+        StringAssert.Contains(output, "Class");
+        StringAssert.Contains(output, "Text");
+        StringAssert.Contains(output, "Value");
+        StringAssert.Contains(output, "Window");
+        StringAssert.Contains(output, "321");
+        StringAssert.Contains(output, "101");
+        StringAssert.Contains(output, "1234");
+        StringAssert.Contains(output, "Win32");
+        StringAssert.Contains(output, "Edit");
+        StringAssert.Contains(output, "EditorTextBox");
+        StringAssert.Contains(output, "DesktopManager Test App");
+        StringAssert.Contains(output, "654");
+        StringAssert.Contains(output, "0");
+        StringAssert.Contains(output, "UiAutomation");
+        StringAssert.Contains(output, "Button");
+        StringAssert.Contains(output, "SaveButton");
+        StringAssert.Contains(output, "DesktopManager Command Surface");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the empty control-list message stays explicit.
+    /// </summary>
+    public void WriteNoMatchingControls_WritesExpectedMessage() {
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlCommands.WriteNoMatchingControls(writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "No matching controls found.");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlQueryAndDiagnosticsMappingTests.cs
+++ b/Sources/DesktopManager.Tests/ControlQueryAndDiagnosticsMappingTests.cs
@@ -1,0 +1,165 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control query mapping and diagnostic result shaping.
+/// </summary>
+public class ControlQueryAndDiagnosticsMappingTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures CLI control selection criteria preserve foreground and UI Automation routing flags.
+    /// </summary>
+    public void CreateControlQuery_MapsForegroundAndUiAutomationFlags() {
+        var criteria = new global::DesktopManager.Cli.ControlSelectionCriteria {
+            ClassNamePattern = "WindowsForms10.*",
+            TextPattern = "Search*",
+            ValuePattern = "DesktopManager*",
+            Id = 42,
+            Handle = "0x2A",
+            AutomationIdPattern = "EditorTextBox",
+            ControlTypePattern = "Edit",
+            FrameworkIdPattern = "WPF",
+            IsEnabled = true,
+            IsKeyboardFocusable = true,
+            SupportsBackgroundClick = true,
+            SupportsBackgroundText = false,
+            SupportsBackgroundKeys = true,
+            SupportsForegroundInputFallback = true,
+            EnsureForegroundWindow = true,
+            AllowForegroundInputFallback = true,
+            UiAutomation = true,
+            IncludeUiAutomation = true
+        };
+
+        WindowControlQueryOptions query = global::DesktopManager.Cli.DesktopOperations.CreateControlQuery(criteria);
+
+        Assert.AreEqual("WindowsForms10.*", query.ClassNamePattern);
+        Assert.AreEqual("Search*", query.TextPattern);
+        Assert.AreEqual("DesktopManager*", query.ValuePattern);
+        Assert.AreEqual(42, query.Id);
+        Assert.AreEqual(new IntPtr(0x2A), query.Handle);
+        Assert.AreEqual("EditorTextBox", query.AutomationIdPattern);
+        Assert.AreEqual("Edit", query.ControlTypePattern);
+        Assert.AreEqual("WPF", query.FrameworkIdPattern);
+        Assert.AreEqual(true, query.IsEnabled);
+        Assert.AreEqual(true, query.IsKeyboardFocusable);
+        Assert.AreEqual(true, query.SupportsBackgroundClick);
+        Assert.AreEqual(false, query.SupportsBackgroundText);
+        Assert.AreEqual(true, query.SupportsBackgroundKeys);
+        Assert.AreEqual(true, query.SupportsForegroundInputFallback);
+        Assert.IsTrue(query.EnsureForegroundWindow);
+        Assert.IsTrue(query.AllowForegroundInputFallback);
+        Assert.IsTrue(query.UseUiAutomation);
+        Assert.IsTrue(query.IncludeUiAutomation);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures CLI diagnostic mapping normalizes handles and preserves root, sample, and action-probe metadata.
+    /// </summary>
+    public void MapControlDiagnostics_NormalizesHandlesAndMapsSamples() {
+        var window = new WindowInfo {
+            Title = "DesktopManager Test App",
+            Handle = new IntPtr(0x1234),
+            ProcessId = 321,
+            ThreadId = 654,
+            IsVisible = true,
+            IsTopMost = false,
+            Left = 10,
+            Top = 20,
+            Right = 810,
+            Bottom = 620,
+            MonitorIndex = 1,
+            MonitorDeviceName = @"\\.\\DISPLAY1"
+        };
+        var diagnostics = new DesktopControlDiscoveryDiagnostics {
+            Window = window,
+            RequiresUiAutomation = true,
+            UseUiAutomation = true,
+            IncludeUiAutomation = true,
+            EnsureForegroundWindow = false,
+            UiAutomationAvailable = true,
+            ElapsedMilliseconds = 87,
+            PreparationAttempted = true,
+            PreparationSucceeded = true,
+            UiAutomationFallbackRootCount = 2,
+            UsedUiAutomationFallbackRoots = true,
+            UsedCachedUiAutomationControls = false,
+            UsedPreferredUiAutomationRoot = true,
+            PreferredUiAutomationRootHandle = new IntPtr(0xABCDEF),
+            EffectiveSource = "uia",
+            Win32ControlCount = 1,
+            UiAutomationControlCount = 4,
+            EffectiveControlCount = 4,
+            MatchedControlCount = 2,
+            SampleControls = new[] {
+                new WindowControlInfo {
+                    Source = WindowControlSource.UiAutomation,
+                    Handle = IntPtr.Zero,
+                    AutomationId = "EditorTextBox",
+                    ControlType = "Edit",
+                    Text = "DesktopManager",
+                    Value = "DesktopManager",
+                    SupportsForegroundInputFallback = true
+                }
+            },
+            UiAutomationRoots = new[] {
+                new DesktopUiAutomationRootDiagnostic {
+                    Order = 0,
+                    Handle = new IntPtr(0xABCDEF),
+                    ClassName = "Chrome_RenderWidgetHostHWND",
+                    IsPrimaryRoot = true,
+                    IsPreferredRoot = true,
+                    UsedCachedControls = false,
+                    IncludeRoot = true,
+                    ElementResolved = true,
+                    ControlCount = 4,
+                    SampleControls = new[] {
+                        new WindowControlInfo {
+                            Source = WindowControlSource.UiAutomation,
+                            Handle = IntPtr.Zero,
+                            AutomationId = "EditorTextBox",
+                            ControlType = "Edit",
+                            Text = "DesktopManager"
+                        }
+                    }
+                }
+            },
+            UiAutomationActionProbe = new DesktopUiAutomationActionDiagnostic {
+                Attempted = true,
+                Resolved = true,
+                UsedCachedActionMatch = false,
+                UsedPreferredRoot = true,
+                RootHandle = new IntPtr(0xABCDEF),
+                Score = 92,
+                SearchMode = "preferred-root",
+                ElapsedMilliseconds = 12
+            }
+        };
+
+        global::DesktopManager.Cli.ControlDiagnosticResult result = global::DesktopManager.Cli.DesktopOperations.MapControlDiagnostics(diagnostics);
+
+        Assert.AreEqual("DesktopManager Test App", result.Window.Title);
+        Assert.AreEqual("0x1234", result.Window.Handle);
+        Assert.AreEqual("uia", result.EffectiveSource);
+        Assert.AreEqual("0xABCDEF", result.PreferredUiAutomationRootHandle);
+        Assert.AreEqual(1, result.SampleControls.Count);
+        Assert.AreEqual("EditorTextBox", result.SampleControls[0].AutomationId);
+        Assert.AreEqual("Edit", result.SampleControls[0].ControlType);
+        Assert.AreEqual("DesktopManager", result.SampleControls[0].Text);
+        Assert.AreEqual("DesktopManager", result.SampleControls[0].Value);
+        Assert.AreEqual("0x0", result.SampleControls[0].Handle);
+        Assert.AreEqual("0x1234", result.SampleControls[0].ParentWindow.Handle);
+        Assert.AreEqual(1, result.UiAutomationRoots.Count);
+        Assert.AreEqual("0xABCDEF", result.UiAutomationRoots[0].Handle);
+        Assert.AreEqual("Chrome_RenderWidgetHostHWND", result.UiAutomationRoots[0].ClassName);
+        Assert.AreEqual(1, result.UiAutomationRoots[0].SampleControls.Count);
+        Assert.AreEqual("EditorTextBox", result.UiAutomationRoots[0].SampleControls[0].AutomationId);
+        Assert.IsNotNull(result.UiAutomationActionProbe);
+        Assert.AreEqual("0xABCDEF", result.UiAutomationActionProbe.RootHandle);
+        Assert.AreEqual("preferred-root", result.UiAutomationActionProbe.SearchMode);
+        Assert.AreEqual(92, result.UiAutomationActionProbe.Score);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ControlTargetCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ControlTargetCommandOutputTests.cs
@@ -1,0 +1,138 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI control-target text output.
+/// </summary>
+public class ControlTargetCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures save output writes the control target name and persisted path.
+    /// </summary>
+    public void WriteSavedTargetResult_WritesTargetNameAndPath() {
+        var result = new global::DesktopManager.Cli.ControlTargetResult {
+            Name = "CommandBar",
+            Path = @"C:\Targets\CommandBar.control.json"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlTargetCommands.WriteSavedTargetResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "save: CommandBar");
+        StringAssert.Contains(output, "C:\\Targets\\CommandBar.control.json");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures get output includes configured control criteria and optional description.
+    /// </summary>
+    public void WriteTargetResult_WritesRichControlTargetSummary() {
+        var result = new global::DesktopManager.Cli.ControlTargetResult {
+            Name = "CommandBar",
+            Path = @"C:\Targets\CommandBar.control.json",
+            Target = new global::DesktopManager.Cli.ControlTargetDefinitionResult {
+                ClassNamePattern = "HwndWrapper*",
+                TextPattern = "*Desktop*",
+                ValuePattern = "DesktopManager",
+                ControlTypePattern = "Edit",
+                AutomationIdPattern = "CommandBarTextBox",
+                SupportsBackgroundClick = false,
+                SupportsBackgroundText = false,
+                SupportsBackgroundKeys = false,
+                SupportsForegroundInputFallback = true,
+                Description = "Command bar editor"
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlTargetCommands.WriteTargetResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "CommandBar");
+        StringAssert.Contains(output, "- Path: C:\\Targets\\CommandBar.control.json");
+        StringAssert.Contains(output, "- Class: HwndWrapper*");
+        StringAssert.Contains(output, "- Text: *Desktop*");
+        StringAssert.Contains(output, "- Value: DesktopManager");
+        StringAssert.Contains(output, "- ControlType: Edit");
+        StringAssert.Contains(output, "- AutomationId: CommandBarTextBox");
+        StringAssert.Contains(output, "- BackgroundClick: False");
+        StringAssert.Contains(output, "- BackgroundText: False");
+        StringAssert.Contains(output, "- BackgroundKeys: False");
+        StringAssert.Contains(output, "- ForegroundFallback: True");
+        StringAssert.Contains(output, "- Description: Command bar editor");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures control-target list output sorts names and shows the empty-state message when no targets are present.
+    /// </summary>
+    public void WriteTargetNames_SortsNamesAndSupportsEmptyState() {
+        using var populatedWriter = new StringWriter();
+
+        int populatedExitCode = global::DesktopManager.Cli.ControlTargetCommands.WriteTargetNames(
+            new List<string> { "zeta", "Alpha", "beta" },
+            populatedWriter);
+
+        string populatedOutput = populatedWriter.ToString();
+        int alphaIndex = populatedOutput.IndexOf("Alpha", System.StringComparison.Ordinal);
+        int betaIndex = populatedOutput.IndexOf("beta", System.StringComparison.Ordinal);
+        int zetaIndex = populatedOutput.IndexOf("zeta", System.StringComparison.Ordinal);
+
+        Assert.AreEqual(0, populatedExitCode);
+        Assert.IsTrue(alphaIndex >= 0);
+        Assert.IsTrue(betaIndex > alphaIndex);
+        Assert.IsTrue(zetaIndex > betaIndex);
+
+        using var emptyWriter = new StringWriter();
+
+        int emptyExitCode = global::DesktopManager.Cli.ControlTargetCommands.WriteTargetNames(Array.Empty<string>(), emptyWriter);
+
+        Assert.AreEqual(0, emptyExitCode);
+        StringAssert.Contains(emptyWriter.ToString(), "No named control targets found.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures resolved control target output includes window, control, and capability details.
+    /// </summary>
+    public void WriteResolvedTargets_WritesResolvedControlTargetSummary() {
+        var results = new List<global::DesktopManager.Cli.ResolvedControlTargetResult> {
+            new() {
+                Name = "CommandBar",
+                Window = new global::DesktopManager.Cli.WindowResult {
+                    Title = "DesktopManager Command Surface",
+                    Handle = "0x2222"
+                },
+                Control = new global::DesktopManager.Cli.ControlResult {
+                    ControlType = "Edit",
+                    Text = "DesktopManager",
+                    Handle = "0x0",
+                    SupportsBackgroundText = false,
+                    SupportsForegroundInputFallback = true
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ControlTargetCommands.WriteResolvedTargets(results, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "CommandBar: DesktopManager Command Surface (0x2222)");
+        StringAssert.Contains(output, "- Control: Edit DesktopManager");
+        StringAssert.Contains(output, "- Handle: 0x0");
+        StringAssert.Contains(output, "- BackgroundText: False");
+        StringAssert.Contains(output, "- ForegroundFallback: True");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
@@ -60,6 +60,28 @@ public class DesktopAutomationCoreTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures screenshot paths normalize non-PNG extensions to PNG.
+    /// </summary>
+    public void DesktopStateStore_ResolveCapturePath_ReplacesNonPngExtension() {
+        string testRoot = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", Guid.NewGuid().ToString("N"));
+        string requestedPath = Path.Combine(testRoot, "capture-output.jpg");
+
+        try {
+            string resolvedPath = DesktopStateStore.ResolveCapturePath("desktop", requestedPath);
+            string expectedPath = Path.GetFullPath(Path.Combine(testRoot, "capture-output.png"));
+
+            Assert.AreEqual(expectedPath, resolvedPath, true);
+            Assert.AreEqual(".png", Path.GetExtension(resolvedPath), true);
+            Assert.IsTrue(Directory.Exists(testRoot));
+        } finally {
+            if (Directory.Exists(testRoot)) {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures target paths use json storage.
     /// </summary>
     public void DesktopStateStore_GetTargetPath_UsesJsonExtension() {
@@ -67,6 +89,24 @@ public class DesktopAutomationCoreTests {
 
         Assert.AreEqual(".json", Path.GetExtension(path), true);
         StringAssert.Contains(path, Path.DirectorySeparatorChar + "targets" + Path.DirectorySeparatorChar);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures reserved Windows device names are rejected for saved state.
+    /// </summary>
+    public void DesktopStateStore_GetTargetPath_ReservedDeviceName_ThrowsArgumentException() {
+        Assert.ThrowsException<ArgumentException>(() => DesktopStateStore.GetTargetPath("CON"));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures trailing spaces and dots are normalized away from saved state names.
+    /// </summary>
+    public void DesktopStateStore_GetTargetPath_TrailingDotsAndSpaces_AreTrimmed() {
+        string path = DesktopStateStore.GetTargetPath("editor-center. ");
+
+        Assert.AreEqual("editor-center.json", Path.GetFileName(path), true);
     }
 
     [TestMethod]
@@ -285,7 +325,23 @@ public class DesktopAutomationCoreTests {
 
     [TestMethod]
     /// <summary>
-    /// Ensures process launch can require a window when no match appears.
+    /// Ensures process launch can require a real user-facing window when none appears.
+    /// </summary>
+    public void DesktopAutomationService_LaunchProcess_RequireWindowWithoutUserFacingWindow_ThrowsTimeoutException() {
+        var automation = new DesktopAutomationService();
+
+        Assert.ThrowsException<TimeoutException>(() => automation.LaunchProcess(new DesktopProcessStartOptions {
+            FilePath = "cmd.exe",
+            Arguments = "/c exit",
+            WaitForWindowMilliseconds = 1,
+            WaitForWindowIntervalMilliseconds = 1,
+            RequireWindow = true
+        }));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures process launch can require a matching window selector when no match appears.
     /// </summary>
     public void DesktopAutomationService_LaunchProcess_RequireWindowWithImpossibleSelector_ThrowsTimeoutException() {
         var automation = new DesktopAutomationService();
@@ -293,6 +349,7 @@ public class DesktopAutomationCoreTests {
         Assert.ThrowsException<TimeoutException>(() => automation.LaunchProcess(new DesktopProcessStartOptions {
             FilePath = "cmd.exe",
             Arguments = "/c exit",
+            WindowTitlePattern = "__DesktopManager_NoSuchWindow__",
             WaitForWindowMilliseconds = 1,
             WaitForWindowIntervalMilliseconds = 1,
             RequireWindow = true
@@ -403,6 +460,130 @@ public class DesktopAutomationCoreTests {
         Assert.ThrowsException<InvalidOperationException>(() => automation.SendControlKeys(new WindowControlInfo {
             Handle = new IntPtr(1)
         }, new[] { VirtualKey.VK_A }));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation text routing requires an explicitly fallback-capable control.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationTextFallback_UnsupportedControl_ReturnsError() {
+        string? error = DesktopAutomationService.ValidateUiAutomationTextFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = false
+        }, allowForegroundInputFallback: true);
+
+        StringAssert.Contains(error, "does not expose direct value setting");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation text routing requires an explicit foreground-input opt-in.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationTextFallback_MissingOptIn_ReturnsError() {
+        string? error = DesktopAutomationService.ValidateUiAutomationTextFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = true
+        }, allowForegroundInputFallback: false);
+
+        StringAssert.Contains(error, "Enable foreground input fallback");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation text routing allows explicitly approved foreground fallback.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationTextFallback_AllowedControl_ReturnsNull() {
+        string? error = DesktopAutomationService.ValidateUiAutomationTextFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = true
+        }, allowForegroundInputFallback: true);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures handle-backed controls bypass the zero-handle UI Automation text fallback checks.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationTextFallback_HandleBackedControl_ReturnsNull() {
+        string? error = DesktopAutomationService.ValidateUiAutomationTextFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = new IntPtr(123),
+            SupportsForegroundInputFallback = true
+        }, allowForegroundInputFallback: false);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation key routing requires a fallback-capable control.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationKeyFallback_UnsupportedControl_ReturnsError() {
+        string? error = DesktopAutomationService.ValidateUiAutomationKeyFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = false
+        }, allowForegroundInputFallback: true);
+
+        StringAssert.Contains(error, "cannot receive foreground fallback key input");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation key routing requires an explicit foreground-input opt-in.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationKeyFallback_MissingOptIn_ReturnsError() {
+        string? error = DesktopAutomationService.ValidateUiAutomationKeyFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = true
+        }, allowForegroundInputFallback: false);
+
+        StringAssert.Contains(error, "does not expose a Win32 handle");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures zero-handle UI Automation key routing allows explicitly approved foreground fallback.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationKeyFallback_AllowedControl_ReturnsNull() {
+        string? error = DesktopAutomationService.ValidateUiAutomationKeyFallback(new WindowControlInfo {
+            Source = WindowControlSource.UiAutomation,
+            Handle = IntPtr.Zero,
+            ControlType = "Edit",
+            ClassName = "TextBox",
+            SupportsForegroundInputFallback = true
+        }, allowForegroundInputFallback: true);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures Win32 controls bypass the zero-handle UI Automation key fallback checks.
+    /// </summary>
+    public void DesktopAutomationService_ValidateUiAutomationKeyFallback_Win32Control_ReturnsNull() {
+        string? error = DesktopAutomationService.ValidateUiAutomationKeyFallback(new WindowControlInfo {
+            Source = WindowControlSource.Win32,
+            Handle = IntPtr.Zero,
+            SupportsForegroundInputFallback = false
+        }, allowForegroundInputFallback: false);
+
+        Assert.IsNull(error);
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -7,8 +7,6 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
@@ -25,6 +23,11 @@
   <ItemGroup>
     <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />
     <ProjectReference Include="..\WindowTextHelper32\WindowTextHelper32.csproj" OutputItemType="Content" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+    <ProjectReference Include="..\DesktopManager.Cli\DesktopManager.Cli.csproj" />
+    <ProjectReference Include="..\DesktopManager.TestApp\DesktopManager.TestApp.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Target Name="CopyWindowHelperDependencies" AfterTargets="Build">

--- a/Sources/DesktopManager.Tests/HelpTextTests.cs
+++ b/Sources/DesktopManager.Tests/HelpTextTests.cs
@@ -1,0 +1,65 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI help topic routing and advertised help commands.
+/// </summary>
+public class HelpTextTests {
+    [DataTestMethod]
+    [DataRow("window", "Window commands:")]
+    [DataRow("control", "Control commands:")]
+    [DataRow("monitor", "Monitor commands:")]
+    [DataRow("process", "Process commands:")]
+    [DataRow("screenshot", "Screenshot commands:")]
+    [DataRow("target", "Target commands:")]
+    [DataRow("control-target", "Control-target commands:")]
+    [DataRow("layout", "Layout commands:")]
+    [DataRow("snapshot", "Snapshot commands:")]
+    [DataRow("workflow", "Workflow commands:")]
+    [DataRow("mcp", "MCP commands:")]
+    /// <summary>
+    /// Ensures every supported help topic resolves to its specific help block.
+    /// </summary>
+    public void GetHelpText_KnownTopics_ReturnTopicSpecificHelp(string topic, string expectedHeader) {
+        string help = global::DesktopManager.Cli.CliApplication.GetHelpText(topic);
+
+        StringAssert.StartsWith(help, expectedHeader);
+        Assert.AreNotEqual(global::DesktopManager.Cli.HelpText.GetGeneralHelp(), help);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures unsupported help topics fall back to general help text.
+    /// </summary>
+    public void GetHelpText_UnknownTopic_ReturnsGeneralHelp() {
+        string help = global::DesktopManager.Cli.CliApplication.GetHelpText("unknown-topic");
+
+        Assert.AreEqual(global::DesktopManager.Cli.HelpText.GetGeneralHelp(), help);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the general help text advertises every supported group help command.
+    /// </summary>
+    public void GetGeneralHelp_ListsAllSupportedHelpTopics() {
+        string help = global::DesktopManager.Cli.HelpText.GetGeneralHelp();
+
+        foreach (string topic in new[] {
+            "window",
+            "control",
+            "monitor",
+            "process",
+            "screenshot",
+            "target",
+            "control-target",
+            "layout",
+            "snapshot",
+            "workflow",
+            "mcp"
+        }) {
+            StringAssert.Contains(help, $"desktopmanager help {topic}");
+        }
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/KeyboardInputControlTests.cs
+++ b/Sources/DesktopManager.Tests/KeyboardInputControlTests.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -16,78 +14,36 @@ public class KeyboardInputControlTests {
     
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - underlying SendToControl needs fixing")]
     public void SendToControl_TypesIntoBackgroundControl() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form targetForm = new() { Text = "Target Form", ShowInTaskbar = false };
+        using TextBox textBox = new();
+        using Form foregroundForm = new() { Text = "Foreground Form", ShowInTaskbar = false };
 
-        Process? proc1 = null;
-        Process? proc2 = null;
-        
-        try {
-            proc1 = TestHelper.StartHiddenNotepad();
-            proc2 = TestHelper.StartHiddenNotepad();
-            
-            if (proc1 == null || proc2 == null) {
-                Assert.Inconclusive("Failed to start Notepad");
-            }
+        targetForm.Controls.Add(textBox);
+        targetForm.Show();
+        foregroundForm.Show();
+        textBox.CreateControl();
+        foregroundForm.Activate();
+        Application.DoEvents();
+        Thread.Sleep(100);
 
-            var manager = new WindowManager();
-            
-            WindowInfo? win1 = null;
-            WindowInfo? win2 = null;
-            
-            for (int retry = 0; retry < 5; retry++) {
-                var windows1 = manager.GetWindowsForProcess(proc1!);
-                var windows2 = manager.GetWindowsForProcess(proc2!);
-                
-                if (windows1.Any() && windows2.Any()) {
-                    win1 = windows1.First();
-                    win2 = windows2.First();
-                    break;
-                }
-                
-                Thread.Sleep(500);
-            }
-            
-            if (win1 == null || win2 == null) {
-                Assert.Inconclusive("Windows not found after retries");
-            }
-            
-            MonitorNativeMethods.SetForegroundWindow(win2.Handle);
-            Thread.Sleep(100);
+        WindowControlInfo control = new() {
+            ParentWindowHandle = targetForm.Handle,
+            Handle = textBox.Handle,
+            ClassName = "Edit",
+            Id = MonitorNativeMethods.GetDlgCtrlID(textBox.Handle),
+            Text = textBox.Text
+        };
 
-            var enumerator = new ControlEnumerator();
-            WindowControlInfo? ctrl = null;
-            
-            for (int retry = 0; retry < 3; retry++) {
-                ctrl = enumerator.EnumerateControls(win1.Handle).FirstOrDefault(c => c.ClassName == "Edit");
-                if (ctrl != null) break;
-                Thread.Sleep(500);
-            }
-            
-            if (ctrl == null) {
-                Assert.Inconclusive("Edit control not found after retries");
-            }
-            
-            KeyboardInputService.SendToControl(ctrl, VirtualKey.VK_H, VirtualKey.VK_I);
-            Thread.Sleep(1000);
+        KeyboardInputService.SendToControl(control, VirtualKey.VK_H, VirtualKey.VK_I);
+        Application.DoEvents();
+        Thread.Sleep(100);
 
-            int len = MonitorNativeMethods.GetWindowTextLength(ctrl.Handle);
-            StringBuilder sb = new(Math.Max(len + 1, 10));
-            MonitorNativeMethods.GetWindowText(ctrl.Handle, sb, sb.Capacity);
-            
-            string text = sb.ToString();
-            Assert.IsTrue(text.Contains("HI") || text.EndsWith("HI"), 
-                $"Expected text to contain 'HI' but got '{text}'");
-        } finally {
-            TestHelper.SafeKillProcess(proc1);
-            TestHelper.SafeKillProcess(proc2);
-        }
+        Assert.AreEqual("HI", textBox.Text);
     }
 }

--- a/Sources/DesktopManager.Tests/LayoutCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/LayoutCommandOutputTests.cs
@@ -1,0 +1,140 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI layout text output.
+/// </summary>
+public class LayoutCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures path output writes the action and persisted layout path.
+    /// </summary>
+    public void WritePathResult_WritesActionAndPath() {
+        var payload = new global::DesktopManager.Cli.NamedStateResult {
+            Action = "save-layout",
+            Name = "Coding",
+            Path = @"C:\Layouts\Coding.layout.json"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.LayoutCommands.WritePathResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "save-layout: Coding");
+        StringAssert.Contains(output, "C:\\Layouts\\Coding.layout.json");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures list output sorts names and shows the empty-state message when no layouts are present.
+    /// </summary>
+    public void WriteLayoutNames_SortsNamesAndSupportsEmptyState() {
+        using var populatedWriter = new StringWriter();
+
+        int populatedExitCode = global::DesktopManager.Cli.LayoutCommands.WriteLayoutNames(
+            new List<string> { "zeta", "Alpha", "beta" },
+            populatedWriter);
+
+        string populatedOutput = populatedWriter.ToString();
+        int alphaIndex = populatedOutput.IndexOf("Alpha", System.StringComparison.Ordinal);
+        int betaIndex = populatedOutput.IndexOf("beta", System.StringComparison.Ordinal);
+        int zetaIndex = populatedOutput.IndexOf("zeta", System.StringComparison.Ordinal);
+
+        Assert.AreEqual(0, populatedExitCode);
+        Assert.IsTrue(alphaIndex >= 0);
+        Assert.IsTrue(betaIndex > alphaIndex);
+        Assert.IsTrue(zetaIndex > betaIndex);
+
+        using var emptyWriter = new StringWriter();
+
+        int emptyExitCode = global::DesktopManager.Cli.LayoutCommands.WriteLayoutNames(Array.Empty<string>(), emptyWriter);
+
+        Assert.AreEqual(0, emptyExitCode);
+        StringAssert.Contains(emptyWriter.ToString(), "No named layouts found.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures layout assertion output includes artifacts, missing windows, mismatches, and warnings.
+    /// </summary>
+    public void WriteLayoutAssertionResult_WritesRichAssertionSummary() {
+        var payload = new global::DesktopManager.Cli.WindowLayoutAssertionResult {
+            Matched = false,
+            ExpectedCount = 3,
+            MatchedCount = 1,
+            MissingCount = 1,
+            MismatchCount = 1,
+            Path = @"C:\Layouts\Coding.layout.json",
+            BeforeScreenshots = new List<global::DesktopManager.Cli.ScreenshotResult> {
+                new() { Path = @"C:\Artifacts\before.png" }
+            },
+            AfterScreenshots = new List<global::DesktopManager.Cli.ScreenshotResult> {
+                new() { Path = @"C:\Artifacts\after.png" }
+            },
+            MissingWindows = new List<global::DesktopManager.Cli.SavedWindowLayoutEntryResult> {
+                new() { Title = "Missing App", ProcessId = 42 }
+            },
+            MismatchedWindows = new List<global::DesktopManager.Cli.WindowLayoutMismatchResult> {
+                new() {
+                    Expected = new global::DesktopManager.Cli.SavedWindowLayoutEntryResult {
+                        Title = "Editor",
+                        ProcessId = 77
+                    },
+                    LeftDelta = 10,
+                    TopDelta = -5,
+                    WidthDelta = 20,
+                    HeightDelta = 15,
+                    StateMatched = false
+                }
+            },
+            ArtifactWarnings = new List<string> { "after screenshot truncated" }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.LayoutCommands.WriteLayoutAssertionResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "assert-layout: matched=False expected=3 matched-count=1 missing=1 mismatched=1");
+        StringAssert.Contains(output, "C:\\Layouts\\Coding.layout.json");
+        StringAssert.Contains(output, "artifacts: before=1 after=1");
+        StringAssert.Contains(output, "missing: Missing App [PID 42]");
+        StringAssert.Contains(output, "mismatch: Editor [PID 77] left=10 top=-5 width=20 height=15 state=False");
+        StringAssert.Contains(output, "warning: after screenshot truncated");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures matching layout assertion output omits optional artifact and warning lines.
+    /// </summary>
+    public void WriteLayoutAssertionResult_OmitsOptionalSectionsWhenUnset() {
+        var payload = new global::DesktopManager.Cli.WindowLayoutAssertionResult {
+            Matched = true,
+            ExpectedCount = 1,
+            MatchedCount = 1,
+            MissingCount = 0,
+            MismatchCount = 0,
+            Path = @"C:\Layouts\Coding.layout.json"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.LayoutCommands.WriteLayoutAssertionResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "assert-layout: matched=True expected=1 matched-count=1 missing=0 mismatched=0");
+        Assert.IsFalse(output.Contains("artifacts:", System.StringComparison.Ordinal));
+        Assert.IsFalse(output.Contains("missing:", System.StringComparison.Ordinal));
+        Assert.IsFalse(output.Contains("mismatch:", System.StringComparison.Ordinal));
+        Assert.IsFalse(output.Contains("warning:", System.StringComparison.Ordinal));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/McpSafetyPolicyTests.cs
+++ b/Sources/DesktopManager.Tests/McpSafetyPolicyTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+#if NET8_0_OR_GREATER
+[TestClass]
+/// <summary>
+/// Tests for MCP safety-policy decisions and operator guidance text.
+/// </summary>
+public class McpSafetyPolicyTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures foreground-input guidance is explicit when the server blocks zero-handle UI Automation fallback.
+    /// </summary>
+    public void McpSafetyPolicy_BuildInstructions_ForegroundInputDisabled_MentionsServerOptIn() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: true,
+            allowForegroundInput: false,
+            dryRun: false);
+
+        string instructions = policy.BuildInstructions();
+
+        StringAssert.Contains(instructions, "Focused foreground input fallback is blocked");
+        StringAssert.Contains(instructions, "--allow-foreground-input");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures foreground-input guidance is explicit when the server allows zero-handle UI Automation fallback.
+    /// </summary>
+    public void McpSafetyPolicy_BuildInstructions_ForegroundInputEnabled_MentionsEnabledMode() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: true,
+            allowForegroundInput: true,
+            dryRun: false);
+
+        string instructions = policy.BuildInstructions();
+
+        StringAssert.Contains(instructions, "Focused foreground input fallback is enabled");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures set-control-text requests that ask for foreground fallback are denied without server opt-in.
+    /// </summary>
+    public void McpSafetyPolicy_EvaluateToolCall_SetControlTextForegroundFallbackWithoutOptIn_DeniesRequest() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: true,
+            allowForegroundInput: false,
+            dryRun: false);
+
+        DesktopManager.Cli.McpToolSafetyDecision decision = policy.EvaluateToolCall(
+            "set_control_text",
+            CreateArguments(new {
+                processName = "DesktopManager.TestApp",
+                targetName = "Editor",
+                text = "Hello world",
+                allowForegroundInput = true
+            }));
+
+        Assert.AreEqual(DesktopManager.Cli.McpToolSafetyDecisionKind.Deny, decision.Kind);
+        StringAssert.Contains(decision.Message, "--allow-foreground-input");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures send-control-keys requests that ask for foreground fallback are denied without server opt-in.
+    /// </summary>
+    public void McpSafetyPolicy_EvaluateToolCall_SendControlKeysForegroundFallbackWithoutOptIn_DeniesRequest() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: true,
+            allowForegroundInput: false,
+            dryRun: false);
+
+        DesktopManager.Cli.McpToolSafetyDecision decision = policy.EvaluateToolCall(
+            "send_control_keys",
+            CreateArguments(new {
+                processName = "DesktopManager.TestApp",
+                targetName = "CommandBar",
+                keys = new[] { "ENTER" },
+                allowForegroundInput = true
+            }));
+
+        Assert.AreEqual(DesktopManager.Cli.McpToolSafetyDecisionKind.Deny, decision.Kind);
+        StringAssert.Contains(decision.Message, "--allow-foreground-input");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures dry-run previews preserve the requested foreground-fallback flag for operator visibility.
+    /// </summary>
+    public void McpSafetyPolicy_EvaluateToolCall_DryRunForegroundFallbackPreview_ReportsRequestedFlag() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: false,
+            allowForegroundInput: false,
+            dryRun: true);
+
+        DesktopManager.Cli.McpToolSafetyDecision decision = policy.EvaluateToolCall(
+            "send_control_keys",
+            CreateArguments(new {
+                processName = "DesktopManager.TestApp",
+                targetName = "CommandBar",
+                keys = new[] { "ENTER" },
+                allowForegroundInput = true
+            }));
+
+        Assert.AreEqual(DesktopManager.Cli.McpToolSafetyDecisionKind.DryRun, decision.Kind);
+        using JsonDocument result = JsonDocument.Parse(JsonSerializer.Serialize(decision.Result));
+        Assert.IsTrue(result.RootElement.GetProperty("requestedForegroundInputFallback").GetBoolean());
+        Assert.AreEqual("dry-run", result.RootElement.GetProperty("safetyMode").GetString());
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures foreground-fallback requests are allowed when the server opt-in is enabled.
+    /// </summary>
+    public void McpSafetyPolicy_EvaluateToolCall_ForegroundFallbackWithServerOptIn_AllowsRequest() {
+        var policy = new DesktopManager.Cli.McpSafetyPolicy(
+            allowMutations: true,
+            allowForegroundInput: true,
+            dryRun: false);
+
+        DesktopManager.Cli.McpToolSafetyDecision decision = policy.EvaluateToolCall(
+            "send_control_keys",
+            CreateArguments(new {
+                processName = "DesktopManager.TestApp",
+                targetName = "CommandBar",
+                keys = new[] { "ENTER" },
+                allowForegroundInput = true
+            }));
+
+        Assert.AreEqual(DesktopManager.Cli.McpToolSafetyDecisionKind.Allow, decision.Kind);
+        Assert.IsNull(decision.Message);
+    }
+
+    private static JsonElement CreateArguments(object value) {
+        using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return document.RootElement.Clone();
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerEndToEndTests.cs
@@ -12,12 +12,13 @@ namespace DesktopManager.Tests;
 /// End-to-end MCP server tests against a disposable desktop application.
 /// </summary>
 public class McpServerEndToEndTests {
-    private const int NotepadLaunchTimeoutMs = 20000;
-    private const int NotepadControlDiscoveryTimeoutMs = 20000;
-    private const int EdgeLaunchTimeoutMs = 30000;
-    private const int EdgeControlDiscoveryTimeoutMs = 15000;
-    private const double EdgeOmniboxFallbackXRatio = 0.42;
-    private const double EdgeOmniboxFallbackYRatio = 0.05;
+    private const int TestAppLaunchTimeoutMs = 20000;
+    private const int TestAppControlDiscoveryTimeoutMs = 20000;
+    private const string TestAppProcessName = "DesktopManager.TestApp";
+    private const string TestAppTitlePrefix = "DesktopManager-McpTestApp";
+    private const string TestAppCommandBarSurface = "commandbar";
+    private const string TestAppCommandBarAutomationId = "CommandBarTextBox";
+    private const string TestAppCommandBarControlType = "Edit";
 
     [TestCleanup]
     public void Cleanup() {
@@ -27,17 +28,19 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP can launch Notepad, discover an editable control, set text, assert the value, and capture an artifact.
+    /// Ensures MCP can launch the local desktop test app, discover an editable control, set text, assert the value, and capture an artifact.
     /// </summary>
-    public void McpServer_NotepadRoundTrip_LaunchesSetsTextAssertsValueAndCapturesArtifact() {
+    public void McpServer_TestAppRoundTrip_LaunchesSetsTextAssertsValueAndCapturesArtifact() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
         string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        string windowTitle = CreateTestAppWindowTitle("roundtrip");
+        string testAppPath = RequireTestAppExecutablePath();
         int resolvedProcessId = 0;
 
         try {
@@ -47,8 +50,9 @@ public class McpServerEndToEndTests {
             });
 
             JsonElement launchResult = client.CallTool(2, "launch_and_wait_for_window", new {
-                filePath = "notepad.exe",
-                timeoutMs = NotepadLaunchTimeoutMs,
+                filePath = testAppPath,
+                arguments = BuildTestAppArguments(windowTitle),
+                timeoutMs = TestAppLaunchTimeoutMs,
                 intervalMs = 100,
                 captureAfter = true,
                 artifactDirectory
@@ -58,38 +62,50 @@ public class McpServerEndToEndTests {
             Assert.IsTrue(launchResult.GetProperty("WindowWait").GetProperty("Count").GetInt32() > 0);
             resolvedProcessId = ReadResolvedProcessId(launchResult.GetProperty("Launch"));
             Assert.IsTrue(resolvedProcessId > 0);
+            Assert.AreEqual("resolved-process-id", launchResult.GetProperty("WaitBinding").GetString());
+            Assert.AreEqual(resolvedProcessId, launchResult.GetProperty("BoundProcessId").GetInt32());
+            Assert.AreEqual(JsonValueKind.Null, launchResult.GetProperty("BoundProcessName").ValueKind);
             AssertScreenshotPathsExist(launchResult.GetProperty("AfterScreenshots"));
             JsonElement launchedWindow = launchResult.GetProperty("WindowWait").GetProperty("Windows")[0];
             string launchedWindowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched test app window to expose a handle.");
 
             int requestId = 3;
-            JsonElement editor = WaitForEditableNotepadControl(client, ref requestId, launchedWindowHandle, NotepadControlDiscoveryTimeoutMs, 100);
+            JsonElement editor = WaitForEditableTextControl(client, ref requestId, launchedWindowHandle, TestAppControlDiscoveryTimeoutMs, 100);
             string editorClassName = editor.GetProperty("ClassName").GetString() ?? string.Empty;
             string editorHandle = editor.GetProperty("Handle").GetString() ?? string.Empty;
             string windowHandle = editor.GetProperty("ParentWindow").GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(editorClassName), "Expected an editable Notepad control class.");
+            string editorAutomationId = ReadOptionalString(editor, "AutomationId");
+            string editorControlType = ReadOptionalString(editor, "ControlType");
+            bool useUiAutomationEditor = !string.IsNullOrWhiteSpace(editorAutomationId) && !string.IsNullOrWhiteSpace(editorControlType);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(editorClassName), "Expected an editable test app control class.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the resolved editor control to include its parent window handle.");
 
             string resolvedControlHandle = editorHandle;
-            if (string.IsNullOrWhiteSpace(resolvedControlHandle)) {
+            if (!useUiAutomationEditor && string.IsNullOrWhiteSpace(resolvedControlHandle)) {
                 JsonElement waitedControl = client.CallTool(requestId++, "wait_for_control", new {
                     windowHandle,
                     controlClassName = editorClassName,
                     timeoutMs = 5000,
                     intervalMs = 100
                 });
-                Assert.IsTrue(waitedControl.GetProperty("Count").GetInt32() >= 1, "Expected MCP to wait for the Notepad editor control before mutating it.");
+                Assert.IsTrue(waitedControl.GetProperty("Count").GetInt32() >= 1, "Expected MCP to wait for the test app editor control before mutating it.");
                 JsonElement freshEditor = waitedControl.GetProperty("Controls")[0];
                 resolvedControlHandle = freshEditor.GetProperty("Handle").GetString() ?? string.Empty;
             }
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(resolvedControlHandle), "Expected the resolved Notepad editor control to expose a handle.");
+            if (!useUiAutomationEditor) {
+                Assert.IsFalse(string.IsNullOrWhiteSpace(resolvedControlHandle), "Expected the resolved test app editor control to expose a handle.");
+            }
 
             string expectedText = "DesktopManager MCP E2E " + Guid.NewGuid().ToString("N");
             JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
                 windowHandle,
-                controlHandle = resolvedControlHandle,
+                controlHandle = useUiAutomationEditor ? null : resolvedControlHandle,
+                controlAutomationId = useUiAutomationEditor ? editorAutomationId : null,
+                controlType = useUiAutomationEditor ? editorControlType : null,
+                uiAutomation = useUiAutomationEditor,
+                ensureForegroundWindow = useUiAutomationEditor,
                 text = expectedText,
                 captureAfter = true,
                 artifactDirectory
@@ -100,13 +116,21 @@ public class McpServerEndToEndTests {
             StringAssert.Contains(setTextResult.GetProperty("SafetyMode").GetString() ?? string.Empty, "background");
             AssertScreenshotPathsExist(setTextResult.GetProperty("AfterScreenshots"));
 
-            JsonElement assertionResult = client.CallTool(requestId++, "assert_control_value", new {
+            JsonElement assertionResult = WaitForControlValueMatch(
+                client,
+                ref requestId,
                 windowHandle,
-                controlHandle = resolvedControlHandle,
-                expectedValue = expectedText
-            });
+                expectedText,
+                5000,
+                100,
+                controlHandle: useUiAutomationEditor ? null : resolvedControlHandle,
+                controlAutomationId: useUiAutomationEditor ? editorAutomationId : null,
+                controlType: useUiAutomationEditor ? editorControlType : null,
+                uiAutomation: useUiAutomationEditor,
+                includeUiAutomation: !useUiAutomationEditor,
+                ensureForegroundWindow: useUiAutomationEditor);
 
-            Assert.IsTrue(assertionResult.GetProperty("Matched").GetBoolean(), "Expected MCP to verify the Notepad editor value after text entry.");
+            Assert.IsTrue(assertionResult.GetProperty("Matched").GetBoolean(), "Expected MCP to verify the test app editor value after text entry.");
             Assert.IsTrue(assertionResult.GetProperty("MatchedCount").GetInt32() >= 1);
         } finally {
             if (resolvedProcessId > 0) {
@@ -127,19 +151,20 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP can save a reusable target area, resolve it against Notepad, and capture that exact region.
+    /// Ensures MCP can save a reusable target area, resolve it against the local desktop test app, and capture that exact region.
     /// </summary>
-    public void McpServer_NotepadTargetAreaRoundTrip_SavesResolvesAndCapturesTarget() {
+    public void McpServer_TestAppTargetAreaRoundTrip_SavesResolvesAndCapturesTarget() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
         string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
         string targetName = "McpServerEndToEnd-" + Guid.NewGuid().ToString("N");
         string targetPath = DesktopStateStore.GetTargetPath(targetName);
+        string windowTitle = CreateTestAppWindowTitle("target");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
@@ -149,13 +174,13 @@ public class McpServerEndToEndTests {
                 protocolVersion = "2025-06-18"
             });
 
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
             int requestId = 2;
-            WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "target capture");
+            WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "target capture");
 
             JsonElement saveTargetResult = client.CallTool(requestId++, "save_window_target", new {
                 name = targetName,
-                description = "Notepad center area",
+                description = "Test app center area",
                 xRatio = 0.25,
                 yRatio = 0.2,
                 widthRatio = 0.5,
@@ -171,7 +196,7 @@ public class McpServerEndToEndTests {
                 processId = resolvedProcessId
             });
 
-            Assert.IsTrue(resolvedTargets.ValueKind == JsonValueKind.Array && resolvedTargets.GetArrayLength() == 1, "Expected the named target to resolve against exactly one Notepad window.");
+            Assert.IsTrue(resolvedTargets.ValueKind == JsonValueKind.Array && resolvedTargets.GetArrayLength() == 1, "Expected the named target to resolve against exactly one test app window.");
             JsonElement resolvedTarget = resolvedTargets[0];
             Assert.AreEqual(targetName, resolvedTarget.GetProperty("Name").GetString());
             Assert.IsTrue(resolvedTarget.GetProperty("Target").GetProperty("ClientArea").GetBoolean());
@@ -180,7 +205,7 @@ public class McpServerEndToEndTests {
             Assert.IsTrue(screenWidth > 0);
             Assert.IsTrue(screenHeight > 0);
 
-            string outputPath = Path.Combine(artifactDirectory, "notepad-target.png");
+            string outputPath = Path.Combine(artifactDirectory, "testapp-target.png");
             JsonElement screenshotResult = client.CallTool(requestId++, "screenshot_window", new {
                 processId = resolvedProcessId,
                 targetName,
@@ -214,15 +239,16 @@ public class McpServerEndToEndTests {
     /// <summary>
     /// Ensures MCP can move a live window, return screenshot artifacts, and verify the new geometry.
     /// </summary>
-    public void McpServer_NotepadWindowMutationRoundTrip_MovesWindowAndVerifiesGeometry() {
+    public void McpServer_TestAppWindowMutationRoundTrip_MovesWindowAndVerifiesGeometry() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
         string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        string windowTitle = CreateTestAppWindowTitle("move");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
@@ -232,11 +258,11 @@ public class McpServerEndToEndTests {
                 protocolVersion = "2025-06-18"
             });
 
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
             int requestId = 2;
-            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "window mutation");
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "window mutation");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched test app window to expose a handle.");
 
             JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
                 handle = windowHandle
@@ -288,17 +314,18 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP can run a higher-level workflow against a live Notepad window and return structured evidence.
+    /// Ensures MCP can run a higher-level workflow against a live local desktop test app window and return structured evidence.
     /// </summary>
-    public void McpServer_NotepadWorkflowRoundTrip_PreparesForCodingAndCapturesArtifact() {
+    public void McpServer_TestAppWorkflowRoundTrip_PreparesForCodingAndCapturesArtifact() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
         string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        string windowTitle = CreateTestAppWindowTitle("workflow");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
@@ -308,11 +335,11 @@ public class McpServerEndToEndTests {
                 protocolVersion = "2025-06-18"
             });
 
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
             int requestId = 2;
-            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "workflow");
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "workflow");
             string launchedWindowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(launchedWindowHandle), "Expected the launched test app window to expose a handle.");
 
             JsonElement workflowResult = client.CallTool(requestId++, "prepare_for_coding", new {
                 handle = launchedWindowHandle,
@@ -352,31 +379,32 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP process allowlists permit a scoped live Notepad mutation when both process name and exact handle are supplied.
+    /// Ensures MCP process allowlists permit a scoped live test app mutation when both process name and exact handle are supplied.
     /// </summary>
-    public void McpServer_NotepadAllowedProcessPolicy_AllowsScopedMoveWindowMutation() {
+    public void McpServer_TestAppAllowedProcessPolicy_AllowsScopedMoveWindowMutation() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
         string artifactDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "McpE2E", Guid.NewGuid().ToString("N"));
+        string windowTitle = CreateTestAppWindowTitle("allow");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
         try {
-            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process notepad");
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process " + TestAppProcessName);
             client.SendRequest(1, "initialize", new {
                 protocolVersion = "2025-06-18"
             });
 
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
             int requestId = 2;
-            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "allowed-process policy");
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "allowed-process policy");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched test app window to expose a handle.");
 
             JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
                 handle = windowHandle
@@ -392,7 +420,7 @@ public class McpServerEndToEndTests {
             int targetTop = initialTop >= 60 ? initialTop - 30 : initialTop + 30;
 
             JsonElement moveResult = client.CallTool(requestId++, "move_window", new {
-                processName = "notepad",
+                processName = TestAppProcessName,
                 handle = windowHandle,
                 x = targetLeft,
                 y = targetTop,
@@ -429,31 +457,32 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP denied-process filters block a scoped live Notepad window mutation without changing geometry.
+    /// Ensures MCP denied-process filters block a scoped live test app window mutation without changing geometry.
     /// </summary>
-    public void McpServer_NotepadDeniedProcessPolicy_BlocksScopedMoveWindowMutation() {
+    public void McpServer_TestAppDeniedProcessPolicy_BlocksScopedMoveWindowMutation() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
+        string windowTitle = CreateTestAppWindowTitle("deny");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
         try {
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
 
-            using var client = McpTestClient.Start("mcp serve --allow-mutations --deny-process notepad");
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --deny-process " + TestAppProcessName);
             client.SendRequest(1, "initialize", new {
                 protocolVersion = "2025-06-18"
             });
 
             int requestId = 2;
-            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "denied-process policy");
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "denied-process policy");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the denied-policy Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the denied-policy test app window to expose a handle.");
 
             JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
                 handle = windowHandle
@@ -467,7 +496,7 @@ public class McpServerEndToEndTests {
             int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
 
             JsonElement toolError = client.CallToolExpectError(requestId++, "move_window", new {
-                processName = "notepad",
+                processName = TestAppProcessName,
                 handle = windowHandle,
                 x = initialLeft + 40,
                 y = initialTop + 40,
@@ -495,32 +524,33 @@ public class McpServerEndToEndTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
-    /// Ensures MCP dry-run mode previews a scoped live Notepad window mutation without changing geometry.
+    /// Ensures MCP dry-run mode previews a scoped live test app window mutation without changing geometry.
     /// </summary>
-    public void McpServer_NotepadDryRunPolicy_PreviewsScopedMoveWindowMutationWithoutChangingGeometry() {
+    public void McpServer_TestAppDryRunPolicy_PreviewsScopedMoveWindowMutationWithoutChangingGeometry() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireExternalDesktopApplicationTests();
 
+        string windowTitle = CreateTestAppWindowTitle("dryrun");
         int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
         try {
-            LaunchNotepadProcess(out launcherProcessId, out resolvedProcessId);
+            LaunchTestAppProcess(windowTitle, out launcherProcessId, out resolvedProcessId);
 
-            using var client = McpTestClient.Start("mcp serve --dry-run --allow-process notepad");
+            using var client = McpTestClient.Start("mcp serve --dry-run --allow-process " + TestAppProcessName);
             JsonElement initializeResult = client.SendRequest(1, "initialize", new {
                 protocolVersion = "2025-06-18"
             });
             Assert.IsTrue(initializeResult.GetProperty("safetyPolicy").GetProperty("dryRun").GetBoolean());
 
             int requestId = 2;
-            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, NotepadLaunchTimeoutMs, 100, "dry-run policy");
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "dry-run policy");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the dry-run Notepad window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the dry-run test app window to expose a handle.");
 
             JsonElement initialGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
                 handle = windowHandle
@@ -534,7 +564,7 @@ public class McpServerEndToEndTests {
             int initialHeight = initialGeometry.GetProperty("WindowHeight").GetInt32();
 
             JsonElement dryRunResult = client.CallTool(requestId++, "move_window", new {
-                processName = "notepad",
+                processName = TestAppProcessName,
                 handle = windowHandle,
                 x = initialLeft + 40,
                 y = initialTop + 40,
@@ -546,7 +576,7 @@ public class McpServerEndToEndTests {
             Assert.IsFalse(dryRunResult.GetProperty("applied").GetBoolean());
             Assert.AreEqual("move_window", dryRunResult.GetProperty("toolName").GetString());
             Assert.AreEqual("dry-run", dryRunResult.GetProperty("safetyMode").GetString());
-            Assert.AreEqual("notepad", dryRunResult.GetProperty("requestedProcesses")[0].GetString());
+            Assert.AreEqual(TestAppProcessName, dryRunResult.GetProperty("requestedProcesses")[0].GetString());
 
             JsonElement finalGeometryResult = client.CallTool(requestId++, "get_window_geometry", new {
                 handle = windowHandle
@@ -568,82 +598,68 @@ public class McpServerEndToEndTests {
     [TestCategory("UITest")]
     [TestCategory("ExperimentalUITest")]
     /// <summary>
-    /// Ensures the live Edge omnibox key path is blocked when foreground-input fallback is requested without server opt-in.
+    /// Ensures the local WPF command bar key path is blocked when foreground-input fallback is requested without server opt-in.
     /// </summary>
-    public void McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn() {
+    public void McpServer_TestAppForegroundInputPolicy_BlocksCommandBarEnterWithoutServerOptIn() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
         TestHelper.RequireExperimentalDesktopChanges();
+        TestHelper.RequireInteractiveDesktopSession();
 
-        string edgePath = RequireEdgeExecutablePath();
-        string profileDirectory = CreateTemporaryDirectory("DesktopManager-EdgeProfile-");
-        string diagnosticDirectory = CreateTemporaryDirectory(Path.Combine("DesktopManager.Tests", "McpE2E", "Experimental", "Edge-Blocked-"));
-        string windowTargetName = "McpServerEndToEnd-EdgeOmniboxWindow-" + Guid.NewGuid().ToString("N");
-        string windowTargetPath = DesktopStateStore.GetTargetPath(windowTargetName);
-        string controlTargetName = "McpServerEndToEnd-EdgeOmniboxControl-" + Guid.NewGuid().ToString("N");
-        string controlTargetPath = DesktopStateStore.GetControlTargetPath(controlTargetName);
-        string startTitle = "Foreground Fallback Start " + Guid.NewGuid().ToString("N");
-        string targetTitle = "Foreground Fallback Target " + Guid.NewGuid().ToString("N");
-        string startPagePath = CreateForegroundFallbackPage(startTitle);
-        string targetPagePath = CreateForegroundFallbackPage(targetTitle);
-        Process? edgeProcess = null;
+        string windowTitle = CreateTestAppWindowTitle("commandbar-blocked");
+        string commandText = "blocked-" + Guid.NewGuid().ToString("N");
+        string expectedTitle = windowTitle + " - Accepted - " + commandText;
+        int launcherProcessId = 0;
         int resolvedProcessId = 0;
 
         try {
-            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process msedge");
+            LaunchTestAppProcess(windowTitle, TestAppCommandBarSurface, out launcherProcessId, out resolvedProcessId);
+
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process " + TestAppProcessName);
             client.SendRequest(1, "initialize", new {
                 protocolVersion = "2025-06-18"
             });
             int requestId = 2;
-            SaveEdgeOmniboxTarget(client, ref requestId, windowTargetName);
-            SaveEdgeOmniboxControlTarget(client, ref requestId, controlTargetName);
-
-            edgeProcess = LaunchEdgeProcess(edgePath, profileDirectory, BuildFileUrl(startPagePath));
-
-            JsonElement waitResult = client.CallTool(requestId++, "wait_for_window", new {
-                processName = "msedge",
-                windowTitle = "*" + startTitle + "*",
-                timeoutMs = EdgeLaunchTimeoutMs,
-                intervalMs = 200
-            });
-
-            Assert.IsTrue(waitResult.GetProperty("Count").GetInt32() >= 1, "Expected the sacrificial Edge start page window to appear.");
-            JsonElement launchedWindow = waitResult.GetProperty("Windows")[0];
-            resolvedProcessId = launchedWindow.GetProperty("ProcessId").GetInt32();
-            Assert.IsTrue(resolvedProcessId > 0);
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "foreground-input blocked");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Edge window to expose a handle.");
-
-            WaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched test app window to expose a handle.");
+            WaitForCommandBarControl(client, ref requestId, windowHandle);
 
             JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
-                processName = "msedge",
+                processName = TestAppProcessName,
                 windowHandle,
-                targetName = controlTargetName,
-                text = BuildFileUrl(targetPagePath)
+                controlAutomationId = TestAppCommandBarAutomationId,
+                controlType = TestAppCommandBarControlType,
+                uiAutomation = true,
+                ensureForegroundWindow = true,
+                text = commandText
             });
             Assert.IsTrue(setTextResult.GetProperty("Success").GetBoolean());
+            Assert.AreEqual("uia-direct-value", setTextResult.GetProperty("SafetyMode").GetString());
 
             JsonElement toolError = client.CallToolExpectError(requestId++, "send_control_keys", new {
-                processName = "msedge",
+                processName = TestAppProcessName,
                 windowHandle,
-                targetName = controlTargetName,
+                controlAutomationId = TestAppCommandBarAutomationId,
+                controlType = TestAppCommandBarControlType,
+                uiAutomation = true,
+                ensureForegroundWindow = true,
                 allowForegroundInput = true,
                 keys = new[] { "VK_RETURN" }
             });
             StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "--allow-foreground-input");
+
+            JsonElement titleStillOriginal = client.CallTool(requestId++, "window_exists", new {
+                processId = resolvedProcessId,
+                windowTitle = expectedTitle
+            });
+            Assert.IsFalse(titleStillOriginal.GetProperty("Matched").GetBoolean(), "Expected the blocked foreground-input path to leave the command bar action unapplied.");
         } finally {
-            TestHelper.SafeKillProcess(edgeProcess);
-            TryDeleteFile(startPagePath);
-            TryDeleteFile(targetPagePath);
-            TryDeleteDirectory(profileDirectory);
-            TryDeleteDirectory(diagnosticDirectory);
-            TryDeleteFile(windowTargetPath);
-            TryDeleteFile(controlTargetPath);
             KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
         }
     }
 
@@ -651,109 +667,69 @@ public class McpServerEndToEndTests {
     [TestCategory("UITest")]
     [TestCategory("ExperimentalUITest")]
     /// <summary>
-    /// Ensures the live Edge omnibox key path can navigate to a local page when both the MCP server and tool call explicitly opt into foreground-input fallback.
+    /// Ensures the local WPF command bar key path succeeds when both the MCP server and tool call explicitly opt into foreground-input fallback.
     /// </summary>
-    public void McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn() {
+    public void McpServer_TestAppForegroundInputPolicy_AllowsCommandBarEnterWithServerOptIn() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
         RequireNet8McpLiveHarness();
         TestHelper.RequireExperimentalDesktopChanges();
+        TestHelper.RequireInteractiveDesktopSession();
 
-        string edgePath = RequireEdgeExecutablePath();
-        string profileDirectory = CreateTemporaryDirectory("DesktopManager-EdgeProfile-");
-        string diagnosticDirectory = CreateTemporaryDirectory(Path.Combine("DesktopManager.Tests", "McpE2E", "Experimental", "Edge-Allow-"));
-        string windowTargetName = "McpServerEndToEnd-EdgeOmniboxWindow-" + Guid.NewGuid().ToString("N");
-        string windowTargetPath = DesktopStateStore.GetTargetPath(windowTargetName);
-        string controlTargetName = "McpServerEndToEnd-EdgeOmniboxControl-" + Guid.NewGuid().ToString("N");
-        string controlTargetPath = DesktopStateStore.GetControlTargetPath(controlTargetName);
-        string startTitle = "Foreground Fallback Start " + Guid.NewGuid().ToString("N");
-        string targetTitle = "Foreground Fallback Target " + Guid.NewGuid().ToString("N");
-        string startPagePath = CreateForegroundFallbackPage(startTitle);
-        string targetPagePath = CreateForegroundFallbackPage(targetTitle);
-        Process? edgeProcess = null;
+        string windowTitle = CreateTestAppWindowTitle("commandbar-allow");
+        string commandText = "allow-" + Guid.NewGuid().ToString("N");
+        string expectedTitle = windowTitle + " - Accepted - " + commandText;
+        int launcherProcessId = 0;
         int resolvedProcessId = 0;
-        bool preserveDiagnostics = false;
 
         try {
-            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process msedge --allow-foreground-input");
+            LaunchTestAppProcess(windowTitle, TestAppCommandBarSurface, out launcherProcessId, out resolvedProcessId);
+            SetTestAppCommandBarText(resolvedProcessId, windowTitle, commandText);
+
+            using var client = McpTestClient.Start("mcp serve --allow-mutations --allow-process " + TestAppProcessName + " --allow-foreground-input");
             client.SendRequest(1, "initialize", new {
                 protocolVersion = "2025-06-18"
             });
             int requestId = 2;
-            SaveEdgeOmniboxTarget(client, ref requestId, windowTargetName);
-            SaveEdgeOmniboxControlTarget(client, ref requestId, controlTargetName);
-
-            edgeProcess = LaunchEdgeProcess(edgePath, profileDirectory, BuildFileUrl(startPagePath));
-
-            JsonElement waitResult = client.CallTool(requestId++, "wait_for_window", new {
-                processName = "msedge",
-                windowTitle = "*" + startTitle + "*",
-                timeoutMs = EdgeLaunchTimeoutMs,
-                intervalMs = 200
-            });
-
-            Assert.IsTrue(waitResult.GetProperty("Count").GetInt32() >= 1, "Expected the sacrificial Edge start page window to appear.");
-            JsonElement launchedWindow = waitResult.GetProperty("Windows")[0];
-            resolvedProcessId = launchedWindow.GetProperty("ProcessId").GetInt32();
-            Assert.IsTrue(resolvedProcessId > 0);
+            JsonElement launchedWindow = WaitForProcessWindow(client, ref requestId, resolvedProcessId, TestAppLaunchTimeoutMs, 100, "foreground-input allowed");
             string windowHandle = launchedWindow.GetProperty("Handle").GetString() ?? string.Empty;
-            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched Edge window to expose a handle.");
+            Assert.IsFalse(string.IsNullOrWhiteSpace(windowHandle), "Expected the launched test app window to expose a handle.");
 
             JsonElement focusResult = client.CallTool(requestId++, "focus_window", new {
-                processName = "msedge",
+                processName = TestAppProcessName,
                 handle = windowHandle
             });
             Assert.IsTrue(focusResult.GetProperty("Success").GetBoolean());
-            var decisionTrace = new List<string> {
-                "Saved window target: " + windowTargetName,
-                "Saved control target: " + controlTargetName,
-                "Focused window handle: " + windowHandle
-            };
-            string targetUrl = BuildFileUrl(targetPagePath);
-            string? navigationSafetyMode = TryNavigateEdgeOmnibox(client, ref requestId, windowHandle, windowTargetName, controlTargetName, targetUrl, decisionTrace);
-            if (string.IsNullOrWhiteSpace(navigationSafetyMode)) {
-                preserveDiagnostics = true;
-                string bundlePath = CaptureEdgeForegroundDiagnostics(client, ref requestId, windowHandle, controlTargetName, diagnosticDirectory, decisionTrace);
-                Assert.Inconclusive($"Edge did not expose a reusable omnibox control through MCP in this session, so the experimental foreground-input success harness could not complete. Diagnostic bundle: {bundlePath}");
-            }
 
-            string resolvedNavigationSafetyMode = navigationSafetyMode!;
-            Assert.IsTrue(
-                resolvedNavigationSafetyMode.IndexOf("foreground", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                string.Equals(resolvedNavigationSafetyMode, "window-key-input", StringComparison.OrdinalIgnoreCase),
-                "Expected the Edge navigation safety mode to reflect either explicit foreground control input or the shared window-level key fallback.");
-            decisionTrace.Add("Navigation safety mode: " + resolvedNavigationSafetyMode);
+            WaitForCommandBarControl(client, ref requestId, windowHandle);
 
-            try {
-                JsonElement targetWindowWait = client.CallTool(requestId++, "wait_for_window", new {
-                    processName = "msedge",
-                    windowTitle = "*" + targetTitle + "*",
-                    timeoutMs = EdgeLaunchTimeoutMs,
-                    intervalMs = 200
-                });
+            JsonElement sendKeysResult = client.CallTool(requestId++, "send_control_keys", new {
+                processName = TestAppProcessName,
+                processId = resolvedProcessId,
+                windowTitle,
+                controlAutomationId = TestAppCommandBarAutomationId,
+                controlType = TestAppCommandBarControlType,
+                supportsForegroundInputFallback = true,
+                uiAutomation = true,
+                ensureForegroundWindow = true,
+                allowForegroundInput = true,
+                keys = new[] { "VK_RETURN" }
+            });
+            Assert.IsTrue(sendKeysResult.GetProperty("Success").GetBoolean());
+            Assert.AreEqual("foreground-input-fallback", sendKeysResult.GetProperty("SafetyMode").GetString());
 
-                Assert.IsTrue(targetWindowWait.GetProperty("Count").GetInt32() >= 1, "Expected Edge to navigate to the target page after explicit foreground-input opt-in.");
-                JsonElement targetWindow = targetWindowWait.GetProperty("Windows")[0];
-                Assert.AreEqual(resolvedProcessId, targetWindow.GetProperty("ProcessId").GetInt32(), "Expected the target page to reuse the same sacrificial Edge window process.");
-            } catch (AssertFailedException ex) {
-                preserveDiagnostics = true;
-                decisionTrace.Add("Navigation verification failed: " + ex.Message);
-                string bundlePath = CaptureEdgeForegroundDiagnostics(client, ref requestId, windowHandle, controlTargetName, diagnosticDirectory, decisionTrace);
-                Assert.Inconclusive($"Edge accepted the experimental input path but did not complete navigation reliably in this session. Diagnostic bundle: {bundlePath}. Failure: {ex.Message}");
-            }
+            JsonElement acceptedWindow = client.CallTool(requestId++, "wait_for_window", new {
+                processId = resolvedProcessId,
+                windowTitle = expectedTitle,
+                timeoutMs = TestAppLaunchTimeoutMs,
+                intervalMs = 100
+            });
+            Assert.IsTrue(acceptedWindow.GetProperty("Count").GetInt32() >= 1, "Expected the command bar Enter action to update the test app window title.");
         } finally {
-            TestHelper.SafeKillProcess(edgeProcess);
-            TryDeleteFile(startPagePath);
-            TryDeleteFile(targetPagePath);
-            TryDeleteDirectory(profileDirectory);
-            if (!preserveDiagnostics) {
-                TryDeleteDirectory(diagnosticDirectory);
-            }
-            TryDeleteFile(windowTargetPath);
-            TryDeleteFile(controlTargetPath);
             KillProcessById(resolvedProcessId);
+            KillProcessById(launcherProcessId);
         }
     }
 
@@ -766,21 +742,51 @@ public class McpServerEndToEndTests {
         return launchResult.GetProperty("ProcessId").GetInt32();
     }
 
-    private static void LaunchNotepadProcess(out int launcherProcessId, out int resolvedProcessId) {
+    private static void LaunchTestAppProcess(string windowTitle, out int launcherProcessId, out int resolvedProcessId) {
+        LaunchTestAppProcess(windowTitle, surface: null, out launcherProcessId, out resolvedProcessId);
+    }
+
+    private static void LaunchTestAppProcess(string windowTitle, string? surface, out int launcherProcessId, out int resolvedProcessId) {
         var automation = new DesktopAutomationService();
+        string executablePath = RequireTestAppExecutablePath();
         DesktopProcessLaunchInfo launch = automation.LaunchProcess(new DesktopProcessStartOptions {
-            FilePath = "notepad.exe",
+            FilePath = executablePath,
+            Arguments = BuildTestAppArguments(windowTitle, surface),
             WaitForInputIdleMilliseconds = 5000,
-            WaitForWindowMilliseconds = NotepadLaunchTimeoutMs,
+            WaitForWindowMilliseconds = TestAppLaunchTimeoutMs,
             WaitForWindowIntervalMilliseconds = 100,
             RequireWindow = true
         });
 
         launcherProcessId = launch.ProcessId;
         resolvedProcessId = launch.ResolvedProcessId ?? launch.ProcessId;
-        Assert.IsTrue(launcherProcessId > 0, "Expected direct Notepad setup to return a launcher process id.");
-        Assert.IsTrue(resolvedProcessId > 0, "Expected direct Notepad setup to resolve the live window process.");
-        Assert.IsNotNull(launch.MainWindow, "Expected direct Notepad setup to resolve a visible window.");
+        TestHelper.TrackProcessId(launcherProcessId);
+        TestHelper.TrackProcessId(resolvedProcessId);
+        Assert.IsTrue(launcherProcessId > 0, "Expected direct test app setup to return a launcher process id.");
+        Assert.IsTrue(resolvedProcessId > 0, "Expected direct test app setup to resolve the live window process.");
+        Assert.IsNotNull(launch.MainWindow, "Expected direct test app setup to resolve a visible window.");
+    }
+
+    private static void SetTestAppCommandBarText(int processId, string windowTitle, string text) {
+        var automation = new DesktopAutomationService();
+        IReadOnlyList<WindowControlTargetInfo> controls = automation.SetControlText(
+            new WindowQueryOptions {
+                ProcessId = processId,
+                TitlePattern = windowTitle,
+                IncludeOwned = true,
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeEmptyTitles = true
+            },
+            new WindowControlQueryOptions {
+                AutomationIdPattern = TestAppCommandBarAutomationId,
+                ControlTypePattern = TestAppCommandBarControlType,
+                SupportsForegroundInputFallback = true,
+                UseUiAutomation = true,
+                EnsureForegroundWindow = true
+            },
+            text);
+        Assert.IsTrue(controls.Count >= 1, "Expected direct command bar text setup to resolve the WPF command bar control.");
     }
 
     private static void RequireNet8McpLiveHarness() {
@@ -789,404 +795,59 @@ public class McpServerEndToEndTests {
 #endif
     }
 
-    private static string RequireEdgeExecutablePath() {
-        string[] candidates = {
-            @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
-            @"C:\Program Files\Microsoft\Edge\Application\msedge.exe"
-        };
-
-        foreach (string candidate in candidates) {
+    private static string RequireTestAppExecutablePath() {
+        DirectoryInfo? current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null) {
+            string candidate = Path.Combine(current.FullName, "Sources", "DesktopManager.TestApp", "bin", "Debug", "net8.0-windows", "DesktopManager.TestApp.exe");
             if (File.Exists(candidate)) {
                 return candidate;
             }
+
+            string releaseCandidate = Path.Combine(current.FullName, "Sources", "DesktopManager.TestApp", "bin", "Release", "net8.0-windows", "DesktopManager.TestApp.exe");
+            if (File.Exists(releaseCandidate)) {
+                return releaseCandidate;
+            }
+
+            current = current.Parent;
         }
 
-        Assert.Inconclusive("Microsoft Edge was not found on this machine, so the live foreground-input MCP harness cannot run.");
+        Assert.Inconclusive("DesktopManager.TestApp.exe was not found. Build the DesktopManager.TestApp project before running the live MCP harness.");
         return string.Empty;
     }
 
-    private static string CreateTemporaryDirectory(string prefix) {
-        string path = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(path);
-        return path;
+    private static string CreateTestAppWindowTitle(string scenario) {
+        return TestAppTitlePrefix + "-" + scenario + "-" + Guid.NewGuid().ToString("N");
     }
 
-    private static string CreateForegroundFallbackPage(string title) {
-        string path = Path.Combine(Path.GetTempPath(), "DesktopManager-ForegroundFallback-" + Guid.NewGuid().ToString("N") + ".html");
-        string html = @"<!doctype html>
-<html>
-<head>
-    <meta charset=""utf-8"">
-    <title>" + title + @"</title>
-</head>
-<body style=""font-family:Segoe UI;padding:24px"">
-    <h1>" + title + @"</h1>
-    <textarea id=""editor"" autofocus style=""width:900px;height:260px"">seed</textarea>
-    <script>
-        window.addEventListener('load', function () {
-            var editor = document.getElementById('editor');
-            if (editor) {
-                editor.focus();
-            }
-        });
-    </script>
-</body>
-</html>";
-        File.WriteAllText(path, html);
-        return path;
-    }
-
-    private static string BuildFileUrl(string path) {
-        return new Uri(path).AbsoluteUri;
-    }
-
-    private static string BuildEdgeArguments(string profileDirectory, string url) {
-        return $"--user-data-dir=\"{profileDirectory}\" --no-first-run --new-window {url}";
-    }
-
-    private static Process? LaunchEdgeProcess(string edgePath, string profileDirectory, string url) {
-        var startInfo = new ProcessStartInfo(edgePath, BuildEdgeArguments(profileDirectory, url)) {
-            UseShellExecute = true
-        };
-
-        return Process.Start(startInfo);
-    }
-
-    private static void WaitForEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, int timeoutMilliseconds = EdgeControlDiscoveryTimeoutMs) {
-        if (TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, timeoutMilliseconds)) {
-            return;
+    private static string BuildTestAppArguments(string windowTitle, string? surface = null) {
+        string arguments = "--title " + windowTitle + " --text seed";
+        if (!string.IsNullOrWhiteSpace(surface)) {
+            arguments += " --surface " + surface;
         }
 
-        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for the Edge omnibox control to be discoverable through MCP.");
+        return arguments;
     }
 
-    private static bool TryWaitForEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, int timeoutMilliseconds) {
+    private static void WaitForCommandBarControl(McpTestClient client, ref int requestId, string windowHandle, int timeoutMilliseconds = TestAppControlDiscoveryTimeoutMs) {
         Stopwatch stopwatch = Stopwatch.StartNew();
         while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds) {
-            JsonElement controls = GetEdgeOmniboxControls(client, ref requestId, windowHandle, controlTargetName);
+            JsonElement controls = client.CallTool(requestId++, "list_window_controls", new {
+                processName = TestAppProcessName,
+                windowHandle,
+                controlAutomationId = TestAppCommandBarAutomationId,
+                controlType = TestAppCommandBarControlType,
+                supportsForegroundInputFallback = true,
+                uiAutomation = true,
+                ensureForegroundWindow = true
+            });
             if (controls.ValueKind == JsonValueKind.Array && controls.GetArrayLength() > 0) {
-                return true;
+                return;
             }
 
             System.Threading.Thread.Sleep(100);
         }
 
-        return false;
-    }
-
-    private static string? TryNavigateEdgeOmnibox(McpTestClient client, ref int requestId, string windowHandle, string windowTargetName, string controlTargetName, string targetUrl, IList<string> decisionTrace) {
-        for (int attempt = 0; attempt < 3; attempt++) {
-            try {
-                decisionTrace.Add($"Attempt {attempt + 1}: start");
-                if (!TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeControlDiscoveryTimeoutMs)) {
-                    decisionTrace.Add($"Attempt {attempt + 1}: named control target not resolved within {EdgeControlDiscoveryTimeoutMs}ms");
-                    ClickEdgeOmniboxFallbackPoint(client, ref requestId, windowHandle, windowTargetName);
-                    decisionTrace.Add($"Attempt {attempt + 1}: clicked named window target fallback {windowTargetName}");
-                    WaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeLaunchTimeoutMs);
-                    decisionTrace.Add($"Attempt {attempt + 1}: named control target resolved after fallback click");
-                } else {
-                    decisionTrace.Add($"Attempt {attempt + 1}: named control target resolved without fallback");
-                }
-
-                JsonElement setTextResult = client.CallTool(requestId++, "set_control_text", new {
-                    processName = "msedge",
-                    windowHandle,
-                    targetName = controlTargetName,
-                    allowForegroundInput = true,
-                    text = targetUrl
-                });
-                Assert.IsTrue(setTextResult.GetProperty("Success").GetBoolean(), "Expected Edge omnibox text entry to succeed once foreground-input fallback is explicitly allowed.");
-                decisionTrace.Add($"Attempt {attempt + 1}: set_control_text succeeded with safety mode {setTextResult.GetProperty("SafetyMode").GetString()}");
-
-                bool controlAvailableAfterText = TryWaitForEdgeOmnibox(client, ref requestId, windowHandle, controlTargetName, EdgeControlDiscoveryTimeoutMs);
-                if (!controlAvailableAfterText) {
-                    decisionTrace.Add($"Attempt {attempt + 1}: named control target disappeared after text entry");
-                    ClickEdgeOmniboxFallbackPoint(client, ref requestId, windowHandle, windowTargetName);
-                    decisionTrace.Add($"Attempt {attempt + 1}: clicked named window target fallback after text entry");
-                    JsonElement sendWindowKeysResult = client.CallTool(requestId++, "send_window_keys", new {
-                        processName = "msedge",
-                        handle = windowHandle,
-                        keys = new[] { "VK_RETURN" },
-                        activate = true
-                    });
-
-                    Assert.IsTrue(sendWindowKeysResult.GetProperty("Success").GetBoolean(), "Expected the window-level Edge Enter fallback to succeed after omnibox text entry.");
-                    decisionTrace.Add($"Attempt {attempt + 1}: send_window_keys fallback succeeded with safety mode {sendWindowKeysResult.GetProperty("SafetyMode").GetString()}");
-                    return sendWindowKeysResult.GetProperty("SafetyMode").GetString();
-                } else {
-                    decisionTrace.Add($"Attempt {attempt + 1}: named control target remained available after text entry");
-                }
-
-                JsonElement sendKeysResult = client.CallTool(requestId++, "send_control_keys", new {
-                    processName = "msedge",
-                    windowHandle,
-                    targetName = controlTargetName,
-                    allowForegroundInput = true,
-                    keys = new[] { "VK_RETURN" }
-                });
-
-                Assert.IsTrue(sendKeysResult.GetProperty("Success").GetBoolean(), "Expected Edge omnibox Enter to succeed once foreground-input fallback is explicitly allowed.");
-                decisionTrace.Add($"Attempt {attempt + 1}: send_control_keys succeeded with safety mode {sendKeysResult.GetProperty("SafetyMode").GetString()}");
-                return sendKeysResult.GetProperty("SafetyMode").GetString();
-            } catch (AssertFailedException) when (attempt < 2) {
-                decisionTrace.Add($"Attempt {attempt + 1}: assertion failed, retrying");
-                System.Threading.Thread.Sleep(500);
-            } catch (AssertFailedException) {
-                decisionTrace.Add($"Attempt {attempt + 1}: assertion failed, giving up");
-                return null;
-            }
-        }
-
-        decisionTrace.Add("Navigation failed after all attempts");
-        return null;
-    }
-
-    private static void ClickEdgeOmniboxFallbackPoint(McpTestClient client, ref int requestId, string windowHandle, string targetName) {
-        JsonElement clickResult = client.CallTool(requestId++, "click_window_point", new {
-            processName = "msedge",
-            handle = windowHandle,
-            targetName,
-            activate = true,
-            clientArea = false
-        });
-        Assert.IsTrue(clickResult.GetProperty("Success").GetBoolean(), "Expected the geometry-assisted Edge omnibox fallback click to succeed.");
-        System.Threading.Thread.Sleep(250);
-    }
-
-    private static void SaveEdgeOmniboxTarget(McpTestClient client, ref int requestId, string targetName) {
-        JsonElement saveTargetResult = client.CallTool(requestId++, "save_window_target", new {
-            name = targetName,
-            description = "Experimental Edge omnibox fallback point",
-            xRatio = EdgeOmniboxFallbackXRatio,
-            yRatio = EdgeOmniboxFallbackYRatio,
-            clientArea = false
-        });
-        Assert.AreEqual(targetName, saveTargetResult.GetProperty("Name").GetString());
-    }
-
-    private static void SaveEdgeOmniboxControlTarget(McpTestClient client, ref int requestId, string targetName) {
-        JsonElement saveResult = client.CallTool(requestId++, "save_control_target", new {
-            name = targetName,
-            description = "Experimental Edge omnibox control",
-            controlClassName = "OmniboxViewViews",
-            controlType = "Edit",
-            controlText = "Address and search bar",
-            isKeyboardFocusable = true,
-            supportsForegroundInputFallback = true,
-            uiAutomation = true
-        });
-        Assert.AreEqual(targetName, saveResult.GetProperty("Name").GetString());
-    }
-
-    private static string CaptureEdgeForegroundDiagnostics(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName, string diagnosticDirectory, IReadOnlyList<string>? decisionTrace = null) {
-        Directory.CreateDirectory(diagnosticDirectory);
-
-        string screenshotPath = Path.Combine(diagnosticDirectory, "edge-window.png");
-        JsonElement screenshotResult = client.CallTool(requestId++, "screenshot_window", new {
-            processName = "msedge",
-            windowHandle,
-            outputPath = screenshotPath
-        });
-
-        JsonElement diagnostics = client.CallTool(requestId++, "diagnose_window_controls", new {
-            processName = "msedge",
-            windowHandle,
-            targetName = controlTargetName,
-            sampleLimit = 10
-        });
-
-        JsonElement controls = GetEdgeOmniboxControls(client, ref requestId, windowHandle, controlTargetName);
-
-        File.WriteAllText(Path.Combine(diagnosticDirectory, "screenshot.json"), JsonSerializer.Serialize(JsonDocument.Parse(screenshotResult.GetRawText()).RootElement, new JsonSerializerOptions {
-            WriteIndented = true
-        }));
-        File.WriteAllText(Path.Combine(diagnosticDirectory, "diagnostics.json"), JsonSerializer.Serialize(JsonDocument.Parse(diagnostics.GetRawText()).RootElement, new JsonSerializerOptions {
-            WriteIndented = true
-        }));
-        File.WriteAllText(Path.Combine(diagnosticDirectory, "controls.json"), JsonSerializer.Serialize(JsonDocument.Parse(controls.GetRawText()).RootElement, new JsonSerializerOptions {
-            WriteIndented = true
-        }));
-        if (decisionTrace != null && decisionTrace.Count > 0) {
-            File.WriteAllLines(Path.Combine(diagnosticDirectory, "decision-trace.txt"), decisionTrace);
-        }
-        WriteEdgeForegroundComparisonReport(diagnosticDirectory);
-
-        return diagnosticDirectory;
-    }
-
-    private static void WriteEdgeForegroundComparisonReport(string diagnosticDirectory) {
-        string? familyPrefix = GetEdgeDiagnosticFamilyPrefix(diagnosticDirectory);
-        if (string.IsNullOrWhiteSpace(familyPrefix)) {
-            return;
-        }
-
-        string parentDirectory = Path.GetDirectoryName(diagnosticDirectory) ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(parentDirectory) || !Directory.Exists(parentDirectory)) {
-            return;
-        }
-
-        DirectoryInfo? previousBundle = new DirectoryInfo(parentDirectory)
-            .EnumerateDirectories(familyPrefix + "*", SearchOption.TopDirectoryOnly)
-            .Where(directory => !string.Equals(directory.FullName, diagnosticDirectory, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(directory => directory.LastWriteTimeUtc)
-            .FirstOrDefault();
-
-        var summaryLines = new List<string> {
-            "Current bundle: " + diagnosticDirectory
-        };
-
-        if (previousBundle == null) {
-            summaryLines.Add("Previous bundle: none");
-            File.WriteAllLines(Path.Combine(diagnosticDirectory, "comparison.txt"), summaryLines);
-            return;
-        }
-
-        summaryLines.Add("Previous bundle: " + previousBundle.FullName);
-
-        EdgeDiagnosticSnapshot currentSnapshot = ReadEdgeDiagnosticSnapshot(diagnosticDirectory);
-        EdgeDiagnosticSnapshot previousSnapshot = ReadEdgeDiagnosticSnapshot(previousBundle.FullName);
-
-        summaryLines.Add(string.Format("Matched controls: current {0}, previous {1}, delta {2}", currentSnapshot.MatchedControlCount, previousSnapshot.MatchedControlCount, currentSnapshot.MatchedControlCount - previousSnapshot.MatchedControlCount));
-        summaryLines.Add(string.Format("Effective controls: current {0}, previous {1}, delta {2}", currentSnapshot.EffectiveControlCount, previousSnapshot.EffectiveControlCount, currentSnapshot.EffectiveControlCount - previousSnapshot.EffectiveControlCount));
-        summaryLines.Add(string.Format("Listed controls: current {0}, previous {1}, delta {2}", currentSnapshot.ListedControlCount, previousSnapshot.ListedControlCount, currentSnapshot.ListedControlCount - previousSnapshot.ListedControlCount));
-        summaryLines.Add(string.Format("Elapsed milliseconds: current {0}, previous {1}, delta {2}", currentSnapshot.ElapsedMilliseconds, previousSnapshot.ElapsedMilliseconds, currentSnapshot.ElapsedMilliseconds - previousSnapshot.ElapsedMilliseconds));
-        summaryLines.Add("Preferred root handle: current " + currentSnapshot.PreferredRootHandle + ", previous " + previousSnapshot.PreferredRootHandle);
-        summaryLines.Add("Preferred root reused: current " + currentSnapshot.UsedPreferredRoot + ", previous " + previousSnapshot.UsedPreferredRoot);
-        summaryLines.Add("Cached controls reused: current " + currentSnapshot.UsedCachedControls + ", previous " + previousSnapshot.UsedCachedControls);
-        summaryLines.Add("First listed control: current " + currentSnapshot.FirstListedControlSummary + ", previous " + previousSnapshot.FirstListedControlSummary);
-        summaryLines.Add("Sample control classes: current " + currentSnapshot.SampleControlClasses + ", previous " + previousSnapshot.SampleControlClasses);
-
-        File.WriteAllLines(Path.Combine(diagnosticDirectory, "comparison.txt"), summaryLines);
-    }
-
-    private static string? GetEdgeDiagnosticFamilyPrefix(string diagnosticDirectory) {
-        string name = Path.GetFileName(diagnosticDirectory);
-        if (name.StartsWith("Edge-Allow-", StringComparison.OrdinalIgnoreCase)) {
-            return "Edge-Allow-";
-        }
-
-        if (name.StartsWith("Edge-Blocked-", StringComparison.OrdinalIgnoreCase)) {
-            return "Edge-Blocked-";
-        }
-
-        return null;
-    }
-
-    private static EdgeDiagnosticSnapshot ReadEdgeDiagnosticSnapshot(string diagnosticDirectory) {
-        string diagnosticsPath = Path.Combine(diagnosticDirectory, "diagnostics.json");
-        string controlsPath = Path.Combine(diagnosticDirectory, "controls.json");
-        var snapshot = new EdgeDiagnosticSnapshot();
-
-        if (File.Exists(diagnosticsPath)) {
-            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(diagnosticsPath));
-            if (document.RootElement.ValueKind == JsonValueKind.Array && document.RootElement.GetArrayLength() > 0) {
-                JsonElement diagnostic = document.RootElement[0];
-                snapshot.MatchedControlCount = ReadOptionalInt32(diagnostic, "MatchedControlCount");
-                snapshot.EffectiveControlCount = ReadOptionalInt32(diagnostic, "EffectiveControlCount");
-                snapshot.ElapsedMilliseconds = ReadOptionalInt32(diagnostic, "ElapsedMilliseconds");
-                snapshot.PreferredRootHandle = ReadOptionalString(diagnostic, "PreferredUiAutomationRootHandle");
-                snapshot.UsedPreferredRoot = ReadOptionalBoolean(diagnostic, "UsedPreferredUiAutomationRoot");
-                snapshot.UsedCachedControls = ReadOptionalBoolean(diagnostic, "UsedCachedUiAutomationControls");
-                snapshot.SampleControlClasses = ReadSampleControlClasses(diagnostic);
-            }
-        }
-
-        if (File.Exists(controlsPath)) {
-            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(controlsPath));
-            if (document.RootElement.ValueKind == JsonValueKind.Array) {
-                snapshot.ListedControlCount = document.RootElement.GetArrayLength();
-                if (snapshot.ListedControlCount > 0) {
-                    JsonElement firstControl = document.RootElement[0];
-                    snapshot.FirstListedControlSummary = string.Format(
-                        "{0} / {1} / {2}",
-                        ReadOptionalString(firstControl, "ClassName"),
-                        ReadOptionalString(firstControl, "ControlType"),
-                        ReadOptionalString(firstControl, "AutomationId"));
-                }
-            }
-        }
-
-        return snapshot;
-    }
-
-    private static int ReadOptionalInt32(JsonElement element, string propertyName) {
-        if (element.TryGetProperty(propertyName, out JsonElement value) && value.ValueKind == JsonValueKind.Number) {
-            return value.GetInt32();
-        }
-
-        return 0;
-    }
-
-    private static bool ReadOptionalBoolean(JsonElement element, string propertyName) {
-        if (element.TryGetProperty(propertyName, out JsonElement value) && (value.ValueKind == JsonValueKind.True || value.ValueKind == JsonValueKind.False)) {
-            return value.GetBoolean();
-        }
-
-        return false;
-    }
-
-    private static string ReadOptionalString(JsonElement element, string propertyName) {
-        if (element.TryGetProperty(propertyName, out JsonElement value) && value.ValueKind == JsonValueKind.String) {
-            return value.GetString() ?? string.Empty;
-        }
-
-        return string.Empty;
-    }
-
-    private static string ReadSampleControlClasses(JsonElement diagnostic) {
-        if (!diagnostic.TryGetProperty("SampleControls", out JsonElement sampleControls) || sampleControls.ValueKind != JsonValueKind.Array) {
-            return string.Empty;
-        }
-
-        return string.Join(", ", sampleControls.EnumerateArray().Take(5).Select(control => ReadOptionalString(control, "ClassName")).Where(className => !string.IsNullOrWhiteSpace(className)));
-    }
-
-    private sealed class EdgeDiagnosticSnapshot {
-        public int MatchedControlCount { get; set; }
-        public int EffectiveControlCount { get; set; }
-        public int ListedControlCount { get; set; }
-        public int ElapsedMilliseconds { get; set; }
-        public string PreferredRootHandle { get; set; } = string.Empty;
-        public bool UsedPreferredRoot { get; set; }
-        public bool UsedCachedControls { get; set; }
-        public string FirstListedControlSummary { get; set; } = string.Empty;
-        public string SampleControlClasses { get; set; } = string.Empty;
-    }
-
-    private static JsonElement GetEdgeOmniboxControls(McpTestClient client, ref int requestId, string windowHandle, string controlTargetName) {
-        JsonElement namedTargetControls = client.CallTool(requestId++, "list_window_controls", new {
-            processName = "msedge",
-            windowHandle,
-            targetName = controlTargetName
-        });
-        if (namedTargetControls.ValueKind == JsonValueKind.Array && namedTargetControls.GetArrayLength() > 0) {
-            return namedTargetControls;
-        }
-
-        JsonElement preferredControls = client.CallTool(requestId++, "list_window_controls", new {
-            processName = "msedge",
-            windowHandle,
-            controlClassName = "OmniboxViewViews",
-            controlType = "Edit",
-            controlText = "Address and search bar",
-            isKeyboardFocusable = true,
-            supportsForegroundInputFallback = true,
-            uiAutomation = true,
-            ensureForegroundWindow = true
-        });
-        if (preferredControls.ValueKind == JsonValueKind.Array && preferredControls.GetArrayLength() > 0) {
-            return preferredControls;
-        }
-
-        return client.CallTool(requestId++, "list_window_controls", new {
-            processName = "msedge",
-            windowHandle,
-            controlType = "Edit",
-            isKeyboardFocusable = true,
-            supportsForegroundInputFallback = true,
-            uiAutomation = true,
-            ensureForegroundWindow = true
-        });
+        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for the test app command bar control to be discoverable through MCP.");
     }
 
     private static JsonElement WaitForProcessWindow(McpTestClient client, ref int requestId, int processId, int timeoutMilliseconds, int intervalMilliseconds, string scenario) {
@@ -1197,6 +858,50 @@ public class McpServerEndToEndTests {
         });
         Assert.IsTrue(windows.GetProperty("Count").GetInt32() >= 1, $"Expected MCP to resolve a live window for the {scenario} scenario.");
         return windows.GetProperty("Windows")[0];
+    }
+
+    private static string ReadOptionalString(JsonElement element, string propertyName) {
+        if (element.TryGetProperty(propertyName, out JsonElement value) && value.ValueKind == JsonValueKind.String) {
+            return value.GetString() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static JsonElement WaitForControlValueMatch(
+        McpTestClient client,
+        ref int requestId,
+        string windowHandle,
+        string expectedValue,
+        int timeoutMilliseconds,
+        int intervalMilliseconds,
+        string? controlHandle = null,
+        string? controlAutomationId = null,
+        string? controlType = null,
+        bool uiAutomation = false,
+        bool includeUiAutomation = true,
+        bool ensureForegroundWindow = false) {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        JsonElement lastResult = default;
+        while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds) {
+            lastResult = client.CallTool(requestId++, "assert_control_value", new {
+                windowHandle,
+                controlHandle,
+                controlAutomationId,
+                controlType,
+                uiAutomation,
+                includeUiAutomation,
+                ensureForegroundWindow,
+                expectedValue
+            });
+            if (lastResult.GetProperty("Matched").GetBoolean()) {
+                return lastResult;
+            }
+
+            System.Threading.Thread.Sleep(intervalMilliseconds);
+        }
+
+        return lastResult;
     }
 
     private static void KillProcessById(int processId) {
@@ -1240,16 +945,16 @@ public class McpServerEndToEndTests {
         }
     }
 
-    private static JsonElement FindEditableNotepadControl(JsonElement controls) {
-        if (TryFindEditableNotepadControl(controls, out JsonElement control)) {
+    private static JsonElement FindEditableTextControl(JsonElement controls) {
+        if (TryFindEditableTextControl(controls, out JsonElement control)) {
             return control;
         }
 
-        Assert.Inconclusive("No editable Notepad control with background text support was exposed through MCP.");
+        Assert.Inconclusive("No editable text control with background text support was exposed through MCP.");
         return default;
     }
 
-    private static JsonElement WaitForEditableNotepadControl(McpTestClient client, ref int requestId, string windowHandle, int timeoutMilliseconds, int intervalMilliseconds) {
+    private static JsonElement WaitForEditableTextControl(McpTestClient client, ref int requestId, string windowHandle, int timeoutMilliseconds, int intervalMilliseconds) {
         Stopwatch stopwatch = Stopwatch.StartNew();
         while (stopwatch.ElapsedMilliseconds < timeoutMilliseconds) {
             JsonElement controls = client.CallTool(requestId++, "list_window_controls", new {
@@ -1259,18 +964,18 @@ public class McpServerEndToEndTests {
             });
             if (controls.ValueKind == JsonValueKind.Array &&
                 controls.GetArrayLength() > 0 &&
-                TryFindEditableNotepadControl(controls, out JsonElement control)) {
+                TryFindEditableTextControl(controls, out JsonElement control)) {
                 return control;
             }
 
             System.Threading.Thread.Sleep(intervalMilliseconds);
         }
 
-        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for Notepad to expose an editable control through MCP.");
+        Assert.Fail($"Timed out after {timeoutMilliseconds}ms waiting for the test app to expose an editable control through MCP.");
         return default;
     }
 
-    private static bool TryFindEditableNotepadControl(JsonElement controls, out JsonElement control) {
+    private static bool TryFindEditableTextControl(JsonElement controls, out JsonElement control) {
         JsonElement? richEdit = null;
         JsonElement? fallback = null;
 
@@ -1287,16 +992,15 @@ public class McpServerEndToEndTests {
             }
 
             if (fallback == null &&
-                (string.Equals(className, "NotepadTextBox", StringComparison.OrdinalIgnoreCase) ||
-                 className.IndexOf("Edit", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                (className.IndexOf("Edit", StringComparison.OrdinalIgnoreCase) >= 0 ||
                  className.IndexOf("TextBox", StringComparison.OrdinalIgnoreCase) >= 0)) {
                 fallback = candidate.Clone();
             }
-        }
+            }
 
-        if (richEdit.HasValue) {
-            control = richEdit.Value;
-            return true;
+            if (richEdit.HasValue) {
+                control = richEdit.Value;
+                return true;
         }
 
         if (fallback.HasValue) {

--- a/Sources/DesktopManager.Tests/McpServerTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerTests.cs
@@ -72,6 +72,7 @@ public class McpServerTests {
         AssertToolHasProperty(toolsByName["save_window_target"], "heightRatio");
         AssertToolHasProperty(toolsByName["screenshot_window"], "targetName");
         AssertToolHasProperty(toolsByName["launch_and_wait_for_window"], "timeoutMs");
+        AssertToolHasProperty(toolsByName["launch_and_wait_for_window"], "followProcessFamily");
         AssertToolHasProperty(toolsByName["send_window_keys"], "keys");
         AssertToolHasProperty(toolsByName["assert_window_layout"], "positionTolerancePx");
 
@@ -354,6 +355,26 @@ public class McpServerTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures control-key foreground-input fallback requires explicit MCP server opt-in too.
+    /// </summary>
+    public void McpServer_ForegroundInputFallback_SendControlKeys_RequiresServerOptIn() {
+        using var client = McpTestClient.Start("mcp serve --allow-mutations");
+        client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+
+        JsonElement toolError = client.CallToolExpectError(2, "send_control_keys", new Dictionary<string, object?> {
+            ["windowTitle"] = "*DesktopManagerTests*",
+            ["controlType"] = "Edit",
+            ["keys"] = new[] { "ENTER" },
+            ["allowForegroundInput"] = true
+        });
+
+        StringAssert.Contains(toolError.GetProperty("message").GetString() ?? string.Empty, "--allow-foreground-input");
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures dry-run mode returns a structured preview without mutating persistent state.
     /// </summary>
     public void McpServer_DryRun_PreviewsMutatingToolsWithoutWritingState() {
@@ -382,6 +403,29 @@ public class McpServerTests {
                 File.Delete(path);
             }
         }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures dry-run foreground-input requests preserve the explicit fallback flag in the preview result.
+    /// </summary>
+    public void McpServer_DryRun_ForegroundInputPreview_ReportsRequestedFallback() {
+        using var client = McpTestClient.Start("mcp serve --dry-run");
+        JsonElement initializeResult = client.SendRequest(1, "initialize", new Dictionary<string, object?> {
+            ["protocolVersion"] = "2025-06-18"
+        });
+        Assert.IsTrue(initializeResult.GetProperty("safetyPolicy").GetProperty("dryRun").GetBoolean());
+
+        JsonElement result = client.CallTool(2, "send_control_keys", new Dictionary<string, object?> {
+            ["processName"] = "DesktopManager.TestApp",
+            ["targetName"] = "CommandBar",
+            ["keys"] = new[] { "ENTER" },
+            ["allowForegroundInput"] = true
+        });
+
+        Assert.IsTrue(result.GetProperty("dryRun").GetBoolean());
+        Assert.IsTrue(result.GetProperty("requestedForegroundInputFallback").GetBoolean());
+        Assert.AreEqual("dry-run", result.GetProperty("safetyMode").GetString());
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/MonitorCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorCommandOutputTests.cs
@@ -1,0 +1,65 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI monitor text output.
+/// </summary>
+public class MonitorCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures monitor output renders the expected table headers and row values.
+    /// </summary>
+    public void WriteMonitorResults_WritesMonitorTable() {
+        var monitors = new List<global::DesktopManager.Cli.MonitorResult> {
+            new() {
+                Index = 1,
+                IsPrimary = true,
+                IsConnected = true,
+                Left = 0,
+                Top = 0,
+                Right = 1920,
+                Bottom = 1080,
+                DeviceName = @"\\.\DISPLAY1",
+                DeviceString = "Primary Display"
+            },
+            new() {
+                Index = 2,
+                IsPrimary = false,
+                IsConnected = false,
+                Left = 1920,
+                Top = 0,
+                Right = 3840,
+                Bottom = 1080,
+                DeviceName = @"\\.\DISPLAY2",
+                DeviceString = "Dock Display"
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.MonitorCommands.WriteMonitorResults(monitors, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "Idx");
+        StringAssert.Contains(output, "Primary");
+        StringAssert.Contains(output, "Connected");
+        StringAssert.Contains(output, "Bounds");
+        StringAssert.Contains(output, "DeviceName");
+        StringAssert.Contains(output, "Device");
+        StringAssert.Contains(output, "1");
+        StringAssert.Contains(output, "Yes");
+        StringAssert.Contains(output, "0,0,1920,1080");
+        StringAssert.Contains(output, @"\\.\DISPLAY1");
+        StringAssert.Contains(output, "Primary Display");
+        StringAssert.Contains(output, "2");
+        StringAssert.Contains(output, "1920,0,3840,1080");
+        StringAssert.Contains(output, @"\\.\DISPLAY2");
+        StringAssert.Contains(output, "Dock Display");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/OutputFormatterTests.cs
+++ b/Sources/DesktopManager.Tests/OutputFormatterTests.cs
@@ -1,0 +1,53 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for shared CLI output formatting helpers.
+/// </summary>
+public class OutputFormatterTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures JSON output is written to the provided writer.
+    /// </summary>
+    public void WriteJson_WritesSerializedJsonToWriter() {
+        using var writer = new StringWriter();
+
+        global::DesktopManager.Cli.OutputFormatter.WriteJson(writer, new {
+            Name = "DesktopManager",
+            Count = 2
+        });
+
+        string output = writer.ToString();
+
+        StringAssert.Contains(output, "\"Name\": \"DesktopManager\"");
+        StringAssert.Contains(output, "\"Count\": 2");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures table output includes headers, separator, and aligned rows.
+    /// </summary>
+    public void WriteTable_WritesHeadersSeparatorAndRows() {
+        using var writer = new StringWriter();
+
+        global::DesktopManager.Cli.OutputFormatter.WriteTable(
+            writer,
+            new[] { "Id", "Name" },
+            new List<IReadOnlyList<string>> {
+                new[] { "1", "Alpha" },
+                new[] { "22", "Beta" }
+            });
+
+        string output = writer.ToString();
+
+        StringAssert.Contains(output, "Id  Name ");
+        StringAssert.Contains(output, "--  -----");
+        StringAssert.Contains(output, "1   Alpha");
+        StringAssert.Contains(output, "22  Beta ");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessAndWorkflowCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessAndWorkflowCriteriaTests.cs
@@ -1,0 +1,111 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI process and workflow criteria mapping.
+/// </summary>
+public class ProcessAndWorkflowCriteriaTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures process artifact options return null when no capture flags or directory are provided.
+    /// </summary>
+    public void ProcessCreateArtifactOptions_ReturnsNullWhenNoArtifactsRequested() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start-and-wait",
+            "notepad.exe"
+        });
+
+        global::DesktopManager.Cli.MutationArtifactOptions? options = global::DesktopManager.Cli.ProcessCommands.CreateArtifactOptions(arguments);
+
+        Assert.IsNull(options);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures process artifact options map capture flags and artifact directory.
+    /// </summary>
+    public void ProcessCreateArtifactOptions_MapsCaptureFlagsAndDirectory() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start-and-wait",
+            "notepad.exe",
+            "--capture-before",
+            "--capture-after",
+            "--artifact-directory", @"C:\Artifacts"
+        });
+
+        global::DesktopManager.Cli.MutationArtifactOptions? options = global::DesktopManager.Cli.ProcessCommands.CreateArtifactOptions(arguments);
+
+        Assert.IsNotNull(options);
+        Assert.IsTrue(options.CaptureBefore);
+        Assert.IsTrue(options.CaptureAfter);
+        Assert.AreEqual(@"C:\Artifacts", options.ArtifactDirectory);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures workflow focus criteria map window selector flags and keep all=false.
+    /// </summary>
+    public void WorkflowCreateFocusCriteria_MapsSelectorFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "workflow",
+            "prepare-coding",
+            "--title", "*Editor*",
+            "--process", "DesktopManager.TestApp",
+            "--class", "TestWindowClass",
+            "--pid", "321",
+            "--handle", "0x1234",
+            "--active",
+            "--include-hidden",
+            "--exclude-cloaked",
+            "--exclude-owned",
+            "--include-empty"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.WorkflowCommands.CreateFocusCriteria(arguments);
+
+        Assert.AreEqual("*Editor*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("TestWindowClass", criteria.ClassNamePattern);
+        Assert.AreEqual(321, criteria.ProcessId);
+        Assert.AreEqual("0x1234", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsFalse(criteria.IncludeCloaked);
+        Assert.IsFalse(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsFalse(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures workflow artifact options return null without flags and map requested captures when present.
+    /// </summary>
+    public void WorkflowCreateArtifactOptions_MapsRequestedCaptures() {
+        global::DesktopManager.Cli.CommandLineArguments noArtifacts = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "workflow",
+            "prepare-coding"
+        });
+
+        global::DesktopManager.Cli.MutationArtifactOptions? noArtifactOptions = global::DesktopManager.Cli.WorkflowCommands.CreateArtifactOptions(noArtifacts);
+
+        Assert.IsNull(noArtifactOptions);
+
+        global::DesktopManager.Cli.CommandLineArguments withArtifacts = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "workflow",
+            "prepare-coding",
+            "--capture-after",
+            "--artifact-directory", @"C:\WorkflowArtifacts"
+        });
+
+        global::DesktopManager.Cli.MutationArtifactOptions? artifactOptions = global::DesktopManager.Cli.WorkflowCommands.CreateArtifactOptions(withArtifacts);
+
+        Assert.IsNotNull(artifactOptions);
+        Assert.IsFalse(artifactOptions.CaptureBefore);
+        Assert.IsTrue(artifactOptions.CaptureAfter);
+        Assert.AreEqual(@"C:\WorkflowArtifacts", artifactOptions.ArtifactDirectory);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessAndWorkflowMappingTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessAndWorkflowMappingTests.cs
@@ -1,0 +1,124 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI process and workflow result mapping helpers.
+/// </summary>
+public class ProcessAndWorkflowMappingTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures CLI process launch mapping preserves resolved process and main window metadata.
+    /// </summary>
+    public void BuildProcessLaunchResult_MapsResolvedProcessAndMainWindow() {
+        var launch = new DesktopProcessLaunchInfo {
+            FilePath = "DesktopManager.TestApp.exe",
+            Arguments = "--surface editor",
+            WorkingDirectory = @"C:\Temp",
+            ProcessId = 123,
+            ResolvedProcessId = 456,
+            HasExited = false,
+            MainWindow = new WindowInfo {
+                Title = "DesktopManager Test App",
+                Handle = new IntPtr(0x1234),
+                ProcessId = 456,
+                ThreadId = 789,
+                IsVisible = true,
+                IsTopMost = false,
+                State = WindowState.Normal,
+                Left = 10,
+                Top = 20,
+                Right = 810,
+                Bottom = 620,
+                MonitorIndex = 1,
+                MonitorDeviceName = @"\\.\\DISPLAY1"
+            }
+        };
+
+        global::DesktopManager.Cli.ProcessLaunchResult result = global::DesktopManager.Cli.DesktopOperations.BuildProcessLaunchResult(launch);
+
+        Assert.AreEqual("DesktopManager.TestApp.exe", result.FilePath);
+        Assert.AreEqual("--surface editor", result.Arguments);
+        Assert.AreEqual(@"C:\Temp", result.WorkingDirectory);
+        Assert.AreEqual(123, result.ProcessId);
+        Assert.AreEqual(456, result.ResolvedProcessId);
+        Assert.IsFalse(result.HasExited);
+        Assert.IsNotNull(result.MainWindow);
+        Assert.AreEqual("DesktopManager Test App", result.MainWindow.Title);
+        Assert.AreEqual("0x1234", result.MainWindow.Handle);
+        Assert.AreEqual((uint)456, result.MainWindow.ProcessId);
+        Assert.AreEqual((uint)789, result.MainWindow.ThreadId);
+        Assert.AreEqual("Normal", result.MainWindow.State);
+        Assert.AreEqual(800, result.MainWindow.Width);
+        Assert.AreEqual(600, result.MainWindow.Height);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures CLI workflow result assembly preserves notes, artifacts, and the derived minimized count.
+    /// </summary>
+    public void BuildWorkflowResult_MapsNotesArtifactsAndMinimizedCount() {
+        var minimizedWindows = new[] {
+            new global::DesktopManager.Cli.WindowResult {
+                Title = "Chat",
+                ProcessId = 201
+            },
+            new global::DesktopManager.Cli.WindowResult {
+                Title = "Mail",
+                ProcessId = 202
+            }
+        };
+        var resolvedWindow = new global::DesktopManager.Cli.WindowResult {
+            Title = "Browser",
+            ProcessId = 301
+        };
+        var focusedWindow = new global::DesktopManager.Cli.WindowResult {
+            Title = "Editor",
+            ProcessId = 302
+        };
+        var notes = new[] {
+            "Applied named layout 'Pairing'.",
+            "Focused requested coding window."
+        };
+        var beforeScreenshots = new[] {
+            new global::DesktopManager.Cli.ScreenshotResult()
+        };
+        var afterScreenshots = new[] {
+            new global::DesktopManager.Cli.ScreenshotResult(),
+            new global::DesktopManager.Cli.ScreenshotResult()
+        };
+        var warnings = new[] {
+            "Capture path normalized."
+        };
+
+        global::DesktopManager.Cli.WorkflowResult result = global::DesktopManager.Cli.DesktopOperations.BuildWorkflowResult(
+            "prepare-for-coding",
+            success: true,
+            elapsedMilliseconds: 222,
+            layoutName: "Pairing",
+            layoutApplied: true,
+            minimizedWindows,
+            resolvedWindow,
+            focusedWindow,
+            notes,
+            beforeScreenshots,
+            afterScreenshots,
+            warnings);
+
+        Assert.AreEqual("prepare-for-coding", result.Action);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(222, result.ElapsedMilliseconds);
+        Assert.AreEqual("Pairing", result.LayoutName);
+        Assert.IsTrue(result.LayoutApplied);
+        Assert.AreEqual(2, result.MinimizedCount);
+        Assert.AreEqual(2, result.MinimizedWindows.Count);
+        Assert.AreEqual("Chat", result.MinimizedWindows[0].Title);
+        Assert.AreEqual("Browser", result.ResolvedWindow?.Title);
+        Assert.AreEqual("Editor", result.FocusedWindow?.Title);
+        CollectionAssert.AreEqual(notes, result.Notes.ToArray());
+        Assert.AreEqual(1, result.BeforeScreenshots.Count);
+        Assert.AreEqual(2, result.AfterScreenshots.Count);
+        CollectionAssert.AreEqual(warnings, result.ArtifactWarnings.ToArray());
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessCommandCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessCommandCriteriaTests.cs
@@ -1,0 +1,141 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI process command criteria mapping.
+/// </summary>
+public class ProcessCommandCriteriaTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures start options map explicit launch-related flags.
+    /// </summary>
+    public void CreateStartOptions_MapsLaunchFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start",
+            "notepad.exe",
+            "--arguments", "file.txt",
+            "--working-directory", @"C:\Work",
+            "--wait-for-input-idle-ms", "2500",
+            "--wait-for-window-ms", "4000",
+            "--wait-for-window-interval-ms", "300",
+            "--window-title", "*Notepad*",
+            "--window-class", "Notepad",
+            "--require-window"
+        });
+
+        global::DesktopManager.Cli.ProcessStartCommandOptions options = global::DesktopManager.Cli.ProcessCommands.CreateStartOptions(arguments);
+
+        Assert.AreEqual("notepad.exe", options.FilePath);
+        Assert.AreEqual("file.txt", options.Arguments);
+        Assert.AreEqual(@"C:\Work", options.WorkingDirectory);
+        Assert.AreEqual(2500, options.WaitForInputIdleMilliseconds);
+        Assert.AreEqual(4000, options.WaitForWindowMilliseconds);
+        Assert.AreEqual(300, options.WaitForWindowIntervalMilliseconds);
+        Assert.AreEqual("*Notepad*", options.WindowTitlePattern);
+        Assert.AreEqual("Notepad", options.WindowClassNamePattern);
+        Assert.IsTrue(options.RequireWindow);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures start options use nulls and false for optional fields when no flags are provided.
+    /// </summary>
+    public void CreateStartOptions_UsesDefaultsWhenUnset() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start",
+            "notepad.exe"
+        });
+
+        global::DesktopManager.Cli.ProcessStartCommandOptions options = global::DesktopManager.Cli.ProcessCommands.CreateStartOptions(arguments);
+
+        Assert.AreEqual("notepad.exe", options.FilePath);
+        Assert.IsNull(options.Arguments);
+        Assert.IsNull(options.WorkingDirectory);
+        Assert.IsNull(options.WaitForInputIdleMilliseconds);
+        Assert.IsNull(options.WaitForWindowMilliseconds);
+        Assert.IsNull(options.WaitForWindowIntervalMilliseconds);
+        Assert.IsNull(options.WindowTitlePattern);
+        Assert.IsNull(options.WindowClassNamePattern);
+        Assert.IsFalse(options.RequireWindow);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures start-and-wait options map launch, wait, and artifact flags.
+    /// </summary>
+    public void CreateStartAndWaitOptions_MapsLaunchWaitFlagsAndArtifacts() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start-and-wait",
+            "notepad.exe",
+            "--arguments", "file.txt",
+            "--working-directory", @"C:\Work",
+            "--wait-for-input-idle-ms", "1500",
+            "--launch-wait-for-window-ms", "5000",
+            "--launch-wait-for-window-interval-ms", "250",
+            "--launch-window-title", "*Launcher*",
+            "--launch-window-class", "LauncherWindow",
+            "--window-title", "*Editor*",
+            "--window-class", "EditorWindow",
+            "--include-hidden",
+            "--include-empty",
+            "--all",
+            "--follow-process-family",
+            "--timeout-ms", "12000",
+            "--interval-ms", "350",
+            "--capture-before",
+            "--capture-after",
+            "--artifact-directory", @"C:\Artifacts"
+        });
+
+        global::DesktopManager.Cli.LaunchAndWaitCommandOptions options = global::DesktopManager.Cli.ProcessCommands.CreateStartAndWaitOptions(arguments);
+
+        Assert.AreEqual("notepad.exe", options.FilePath);
+        Assert.AreEqual("file.txt", options.Arguments);
+        Assert.AreEqual(@"C:\Work", options.WorkingDirectory);
+        Assert.AreEqual(1500, options.WaitForInputIdleMilliseconds);
+        Assert.AreEqual(5000, options.LaunchWaitForWindowMilliseconds);
+        Assert.AreEqual(250, options.LaunchWaitForWindowIntervalMilliseconds);
+        Assert.AreEqual("*Launcher*", options.LaunchWindowTitlePattern);
+        Assert.AreEqual("LauncherWindow", options.LaunchWindowClassNamePattern);
+        Assert.AreEqual("*Editor*", options.WindowTitlePattern);
+        Assert.AreEqual("EditorWindow", options.WindowClassNamePattern);
+        Assert.IsTrue(options.IncludeHidden);
+        Assert.IsTrue(options.IncludeEmpty);
+        Assert.IsTrue(options.All);
+        Assert.IsTrue(options.FollowProcessFamily);
+        Assert.AreEqual(12000, options.TimeoutMilliseconds);
+        Assert.AreEqual(350, options.IntervalMilliseconds);
+        Assert.IsNotNull(options.ArtifactOptions);
+        Assert.IsTrue(options.ArtifactOptions.CaptureBefore);
+        Assert.IsTrue(options.ArtifactOptions.CaptureAfter);
+        Assert.AreEqual(@"C:\Artifacts", options.ArtifactOptions.ArtifactDirectory);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures start-and-wait options use default timeout and interval values when unset.
+    /// </summary>
+    public void CreateStartAndWaitOptions_UsesDefaultTimeoutAndInterval() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "process",
+            "start-and-wait",
+            "notepad.exe"
+        });
+
+        global::DesktopManager.Cli.LaunchAndWaitCommandOptions options = global::DesktopManager.Cli.ProcessCommands.CreateStartAndWaitOptions(arguments);
+
+        Assert.AreEqual("notepad.exe", options.FilePath);
+        Assert.AreEqual(10000, options.TimeoutMilliseconds);
+        Assert.AreEqual(200, options.IntervalMilliseconds);
+        Assert.IsFalse(options.IncludeHidden);
+        Assert.IsFalse(options.IncludeEmpty);
+        Assert.IsFalse(options.All);
+        Assert.IsFalse(options.FollowProcessFamily);
+        Assert.IsNull(options.ArtifactOptions);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessCommandOutputTests.cs
@@ -1,0 +1,100 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI process command text output.
+/// </summary>
+public class ProcessCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the start-and-wait text output includes resolved-process wait binding metadata.
+    /// </summary>
+    public void WriteStartAndWaitResult_WritesResolvedProcessBindingFields() {
+        var result = new global::DesktopManager.Cli.LaunchAndWaitResult {
+            Action = "launch-and-wait-for-window",
+            Success = true,
+            ElapsedMilliseconds = 321,
+            WaitBinding = "resolved-process-id",
+            BoundProcessId = 200,
+            BoundProcessName = null,
+            Launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+                FilePath = "notepad.exe",
+                ProcessId = 100,
+                ResolvedProcessId = 200
+            },
+            WindowWait = new global::DesktopManager.Cli.WaitForWindowResult {
+                ElapsedMilliseconds = 150,
+                Count = 1,
+                Windows = new[] {
+                    new global::DesktopManager.Cli.WindowResult {
+                        Title = "Untitled - Notepad",
+                        ProcessId = 200
+                    }
+                }
+            },
+            Notes = new[] { "Resolved launch window." }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ProcessCommands.WriteStartAndWaitResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "launch-and-wait-for-window: success=True elapsed-ms=321");
+        StringAssert.Contains(output, "- PID: 100");
+        StringAssert.Contains(output, "- ResolvedPID: 200");
+        StringAssert.Contains(output, "- File: notepad.exe");
+        StringAssert.Contains(output, "- WaitBinding: resolved-process-id");
+        StringAssert.Contains(output, "- BoundProcessId: 200");
+        Assert.IsFalse(output.Contains("BoundProcessName"));
+        StringAssert.Contains(output, "- WaitCount: 1");
+        StringAssert.Contains(output, "- WaitElapsedMs: 150");
+        StringAssert.Contains(output, "- Window: Untitled - Notepad [PID 200]");
+        StringAssert.Contains(output, "- Note: Resolved launch window.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the start-and-wait text output includes process-family wait binding metadata.
+    /// </summary>
+    public void WriteStartAndWaitResult_WritesProcessFamilyBindingFields() {
+        var result = new global::DesktopManager.Cli.LaunchAndWaitResult {
+            Action = "launch-and-wait-for-window",
+            Success = false,
+            ElapsedMilliseconds = 654,
+            WaitBinding = "process-name-family",
+            BoundProcessId = null,
+            BoundProcessName = "Code",
+            Launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+                FilePath = "\"C:\\Program Files\\Microsoft VS Code\\Code.exe\"",
+                ProcessId = 100
+            },
+            WindowWait = new global::DesktopManager.Cli.WaitForWindowResult {
+                ElapsedMilliseconds = 500,
+                Count = 0
+            },
+            ArtifactWarnings = new[] { "Capture disabled." }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ProcessCommands.WriteStartAndWaitResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "launch-and-wait-for-window: success=False elapsed-ms=654");
+        StringAssert.Contains(output, "- PID: 100");
+        Assert.IsFalse(output.Contains("ResolvedPID"));
+        StringAssert.Contains(output, "- WaitBinding: process-name-family");
+        Assert.IsFalse(output.Contains("BoundProcessId"));
+        StringAssert.Contains(output, "- BoundProcessName: Code");
+        StringAssert.Contains(output, "- WaitCount: 0");
+        StringAssert.Contains(output, "- WaitElapsedMs: 500");
+        StringAssert.Contains(output, "- Warning: Capture disabled.");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessStartCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessStartCommandOutputTests.cs
@@ -1,0 +1,66 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI process start text output.
+/// </summary>
+public class ProcessStartCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the process start text output includes resolved process and window details when available.
+    /// </summary>
+    public void WriteStartResult_WritesResolvedProcessAndWindowFields() {
+        var result = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "notepad.exe",
+            Arguments = "--example",
+            WorkingDirectory = "C:\\Temp",
+            ProcessId = 100,
+            ResolvedProcessId = 200,
+            MainWindow = new global::DesktopManager.Cli.WindowResult {
+                Title = "Untitled - Notepad",
+                ProcessId = 200
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ProcessCommands.WriteStartResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "start: PID 100");
+        StringAssert.Contains(output, "- ResolvedPID: 200");
+        StringAssert.Contains(output, "- File: notepad.exe");
+        StringAssert.Contains(output, "- Arguments: --example");
+        StringAssert.Contains(output, "- WorkingDirectory: C:\\Temp");
+        StringAssert.Contains(output, "- Window: Untitled - Notepad");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the process start text output omits optional fields when they are not populated.
+    /// </summary>
+    public void WriteStartResult_OmitsOptionalFieldsWhenUnset() {
+        var result = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "cmd.exe",
+            ProcessId = 123
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ProcessCommands.WriteStartResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "start: PID 123");
+        StringAssert.Contains(output, "- File: cmd.exe");
+        Assert.IsFalse(output.Contains("ResolvedPID"));
+        Assert.IsFalse(output.Contains("Arguments:"));
+        Assert.IsFalse(output.Contains("WorkingDirectory:"));
+        Assert.IsFalse(output.Contains("Window:"));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ProcessWorkflowBindingTests.cs
+++ b/Sources/DesktopManager.Tests/ProcessWorkflowBindingTests.cs
@@ -1,0 +1,185 @@
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI launch-and-wait process binding decisions.
+/// </summary>
+public class ProcessWorkflowBindingTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait prefers a resolved window process when one is available.
+    /// </summary>
+    public void CreateLaunchWaitBindingPlan_UsesResolvedProcessIdWhenAvailable() {
+        var launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "notepad.exe",
+            ProcessId = 100,
+            ResolvedProcessId = 200
+        };
+
+        global::DesktopManager.Cli.LaunchWaitBindingPlan plan = global::DesktopManager.Cli.DesktopOperations.CreateLaunchWaitBindingPlan(
+            launch,
+            launchWindowTitlePattern: "*Launch*",
+            launchWindowClassNamePattern: "Notepad",
+            windowTitlePattern: "*Final*",
+            windowClassNamePattern: "NotepadFinal",
+            includeHidden: true,
+            includeEmpty: false,
+            all: true,
+            followProcessFamily: true);
+
+        Assert.AreEqual("resolved-process-id", plan.WaitBinding);
+        Assert.AreEqual(200, plan.BoundProcessId);
+        Assert.IsNull(plan.BoundProcessName);
+        Assert.AreEqual(200, plan.Criteria.ProcessId);
+        Assert.AreEqual("*Final*", plan.Criteria.TitlePattern);
+        Assert.AreEqual("NotepadFinal", plan.Criteria.ClassNamePattern);
+        Assert.IsTrue(plan.Criteria.IncludeHidden);
+        Assert.IsTrue(plan.Criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait uses the launcher process by default.
+    /// </summary>
+    public void CreateLaunchWaitBindingPlan_UsesLauncherProcessIdByDefault() {
+        var launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "notepad.exe",
+            ProcessId = 100
+        };
+
+        global::DesktopManager.Cli.LaunchWaitBindingPlan plan = global::DesktopManager.Cli.DesktopOperations.CreateLaunchWaitBindingPlan(
+            launch,
+            launchWindowTitlePattern: "*Launch*",
+            launchWindowClassNamePattern: "LaunchClass",
+            windowTitlePattern: null,
+            windowClassNamePattern: null,
+            includeHidden: false,
+            includeEmpty: true,
+            all: false,
+            followProcessFamily: false);
+
+        Assert.AreEqual("launcher-process-id", plan.WaitBinding);
+        Assert.AreEqual(100, plan.BoundProcessId);
+        Assert.IsNull(plan.BoundProcessName);
+        Assert.AreEqual(100, plan.Criteria.ProcessId);
+        Assert.AreEqual("*Launch*", plan.Criteria.TitlePattern);
+        Assert.AreEqual("LaunchClass", plan.Criteria.ClassNamePattern);
+        Assert.IsTrue(plan.Criteria.IncludeEmptyTitles);
+        Assert.IsFalse(plan.Criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait can opt into following a same-name process family.
+    /// </summary>
+    public void CreateLaunchWaitBindingPlan_UsesProcessFamilyWhenRequested() {
+        var launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "\"C:\\Program Files\\Microsoft VS Code\\Code.exe\"",
+            ProcessId = 100
+        };
+
+        global::DesktopManager.Cli.LaunchWaitBindingPlan plan = global::DesktopManager.Cli.DesktopOperations.CreateLaunchWaitBindingPlan(
+            launch,
+            launchWindowTitlePattern: null,
+            launchWindowClassNamePattern: null,
+            windowTitlePattern: "*Code*",
+            windowClassNamePattern: null,
+            includeHidden: false,
+            includeEmpty: false,
+            all: false,
+            followProcessFamily: true);
+
+        Assert.AreEqual("process-name-family", plan.WaitBinding);
+        Assert.IsNull(plan.BoundProcessId);
+        Assert.AreEqual("Code", plan.BoundProcessName);
+        Assert.IsNull(plan.Criteria.ProcessId);
+        Assert.AreEqual("Code", plan.Criteria.ProcessNamePattern);
+        Assert.AreEqual("*Code*", plan.Criteria.TitlePattern);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait falls back to the launcher process when no process-family hint can be inferred.
+    /// </summary>
+    public void CreateLaunchWaitBindingPlan_FallsBackToLauncherProcessWhenProcessFamilyCannotBeInferred() {
+        var launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+            FilePath = "\"\"",
+            ProcessId = 100
+        };
+
+        global::DesktopManager.Cli.LaunchWaitBindingPlan plan = global::DesktopManager.Cli.DesktopOperations.CreateLaunchWaitBindingPlan(
+            launch,
+            launchWindowTitlePattern: null,
+            launchWindowClassNamePattern: null,
+            windowTitlePattern: null,
+            windowClassNamePattern: null,
+            includeHidden: false,
+            includeEmpty: false,
+            all: false,
+            followProcessFamily: true);
+
+        Assert.AreEqual("launcher-process-id", plan.WaitBinding);
+        Assert.AreEqual(100, plan.BoundProcessId);
+        Assert.IsNull(plan.BoundProcessName);
+        Assert.AreEqual(100, plan.Criteria.ProcessId);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait result payloads keep resolved-process binding metadata in structured JSON output.
+    /// </summary>
+    public void LaunchAndWaitResult_SerializesResolvedProcessBindingMetadata() {
+        var result = new global::DesktopManager.Cli.LaunchAndWaitResult {
+            Action = "launch-and-wait-for-window",
+            Success = true,
+            WaitBinding = "resolved-process-id",
+            BoundProcessId = 200,
+            BoundProcessName = null,
+            Launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+                FilePath = "notepad.exe",
+                ProcessId = 100,
+                ResolvedProcessId = 200
+            },
+            WindowWait = new global::DesktopManager.Cli.WaitForWindowResult {
+                Count = 1
+            }
+        };
+
+        JsonElement json = JsonSerializer.SerializeToElement(result, global::DesktopManager.Cli.JsonUtilities.SerializerOptions);
+
+        Assert.AreEqual("resolved-process-id", json.GetProperty("WaitBinding").GetString());
+        Assert.AreEqual(200, json.GetProperty("BoundProcessId").GetInt32());
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("BoundProcessName").ValueKind);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures launch-and-wait result payloads keep process-family binding metadata in structured JSON output.
+    /// </summary>
+    public void LaunchAndWaitResult_SerializesProcessFamilyBindingMetadata() {
+        var result = new global::DesktopManager.Cli.LaunchAndWaitResult {
+            Action = "launch-and-wait-for-window",
+            Success = true,
+            WaitBinding = "process-name-family",
+            BoundProcessId = null,
+            BoundProcessName = "Code",
+            Launch = new global::DesktopManager.Cli.ProcessLaunchResult {
+                FilePath = "\"C:\\Program Files\\Microsoft VS Code\\Code.exe\"",
+                ProcessId = 100
+            },
+            WindowWait = new global::DesktopManager.Cli.WaitForWindowResult {
+                Count = 1
+            }
+        };
+
+        JsonElement json = JsonSerializer.SerializeToElement(result, global::DesktopManager.Cli.JsonUtilities.SerializerOptions);
+
+        Assert.AreEqual("process-name-family", json.GetProperty("WaitBinding").GetString());
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("BoundProcessId").ValueKind);
+        Assert.AreEqual("Code", json.GetProperty("BoundProcessName").GetString());
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ScreenshotCommandCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/ScreenshotCommandCriteriaTests.cs
@@ -1,0 +1,118 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI screenshot command criteria mapping.
+/// </summary>
+public class ScreenshotCommandCriteriaTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures desktop screenshot options map monitor, device, bounds, and output fields.
+    /// </summary>
+    public void CreateDesktopOptions_MapsMonitorDeviceBoundsAndOutput() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "screenshot",
+            "desktop",
+            "--monitor", "2",
+            "--device-id", "DISPLAY-2",
+            "--device-name", @"\\.\DISPLAY2",
+            "--left", "100",
+            "--top", "200",
+            "--width", "1280",
+            "--height", "720",
+            "--output", @"C:\Captures\desktop.png"
+        });
+
+        global::DesktopManager.Cli.DesktopScreenshotCommandOptions options = global::DesktopManager.Cli.ScreenshotCommands.CreateDesktopOptions(arguments);
+
+        Assert.AreEqual(2, options.MonitorIndex);
+        Assert.AreEqual("DISPLAY-2", options.DeviceId);
+        Assert.AreEqual(@"\\.\DISPLAY2", options.DeviceName);
+        Assert.AreEqual(100, options.Left);
+        Assert.AreEqual(200, options.Top);
+        Assert.AreEqual(1280, options.Width);
+        Assert.AreEqual(720, options.Height);
+        Assert.AreEqual(@"C:\Captures\desktop.png", options.OutputPath);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures desktop screenshot options default to nulls when no capture constraints are provided.
+    /// </summary>
+    public void CreateDesktopOptions_UsesNullDefaultsWhenUnset() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "screenshot",
+            "desktop"
+        });
+
+        global::DesktopManager.Cli.DesktopScreenshotCommandOptions options = global::DesktopManager.Cli.ScreenshotCommands.CreateDesktopOptions(arguments);
+
+        Assert.IsNull(options.MonitorIndex);
+        Assert.IsNull(options.DeviceId);
+        Assert.IsNull(options.DeviceName);
+        Assert.IsNull(options.Left);
+        Assert.IsNull(options.Top);
+        Assert.IsNull(options.Width);
+        Assert.IsNull(options.Height);
+        Assert.IsNull(options.OutputPath);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures screenshot window criteria map selector flags and always keep the broad screenshot defaults enabled.
+    /// </summary>
+    public void CreateWindowCriteria_MapsSelectorFlagsAndBroadDefaults() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "screenshot",
+            "window",
+            "--title", "*Editor*",
+            "--process", "DesktopManager.TestApp",
+            "--class", "TestWindowClass",
+            "--pid", "321",
+            "--handle", "0x1234",
+            "--active"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.ScreenshotCommands.CreateWindowCriteria(arguments);
+
+        Assert.AreEqual("*Editor*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("TestWindowClass", criteria.ClassNamePattern);
+        Assert.AreEqual(321, criteria.ProcessId);
+        Assert.AreEqual("0x1234", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsTrue(criteria.IncludeCloaked);
+        Assert.IsTrue(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsFalse(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures screenshot window criteria fall back to wildcard defaults when no selectors are provided.
+    /// </summary>
+    public void CreateWindowCriteria_UsesWildcardDefaults() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "screenshot",
+            "target",
+            "EditorCenter"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.ScreenshotCommands.CreateWindowCriteria(arguments);
+
+        Assert.AreEqual("*", criteria.TitlePattern);
+        Assert.AreEqual("*", criteria.ProcessNamePattern);
+        Assert.AreEqual("*", criteria.ClassNamePattern);
+        Assert.IsNull(criteria.ProcessId);
+        Assert.IsNull(criteria.Handle);
+        Assert.IsFalse(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsTrue(criteria.IncludeCloaked);
+        Assert.IsTrue(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsFalse(criteria.All);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ScreenshotCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/ScreenshotCommandOutputTests.cs
@@ -1,0 +1,73 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI screenshot text output.
+/// </summary>
+public class ScreenshotCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures screenshot text output includes window, client geometry, and monitor details when available.
+    /// </summary>
+    public void WriteScreenshotResult_WritesRichScreenshotSummary() {
+        var result = new global::DesktopManager.Cli.ScreenshotResult {
+            Kind = "window-target",
+            Path = @"C:\Temp\editor-target.png",
+            Width = 320,
+            Height = 180,
+            MonitorIndex = 1,
+            Window = new global::DesktopManager.Cli.WindowResult {
+                Title = "DesktopManager Test App"
+            },
+            Geometry = new global::DesktopManager.Cli.WindowGeometryResult {
+                ClientWidth = 784,
+                ClientHeight = 560,
+                ClientOffsetLeft = 8,
+                ClientOffsetTop = 32
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ScreenshotCommands.WriteScreenshotResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "screenshot: window-target");
+        StringAssert.Contains(output, "- Path: C:\\Temp\\editor-target.png");
+        StringAssert.Contains(output, "- Size: 320x180");
+        StringAssert.Contains(output, "- Window: DesktopManager Test App");
+        StringAssert.Contains(output, "- Client: 784x560 at offset 8,32");
+        StringAssert.Contains(output, "- Monitor: 1");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures screenshot text output omits optional sections when only the basic capture result is available.
+    /// </summary>
+    public void WriteScreenshotResult_OmitsOptionalSectionsWhenUnset() {
+        var result = new global::DesktopManager.Cli.ScreenshotResult {
+            Kind = "desktop",
+            Path = @"C:\Temp\desktop.png",
+            Width = 1920,
+            Height = 1080
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.ScreenshotCommands.WriteScreenshotResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "screenshot: desktop");
+        StringAssert.Contains(output, "- Path: C:\\Temp\\desktop.png");
+        StringAssert.Contains(output, "- Size: 1920x1080");
+        Assert.IsFalse(output.Contains("- Window:"));
+        Assert.IsFalse(output.Contains("- Client:"));
+        Assert.IsFalse(output.Contains("- Monitor:"));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
+++ b/Sources/DesktopManager.Tests/ScreenshotServiceTests.cs
@@ -2,10 +2,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Diagnostics;
-#if NETFRAMEWORK
 using System.Windows.Forms;
-#endif
 using DesktopManager;
 
 namespace DesktopManager.Tests;
@@ -60,7 +57,7 @@ public class ScreenshotServiceTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        TestHelper.RequireInteractive();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using var bmp = ScreenshotService.CaptureScreen();
         Assert.IsNotNull(bmp);
@@ -89,7 +86,7 @@ public class ScreenshotServiceTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        TestHelper.RequireInteractive();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using var bmp = ScreenshotService.CaptureMonitor(index: 0);
         Assert.IsNotNull(bmp);
@@ -99,7 +96,6 @@ public class ScreenshotServiceTests {
 
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
     /// <summary>
     /// CaptureWindow size matches window bounds.
     /// </summary>
@@ -108,34 +104,17 @@ public class ScreenshotServiceTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("Screenshot Window Harness");
 
-        Process? process = null;
-        
-        try {
-            process = TestHelper.StartHiddenNotepad();
-            if (process == null) {
-                Assert.Inconclusive("Failed to start Notepad");
-            }
-
-            var manager = new WindowManager();
-            var window = manager.WaitWindow("*Notepad*", 10000);
-            Assert.IsNotNull(window);
-
-            Assert.IsTrue(MonitorNativeMethods.GetWindowRect(window.Handle, out RECT rect));
-            using var bmp = ScreenshotService.CaptureWindow(window.Handle);
-            Assert.AreEqual(rect.Right - rect.Left, bmp.Width);
-            Assert.AreEqual(rect.Bottom - rect.Top, bmp.Height);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.IsTrue(MonitorNativeMethods.GetWindowRect(harness.Window.Handle, out RECT rect));
+        using var bmp = ScreenshotService.CaptureWindow(harness.Window.Handle);
+        Assert.AreEqual(rect.Right - rect.Left, bmp.Width);
+        Assert.AreEqual(rect.Bottom - rect.Top, bmp.Height);
     }
 
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
     /// <summary>
     /// CaptureControl size matches control bounds.
     /// </summary>
@@ -144,31 +123,20 @@ public class ScreenshotServiceTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        using TextBox textBox = new() { Text = "Capture" };
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("Screenshot Control Harness", form => form.Controls.Add(textBox));
+        textBox.CreateControl();
+        Application.DoEvents();
 
-        Process? process = null;
-        
-        try {
-            process = TestHelper.StartHiddenNotepad();
-            if (process == null) {
-                Assert.Inconclusive("Failed to start Notepad");
-            }
+        var enumerator = new ControlEnumerator();
+        var controls = enumerator.EnumerateControls(harness.Window.Handle);
+        var edit = controls.FirstOrDefault(c => c.Handle == textBox.Handle);
+        Assert.IsNotNull(edit, "Edit control not found");
 
-            var manager = new WindowManager();
-            var window = manager.WaitWindow("*Notepad*", 10000);
-            var enumerator = new ControlEnumerator();
-            var controls = enumerator.EnumerateControls(window.Handle);
-            var edit = controls.FirstOrDefault(c => c.ClassName == "Edit");
-            Assert.IsNotNull(edit, "Edit control not found");
-
-            Assert.IsTrue(MonitorNativeMethods.GetWindowRect(edit.Handle, out RECT rect));
-            using var bmp = ScreenshotService.CaptureControl(edit.Handle);
-            Assert.AreEqual(rect.Right - rect.Left, bmp.Width);
-            Assert.AreEqual(rect.Bottom - rect.Top, bmp.Height);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.IsTrue(MonitorNativeMethods.GetWindowRect(edit.Handle, out RECT rect));
+        using var bmp = ScreenshotService.CaptureControl(edit.Handle);
+        Assert.AreEqual(rect.Right - rect.Left, bmp.Width);
+        Assert.AreEqual(rect.Bottom - rect.Top, bmp.Height);
     }
 }

--- a/Sources/DesktopManager.Tests/SnapshotCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/SnapshotCommandOutputTests.cs
@@ -1,0 +1,85 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI snapshot text output.
+/// </summary>
+public class SnapshotCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures path output writes the action, path, and scope when available.
+    /// </summary>
+    public void WritePathResult_WritesActionPathAndScope() {
+        var payload = new global::DesktopManager.Cli.NamedStateResult {
+            Action = "restore-snapshot",
+            Name = "Coding",
+            Path = @"C:\Snapshots\Coding.snapshot.json",
+            Scope = "windows"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.SnapshotCommands.WritePathResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "restore-snapshot: Coding");
+        StringAssert.Contains(output, "C:\\Snapshots\\Coding.snapshot.json");
+        StringAssert.Contains(output, "scope: windows");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures path output omits the scope line when no scope is present.
+    /// </summary>
+    public void WritePathResult_OmitsScopeWhenUnset() {
+        var payload = new global::DesktopManager.Cli.NamedStateResult {
+            Action = "save-snapshot",
+            Name = "Coding",
+            Path = @"C:\Snapshots\Coding.snapshot.json"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.SnapshotCommands.WritePathResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "save-snapshot: Coding");
+        Assert.IsFalse(output.Contains("scope:", System.StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures list output sorts names and shows the empty-state message when no snapshots are present.
+    /// </summary>
+    public void WriteSnapshotNames_SortsNamesAndSupportsEmptyState() {
+        using var populatedWriter = new StringWriter();
+
+        int populatedExitCode = global::DesktopManager.Cli.SnapshotCommands.WriteSnapshotNames(
+            new List<string> { "zeta", "Alpha", "beta" },
+            populatedWriter);
+
+        string populatedOutput = populatedWriter.ToString();
+        int alphaIndex = populatedOutput.IndexOf("Alpha", System.StringComparison.Ordinal);
+        int betaIndex = populatedOutput.IndexOf("beta", System.StringComparison.Ordinal);
+        int zetaIndex = populatedOutput.IndexOf("zeta", System.StringComparison.Ordinal);
+
+        Assert.AreEqual(0, populatedExitCode);
+        Assert.IsTrue(alphaIndex >= 0);
+        Assert.IsTrue(betaIndex > alphaIndex);
+        Assert.IsTrue(zetaIndex > betaIndex);
+
+        using var emptyWriter = new StringWriter();
+
+        int emptyExitCode = global::DesktopManager.Cli.SnapshotCommands.WriteSnapshotNames(Array.Empty<string>(), emptyWriter);
+
+        Assert.AreEqual(0, emptyExitCode);
+        StringAssert.Contains(emptyWriter.ToString(), "No named snapshots found.");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/TargetAndScreenshotMappingTests.cs
+++ b/Sources/DesktopManager.Tests/TargetAndScreenshotMappingTests.cs
@@ -1,0 +1,146 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI target result mapping helpers.
+/// </summary>
+public class TargetAndScreenshotMappingTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures resolved window target mapping preserves geometry, area, and target metadata.
+    /// </summary>
+    public void MapResolvedWindowTarget_MapsGeometryAndScreenArea() {
+        var resolvedTarget = new DesktopResolvedWindowTarget {
+            Name = "EditorCenter",
+            Definition = new DesktopWindowTargetDefinition {
+                Description = "Editor center",
+                XRatio = 0.5,
+                YRatio = 0.5,
+                WidthRatio = 0.4,
+                HeightRatio = 0.3,
+                ClientArea = true
+            },
+            Geometry = new DesktopWindowGeometry {
+                Window = new WindowInfo {
+                    Title = "DesktopManager Test App",
+                    Handle = new IntPtr(0x1234),
+                    ProcessId = 321,
+                    ThreadId = 654,
+                    IsVisible = true,
+                    IsTopMost = false,
+                    State = WindowState.Normal,
+                    Left = 10,
+                    Top = 20,
+                    Right = 810,
+                    Bottom = 620,
+                    MonitorIndex = 1,
+                    MonitorDeviceName = @"\\.\\DISPLAY1"
+                },
+                WindowLeft = 10,
+                WindowTop = 20,
+                WindowWidth = 800,
+                WindowHeight = 600,
+                ClientLeft = 18,
+                ClientTop = 52,
+                ClientWidth = 784,
+                ClientHeight = 560,
+                ClientOffsetLeft = 8,
+                ClientOffsetTop = 32
+            },
+            RelativeX = 200,
+            RelativeY = 150,
+            RelativeWidth = 320,
+            RelativeHeight = 180,
+            ScreenX = 210,
+            ScreenY = 170,
+            ScreenWidth = 320,
+            ScreenHeight = 180
+        };
+
+        global::DesktopManager.Cli.ResolvedWindowTargetResult result = global::DesktopManager.Cli.DesktopOperations.MapResolvedWindowTarget(resolvedTarget);
+
+        Assert.AreEqual("EditorCenter", result.Name);
+        Assert.AreEqual("Editor center", result.Target.Description);
+        Assert.AreEqual(0.5d, result.Target.XRatio);
+        Assert.AreEqual(0.4d, result.Target.WidthRatio);
+        Assert.IsTrue(result.Target.ClientArea);
+        Assert.AreEqual("DesktopManager Test App", result.Window.Title);
+        Assert.AreEqual("0x1234", result.Window.Handle);
+        Assert.AreEqual(800, result.Geometry.WindowWidth);
+        Assert.AreEqual(560, result.Geometry.ClientHeight);
+        Assert.AreEqual(200, result.RelativeX);
+        Assert.AreEqual(150, result.RelativeY);
+        Assert.AreEqual(320, result.RelativeWidth);
+        Assert.AreEqual(180, result.RelativeHeight);
+        Assert.AreEqual(210, result.ScreenX);
+        Assert.AreEqual(170, result.ScreenY);
+        Assert.AreEqual(320, result.ScreenWidth);
+        Assert.AreEqual(180, result.ScreenHeight);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures resolved control target mapping preserves target definition, parent window, and control metadata.
+    /// </summary>
+    public void MapResolvedControlTarget_MapsTargetWindowAndControl() {
+        var resolvedTarget = new DesktopResolvedControlTarget {
+            Name = "CommandBar",
+            Definition = new DesktopControlTargetDefinition {
+                Description = "Command bar",
+                AutomationIdPattern = "CommandBarTextBox",
+                ControlTypePattern = "Edit",
+                SupportsForegroundInputFallback = true,
+                UseUiAutomation = true,
+                EnsureForegroundWindow = true
+            },
+            Window = new WindowInfo {
+                Title = "DesktopManager Command Surface",
+                Handle = new IntPtr(0x2222),
+                ProcessId = 444,
+                ThreadId = 555,
+                Left = 100,
+                Top = 200,
+                Right = 900,
+                Bottom = 700,
+                MonitorIndex = 2,
+                MonitorDeviceName = @"\\.\\DISPLAY2"
+            },
+            Control = new WindowControlInfo {
+                Handle = IntPtr.Zero,
+                ClassName = "HwndWrapper[DesktopManager.TestApp;;123456]",
+                Id = 0,
+                Source = WindowControlSource.UiAutomation,
+                AutomationId = "CommandBarTextBox",
+                ControlType = "Edit",
+                FrameworkId = "WPF",
+                Text = "DesktopManager",
+                Value = "DesktopManager",
+                SupportsForegroundInputFallback = true,
+                IsKeyboardFocusable = true,
+                IsEnabled = true
+            }
+        };
+
+        global::DesktopManager.Cli.ResolvedControlTargetResult result = global::DesktopManager.Cli.DesktopOperations.MapResolvedControlTarget(resolvedTarget);
+
+        Assert.AreEqual("CommandBar", result.Name);
+        Assert.AreEqual("Command bar", result.Target.Description);
+        Assert.AreEqual("CommandBarTextBox", result.Target.AutomationIdPattern);
+        Assert.AreEqual("Edit", result.Target.ControlTypePattern);
+        Assert.AreEqual(true, result.Target.SupportsForegroundInputFallback);
+        Assert.IsTrue(result.Target.UseUiAutomation);
+        Assert.IsTrue(result.Target.EnsureForegroundWindow);
+        Assert.AreEqual("DesktopManager Command Surface", result.Window.Title);
+        Assert.AreEqual("0x2222", result.Window.Handle);
+        Assert.AreEqual("HwndWrapper[DesktopManager.TestApp;;123456]", result.Control.ClassName);
+        Assert.AreEqual("0x0", result.Control.Handle);
+        Assert.AreEqual("UiAutomation", result.Control.Source);
+        Assert.AreEqual("CommandBarTextBox", result.Control.AutomationId);
+        Assert.AreEqual("Edit", result.Control.ControlType);
+        Assert.AreEqual("WPF", result.Control.FrameworkId);
+        Assert.AreEqual("DesktopManager", result.Control.Value);
+        Assert.AreEqual("DesktopManager Command Surface", result.Control.ParentWindow.Title);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/TargetCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/TargetCommandOutputTests.cs
@@ -1,0 +1,164 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI target text output.
+/// </summary>
+public class TargetCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures save output writes the target name and persisted path.
+    /// </summary>
+    public void WriteSavedTargetResult_WritesTargetNameAndPath() {
+        var result = new global::DesktopManager.Cli.WindowTargetResult {
+            Name = "EditorCenter",
+            Path = @"C:\Targets\EditorCenter.json"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.TargetCommands.WriteSavedTargetResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "save: EditorCenter");
+        StringAssert.Contains(output, "C:\\Targets\\EditorCenter.json");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target get output includes the configured coordinates and optional description.
+    /// </summary>
+    public void WriteTargetResult_WritesRichTargetSummary() {
+        var result = new global::DesktopManager.Cli.WindowTargetResult {
+            Name = "EditorCenter",
+            Path = @"C:\Targets\EditorCenter.json",
+            Target = new global::DesktopManager.Cli.WindowTargetDefinitionResult {
+                ClientArea = true,
+                X = 20,
+                Y = 30,
+                XRatio = 0.5d,
+                YRatio = 0.25d,
+                Width = 640,
+                Height = 480,
+                WidthRatio = 0.4d,
+                HeightRatio = 0.3d,
+                Description = "Centered editor target"
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.TargetCommands.WriteTargetResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "EditorCenter");
+        StringAssert.Contains(output, "- Path: C:\\Targets\\EditorCenter.json");
+        StringAssert.Contains(output, "- ClientArea: Yes");
+        StringAssert.Contains(output, "- X: 20");
+        StringAssert.Contains(output, "- Y: 30");
+        StringAssert.Contains(output, "- XRatio: 0.5");
+        StringAssert.Contains(output, "- YRatio: 0.25");
+        StringAssert.Contains(output, "- Width: 640");
+        StringAssert.Contains(output, "- Height: 480");
+        StringAssert.Contains(output, "- WidthRatio: 0.4");
+        StringAssert.Contains(output, "- HeightRatio: 0.3");
+        StringAssert.Contains(output, "- Description: Centered editor target");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target list output sorts names and shows the empty-state message when no targets are present.
+    /// </summary>
+    public void WriteTargetNames_SortsNamesAndSupportsEmptyState() {
+        using var populatedWriter = new StringWriter();
+
+        int populatedExitCode = global::DesktopManager.Cli.TargetCommands.WriteTargetNames(
+            new List<string> { "zeta", "Alpha", "beta" },
+            populatedWriter);
+
+        string populatedOutput = populatedWriter.ToString();
+        int alphaIndex = populatedOutput.IndexOf("Alpha", System.StringComparison.Ordinal);
+        int betaIndex = populatedOutput.IndexOf("beta", System.StringComparison.Ordinal);
+        int zetaIndex = populatedOutput.IndexOf("zeta", System.StringComparison.Ordinal);
+
+        Assert.AreEqual(0, populatedExitCode);
+        Assert.IsTrue(alphaIndex >= 0);
+        Assert.IsTrue(betaIndex > alphaIndex);
+        Assert.IsTrue(zetaIndex > betaIndex);
+
+        using var emptyWriter = new StringWriter();
+
+        int emptyExitCode = global::DesktopManager.Cli.TargetCommands.WriteTargetNames(Array.Empty<string>(), emptyWriter);
+
+        Assert.AreEqual(0, emptyExitCode);
+        StringAssert.Contains(emptyWriter.ToString(), "No named targets found.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures resolved target output includes optional area only when the resolved dimensions are available.
+    /// </summary>
+    public void WriteResolvedTargets_WritesRichAndSparseResolvedTargetSummaries() {
+        var results = new List<global::DesktopManager.Cli.ResolvedWindowTargetResult> {
+            new() {
+                Name = "EditorCenter",
+                Target = new global::DesktopManager.Cli.WindowTargetDefinitionResult {
+                    ClientArea = true
+                },
+                Window = new global::DesktopManager.Cli.WindowResult {
+                    Title = "DesktopManager Test App",
+                    Handle = "0x1234"
+                },
+                RelativeX = 200,
+                RelativeY = 150,
+                ScreenX = 210,
+                ScreenY = 170,
+                ScreenWidth = 320,
+                ScreenHeight = 180
+            },
+            new() {
+                Name = "EditorAnchor",
+                Target = new global::DesktopManager.Cli.WindowTargetDefinitionResult {
+                    ClientArea = false
+                },
+                Window = new global::DesktopManager.Cli.WindowResult {
+                    Title = "DesktopManager Command Surface",
+                    Handle = "0x5678"
+                },
+                RelativeX = 12,
+                RelativeY = 18,
+                ScreenX = 112,
+                ScreenY = 118
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.TargetCommands.WriteResolvedTargets(results, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "EditorCenter: DesktopManager Test App (0x1234)");
+        StringAssert.Contains(output, "- Relative: 200,150");
+        StringAssert.Contains(output, "- Screen: 210,170");
+        StringAssert.Contains(output, "- Area: 320x180");
+        StringAssert.Contains(output, "- ClientArea: Yes");
+        StringAssert.Contains(output, "EditorAnchor: DesktopManager Command Surface (0x5678)");
+        StringAssert.Contains(output, "- Relative: 12,18");
+        StringAssert.Contains(output, "- Screen: 112,118");
+        StringAssert.Contains(output, "- ClientArea: No");
+
+        int firstAreaIndex = output.IndexOf("- Area: 320x180", System.StringComparison.Ordinal);
+        int secondTargetIndex = output.IndexOf("EditorAnchor: DesktopManager Command Surface (0x5678)", System.StringComparison.Ordinal);
+        Assert.IsTrue(firstAreaIndex >= 0);
+        Assert.IsTrue(secondTargetIndex > firstAreaIndex);
+        Assert.AreEqual(-1, output.IndexOf("- Area:", secondTargetIndex, System.StringComparison.Ordinal));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/TestHelper.cs
+++ b/Sources/DesktopManager.Tests/TestHelper.cs
@@ -37,7 +37,7 @@ internal static class TestHelper {
         window = null;
 
         try {
-            if (ShouldSkipUITests()) {
+            if (ShouldSkipExternalApplicationUiTests()) {
                 return false;
             }
 
@@ -131,12 +131,64 @@ internal static class TestHelper {
     }
 
     /// <summary>
+    /// Determines if tests that launch live external desktop applications should be skipped.
+    /// </summary>
+    public static bool ShouldSkipExternalApplicationUiTests() {
+        if (ShouldSkipUITests()) {
+            return true;
+        }
+
+        if (Environment.GetEnvironmentVariable("RUN_EXTERNAL_UI_TESTS") == "true" ||
+            Environment.GetEnvironmentVariable("DESKTOPMANAGER_RUN_EXTERNAL_UI_TESTS") == "true") {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Skips UI-impacting tests unless explicitly enabled.
     /// </summary>
     public static void RequireInteractive() {
         if (ShouldSkipUITests()) {
             Assert.Inconclusive("UI tests skipped by default. Set RUN_UI_TESTS=true (or DESKTOPMANAGER_RUN_UI_TESTS=true) to run.");
         }
+    }
+
+    /// <summary>
+    /// Skips deterministic WinForms harness tests when no interactive desktop session is available.
+    /// </summary>
+    public static void RequireInteractiveDesktopSession() {
+        if (!Environment.UserInteractive) {
+            Assert.Inconclusive("Test requires an interactive Windows desktop session.");
+        }
+    }
+
+    /// <summary>
+    /// Skips owned-window UI tests unless UI execution is explicitly enabled and an interactive desktop is available.
+    /// </summary>
+    public static void RequireOwnedWindowUiTests() {
+        RequireInteractive();
+        RequireInteractiveDesktopSession();
+    }
+
+    /// <summary>
+    /// Skips tests that launch real desktop applications unless explicitly enabled.
+    /// </summary>
+    public static void RequireExternalApplicationUiTests() {
+        RequireInteractive();
+        RequireInteractiveDesktopSession();
+        if (ShouldSkipExternalApplicationUiTests()) {
+            Assert.Inconclusive("Live external-application UI tests skipped. Set RUN_EXTERNAL_UI_TESTS=true (or DESKTOPMANAGER_RUN_EXTERNAL_UI_TESTS=true) to run.");
+        }
+    }
+
+    /// <summary>
+    /// Skips desktop-changing tests that also launch external applications unless both gates are explicitly enabled.
+    /// </summary>
+    public static void RequireExternalDesktopApplicationTests() {
+        RequireDesktopChanges();
+        RequireExternalApplicationUiTests();
     }
 
     /// <summary>
@@ -188,6 +240,19 @@ internal static class TestHelper {
         } finally {
             UntrackProcess(process);
             process.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Tracks an externally launched test process by identifier.
+    /// </summary>
+    public static void TrackProcessId(int processId) {
+        try {
+            if (processId > 0) {
+                StartedProcessIds.TryAdd(processId, 0);
+            }
+        } catch {
+            // Ignore tracking failures
         }
     }
 

--- a/Sources/DesktopManager.Tests/UiAutomationControlServiceTests.cs
+++ b/Sources/DesktopManager.Tests/UiAutomationControlServiceTests.cs
@@ -203,11 +203,50 @@ public class UiAutomationControlServiceTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures native-handle controls do not advertise foreground fallback because they should use direct Win32 routing.
+    /// </summary>
+    public void SupportsForegroundFallback_NativeHandleControl_ReturnsFalse() {
+        bool supported = UiAutomationControlService.SupportsForegroundFallback(
+            hasNativeHandle: true,
+            isKeyboardFocusable: true,
+            isEnabled: true,
+            controlType: "Edit",
+            className: "TextBox");
+
+        Assert.IsFalse(supported);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures explicit non-focusable metadata disables foreground fallback even for editable-looking controls.
+    /// </summary>
+    public void SupportsForegroundFallback_NotKeyboardFocusable_ReturnsFalse() {
+        bool supported = UiAutomationControlService.SupportsForegroundFallback(
+            hasNativeHandle: false,
+            isKeyboardFocusable: false,
+            isEnabled: true,
+            controlType: "Edit",
+            className: "TextBox");
+
+        Assert.IsFalse(supported);
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures obvious editable control shapes are detected for modern-app fallback heuristics.
     /// </summary>
     public void IsLikelyEditableControl_EditAndTextBoxShapes_ReturnTrue() {
         Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl("Edit", string.Empty));
         Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl("Document", string.Empty));
+        Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl("ComboBox", string.Empty));
         Assert.IsTrue(UiAutomationControlService.IsLikelyEditableControl(string.Empty, "InputTextBox"));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures non-editable control shapes are not treated as safe foreground-fallback targets by default.
+    /// </summary>
+    public void IsLikelyEditableControl_ButtonShape_ReturnsFalse() {
+        Assert.IsFalse(UiAutomationControlService.IsLikelyEditableControl("Button", "Button"));
     }
 }

--- a/Sources/DesktopManager.Tests/WinFormsWindowHarness.cs
+++ b/Sources/DesktopManager.Tests/WinFormsWindowHarness.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace DesktopManager.Tests;
+
+/// <summary>
+/// Creates an explicit WinForms window for mutation-focused tests.
+/// </summary>
+internal sealed class WinFormsWindowHarness : IDisposable {
+    private WinFormsWindowHarness(Form form, WindowInfo window) {
+        Form = form;
+        Window = window;
+    }
+
+    public Form Form { get; }
+
+    public WindowInfo Window { get; }
+
+    public static WinFormsWindowHarness Create(string title, int width = 320, int height = 240) {
+        Form form = new() {
+            Text = title,
+            Width = width,
+            Height = height,
+            Left = 40,
+            Top = 40,
+            StartPosition = FormStartPosition.Manual,
+            ShowInTaskbar = false
+        };
+
+        form.Show();
+        form.CreateControl();
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        WindowInfo? window = new WindowManager()
+            .GetWindows(includeHidden: true)
+            .FirstOrDefault(candidate => candidate.Handle == form.Handle);
+        if (window == null) {
+            form.Dispose();
+            throw new InvalidOperationException("Failed to resolve the WinForms harness window.");
+        }
+
+        return new WinFormsWindowHarness(form, window);
+    }
+
+    public static WinFormsWindowHarness Create(string title, Action<Form> configure, int width = 320, int height = 240) {
+        if (configure == null) {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        Form form = new() {
+            Text = title,
+            Width = width,
+            Height = height,
+            Left = 40,
+            Top = 40,
+            StartPosition = FormStartPosition.Manual,
+            ShowInTaskbar = false
+        };
+
+        configure(form);
+        form.Show();
+        form.CreateControl();
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        WindowInfo? window = new WindowManager()
+            .GetWindows(includeHidden: true)
+            .FirstOrDefault(candidate => candidate.Handle == form.Handle);
+        if (window == null) {
+            form.Dispose();
+            throw new InvalidOperationException("Failed to resolve the WinForms harness window.");
+        }
+
+        return new WinFormsWindowHarness(form, window);
+    }
+
+    public void Dispose() {
+        try {
+            Form.Close();
+            Application.DoEvents();
+        } catch {
+            // Ignore close failures during test cleanup.
+        } finally {
+            Form.Dispose();
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
+++ b/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -18,36 +18,26 @@ public class WindowActivationPositioningTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        var original = manager.GetWindowPosition(harness.Window);
 
-            var manager = new WindowManager();
-            var original = manager.GetWindowPosition(window);
+        int newWidth = original.Width + 10;
+        int newHeight = original.Height + 10;
+        manager.SetWindowPosition(harness.Window, original.Left, original.Top, newWidth, newHeight);
+        Application.DoEvents();
+        var resized = manager.GetWindowPosition(harness.Window);
 
-            int newWidth = original.Width + 10;
-            int newHeight = original.Height + 10;
-            manager.SetWindowPosition(window, original.Left, original.Top, newWidth, newHeight);
-            var resized = manager.GetWindowPosition(window);
+        int widthTolerance = Math.Abs(newWidth - resized.Width);
+        int heightTolerance = Math.Abs(newHeight - resized.Height);
 
-            // Allow some tolerance for window frame/border differences in different environments
-            int widthTolerance = Math.Abs(newWidth - resized.Width);
-            int heightTolerance = Math.Abs(newHeight - resized.Height);
-
-            Assert.IsTrue(widthTolerance <= 20,
-                $"Width resize failed. Expected: {newWidth}, Actual: {resized.Width}, Tolerance: {widthTolerance}");
-            Assert.IsTrue(heightTolerance <= 20,
-                $"Height resize failed. Expected: {newHeight}, Actual: {resized.Height}, Tolerance: {heightTolerance}");
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.IsTrue(widthTolerance <= 20,
+            $"Width resize failed. Expected: {newWidth}, Actual: {resized.Width}, Tolerance: {widthTolerance}");
+        Assert.IsTrue(heightTolerance <= 20,
+            $"Height resize failed. Expected: {newHeight}, Actual: {resized.Height}, Tolerance: {heightTolerance}");
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/WindowAndTargetCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/WindowAndTargetCriteriaTests.cs
@@ -1,0 +1,125 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window and target criteria mapping.
+/// </summary>
+public class WindowAndTargetCriteriaTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures window command criteria map selector flags and keep include-empty disabled by default for list scenarios.
+    /// </summary>
+    public void WindowCreateCriteria_MapsFlagsAndRespectsListDefault() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "list",
+            "--title", "*Editor*",
+            "--process", "DesktopManager.TestApp",
+            "--class", "TestWindowClass",
+            "--pid", "321",
+            "--handle", "0x1234",
+            "--active",
+            "--include-hidden",
+            "--exclude-cloaked",
+            "--exclude-owned",
+            "--all"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.WindowCommands.CreateCriteria(arguments, includeEmptyDefault: false);
+
+        Assert.AreEqual("*Editor*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("TestWindowClass", criteria.ClassNamePattern);
+        Assert.AreEqual(321, criteria.ProcessId);
+        Assert.AreEqual("0x1234", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsFalse(criteria.IncludeCloaked);
+        Assert.IsFalse(criteria.IncludeOwned);
+        Assert.IsFalse(criteria.IncludeEmptyTitles);
+        Assert.IsTrue(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window command criteria honor explicit include-empty and default wildcard values.
+    /// </summary>
+    public void WindowCreateCriteria_UsesWildcardDefaultsAndIncludeEmptyFlag() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "exists",
+            "--include-empty"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.WindowCommands.CreateCriteria(arguments, includeEmptyDefault: false);
+
+        Assert.AreEqual("*", criteria.TitlePattern);
+        Assert.AreEqual("*", criteria.ProcessNamePattern);
+        Assert.AreEqual("*", criteria.ClassNamePattern);
+        Assert.IsFalse(criteria.IncludeHidden);
+        Assert.IsTrue(criteria.IncludeCloaked);
+        Assert.IsTrue(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsFalse(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target command criteria use include-empty by default for resolve scenarios and honor selector flags.
+    /// </summary>
+    public void TargetCreateCriteria_MapsFlagsAndUsesResolveDefault() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "target",
+            "resolve",
+            "--title", "*Command*",
+            "--process", "DesktopManager.TestApp",
+            "--class", "Chrome_WidgetWin_1",
+            "--pid", "654",
+            "--handle", "0x5678",
+            "--active",
+            "--include-hidden",
+            "--exclude-cloaked",
+            "--exclude-owned",
+            "--all"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.TargetCommands.CreateCriteria(arguments, includeEmptyDefault: true);
+
+        Assert.AreEqual("*Command*", criteria.TitlePattern);
+        Assert.AreEqual("DesktopManager.TestApp", criteria.ProcessNamePattern);
+        Assert.AreEqual("Chrome_WidgetWin_1", criteria.ClassNamePattern);
+        Assert.AreEqual(654, criteria.ProcessId);
+        Assert.AreEqual("0x5678", criteria.Handle);
+        Assert.IsTrue(criteria.Active);
+        Assert.IsTrue(criteria.IncludeHidden);
+        Assert.IsFalse(criteria.IncludeCloaked);
+        Assert.IsFalse(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsTrue(criteria.All);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures target command criteria fall back to wildcard defaults when no selectors are provided.
+    /// </summary>
+    public void TargetCreateCriteria_UsesWildcardDefaults() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "target",
+            "resolve"
+        });
+
+        global::DesktopManager.Cli.WindowSelectionCriteria criteria = global::DesktopManager.Cli.TargetCommands.CreateCriteria(arguments, includeEmptyDefault: true);
+
+        Assert.AreEqual("*", criteria.TitlePattern);
+        Assert.AreEqual("*", criteria.ProcessNamePattern);
+        Assert.AreEqual("*", criteria.ClassNamePattern);
+        Assert.IsFalse(criteria.Active);
+        Assert.IsFalse(criteria.IncludeHidden);
+        Assert.IsTrue(criteria.IncludeCloaked);
+        Assert.IsTrue(criteria.IncludeOwned);
+        Assert.IsTrue(criteria.IncludeEmptyTitles);
+        Assert.IsFalse(criteria.All);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowAssertionCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/WindowAssertionCommandOutputTests.cs
@@ -1,0 +1,94 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window assertion and wait text output.
+/// </summary>
+public class WindowAssertionCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures window wait text output includes elapsed timing and each matched window.
+    /// </summary>
+    public void WriteWaitResult_WritesMatchedWindows() {
+        var result = new global::DesktopManager.Cli.WaitForWindowResult {
+            ElapsedMilliseconds = 350,
+            Count = 2,
+            Windows = new[] {
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Editor",
+                    ProcessId = 101
+                },
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Terminal",
+                    ProcessId = 202
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteWaitResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "wait: 2 window(s) after 350ms");
+        StringAssert.Contains(output, "- Editor [PID 101]");
+        StringAssert.Contains(output, "- Terminal [PID 202]");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window assertion text output includes active-window context and matched windows.
+    /// </summary>
+    public void WriteAssertionResult_WritesActiveWindowAndMatches() {
+        var payload = new global::DesktopManager.Cli.WindowAssertionResult {
+            Matched = true,
+            Count = 1,
+            ActiveWindow = new global::DesktopManager.Cli.WindowResult {
+                Title = "Editor",
+                ProcessId = 101
+            },
+            Windows = new[] {
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Editor",
+                    ProcessId = 101
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteAssertionResult(payload, "Active window matches.", "Active window does not match.", writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "Active window matches.");
+        StringAssert.Contains(output, "Active: Editor [PID 101]");
+        StringAssert.Contains(output, "- Editor [PID 101]");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window assertion text output omits optional sections when no active or matched window is available.
+    /// </summary>
+    public void WriteAssertionResult_WritesFailureWithoutOptionalSections() {
+        var payload = new global::DesktopManager.Cli.WindowAssertionResult {
+            Matched = false,
+            Count = 0
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteAssertionResult(payload, "Matching window found.", "No matching windows found.", writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "No matching windows found.");
+        Assert.IsFalse(output.Contains("Active:"));
+        Assert.IsFalse(output.Contains("[PID"));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowChildEnumerationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowChildEnumerationTests.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -16,24 +16,25 @@ public class WindowChildEnumerationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireOwnedWindowUiTests();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using TextBox textBox = new() { Text = "Child" };
+        using Button button = new() { Text = "Go" };
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("Child Enumeration Harness", form => {
+            form.Controls.Add(textBox);
+            form.Controls.Add(button);
+        });
+        textBox.CreateControl();
+        button.CreateControl();
+        Application.DoEvents();
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
-
-            var manager = new WindowManager();
-            var children = manager.GetChildWindows(window, includeHidden: true);
-            if (children.Count == 0) {
-                Assert.Inconclusive("No child windows were returned for the test window");
-            }
-        } finally {
-            TestHelper.SafeKillProcess(process);
+        var manager = new WindowManager();
+        var children = manager.GetChildWindows(harness.Window, includeHidden: true);
+        if (children.Count == 0) {
+            Assert.Inconclusive("No child windows were returned for the test window");
         }
+
+        Assert.IsTrue(children.Exists(child => child.Handle == textBox.Handle));
+        Assert.IsTrue(children.Exists(child => child.Handle == button.Handle));
     }
 }

--- a/Sources/DesktopManager.Tests/WindowCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/WindowCommandOutputTests.cs
@@ -1,0 +1,84 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window command text output.
+/// </summary>
+public class WindowCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures window mutation text output includes target, artifact, warning, and matched window details.
+    /// </summary>
+    public void WriteWindowMutationResult_WritesRichMutationSummary() {
+        var payload = new global::DesktopManager.Cli.WindowChangeResult {
+            Action = "move-window",
+            Success = true,
+            Count = 2,
+            ElapsedMilliseconds = 145,
+            SafetyMode = "background",
+            TargetName = "EditorCenter",
+            TargetKind = "window-target",
+            BeforeScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            AfterScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult(),
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            ArtifactWarnings = new[] { "Capture path normalized." },
+            Windows = new[] {
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Editor",
+                    ProcessId = 100
+                },
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Terminal",
+                    ProcessId = 101
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteWindowMutationResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "move-window: 2 window(s) success=True safety=background elapsed-ms=145");
+        StringAssert.Contains(output, "target: window-target EditorCenter");
+        StringAssert.Contains(output, "artifacts: before=1 after=2");
+        StringAssert.Contains(output, "warning: Capture path normalized.");
+        StringAssert.Contains(output, "- Editor [PID 100]");
+        StringAssert.Contains(output, "- Terminal [PID 101]");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window mutation text output omits optional sections when they are empty.
+    /// </summary>
+    public void WriteWindowMutationResult_OmitsEmptyOptionalSections() {
+        var payload = new global::DesktopManager.Cli.WindowChangeResult {
+            Action = "focus-window",
+            Success = false,
+            Count = 0,
+            ElapsedMilliseconds = 33,
+            SafetyMode = "foreground"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteWindowMutationResult(payload, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "focus-window: 0 window(s) success=False safety=foreground elapsed-ms=33");
+        Assert.IsFalse(output.Contains("target:"));
+        Assert.IsFalse(output.Contains("artifacts:"));
+        Assert.IsFalse(output.Contains("warning:"));
+        Assert.IsFalse(output.Contains("[PID"));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowControlCheckTests.cs
+++ b/Sources/DesktopManager.Tests/WindowControlCheckTests.cs
@@ -1,42 +1,64 @@
 using System;
 using System.Runtime.InteropServices;
-#if NETFRAMEWORK
+using System.Threading;
 using System.Windows.Forms;
-#endif
 
 namespace DesktopManager.Tests;
 
 [TestClass]
 public class WindowControlCheckTests {
+    private const int WsChild = 0x40000000;
+    private const int WsVisible = 0x10000000;
+    private const int BsAutoCheckBox = 0x00000003;
+
     [TestMethod]
     public void GetAndSetCheckState_Toggles() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        TestHelper.RequireInteractive();
-#if NETFRAMEWORK
-        using Form form = new();
-        using CheckBox box = new() { Text = "Sample" };
-        form.Controls.Add(box);
-        form.Show();
-        box.CreateControl();
+        TestHelper.RequireOwnedWindowUiTests();
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("Check State Harness");
+        IntPtr checkBoxHandle = MonitorNativeMethods.CreateWindowExW(
+            0,
+            "Button",
+            "Sample",
+            WsChild | WsVisible | BsAutoCheckBox,
+            10,
+            10,
+            120,
+            24,
+            harness.Form.Handle,
+            new IntPtr(1001),
+            IntPtr.Zero,
+            IntPtr.Zero);
+        if (checkBoxHandle == IntPtr.Zero) {
+            Assert.Inconclusive("Failed to create a native checkbox control for testing.");
+        }
 
-        WindowControlInfo info = new() {
-            Handle = box.Handle,
-            ClassName = "Button",
-            Id = MonitorNativeMethods.GetDlgCtrlID(box.Handle),
-            Text = box.Text
-        };
+        Application.DoEvents();
+        Thread.Sleep(100);
 
-        Assert.IsFalse(WindowControlService.GetCheckState(info));
-        WindowControlService.SetCheckState(info, true);
-        Assert.IsTrue(WindowControlService.GetCheckState(info));
-        WindowControlService.SetCheckState(info, false);
-        Assert.IsFalse(WindowControlService.GetCheckState(info));
-        form.Close();
-#else
-        Assert.Inconclusive("Test only runs on .NET Framework");
-#endif
+        try {
+            WindowControlInfo info = new() {
+                ParentWindowHandle = harness.Form.Handle,
+                Handle = checkBoxHandle,
+                ClassName = "Button",
+                Id = MonitorNativeMethods.GetDlgCtrlID(checkBoxHandle),
+                Text = "Sample"
+            };
+
+            Assert.IsFalse(WindowControlService.GetCheckState(info));
+            WindowControlService.SetCheckState(info, true);
+            Application.DoEvents();
+            Thread.Sleep(100);
+            Assert.IsTrue(WindowControlService.GetCheckState(info));
+            WindowControlService.SetCheckState(info, false);
+            Application.DoEvents();
+            Thread.Sleep(100);
+            Assert.IsFalse(WindowControlService.GetCheckState(info));
+        } finally {
+            MonitorNativeMethods.DestroyWindow(checkBoxHandle);
+        }
     }
 }

--- a/Sources/DesktopManager.Tests/WindowControlMessageTests.cs
+++ b/Sources/DesktopManager.Tests/WindowControlMessageTests.cs
@@ -1,0 +1,114 @@
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for direct Win32 control messaging helpers.
+/// </summary>
+public class WindowControlMessageTests {
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures printable key sends append buffered text to a standard edit control.
+    /// </summary>
+    public void WindowControlService_SendKeys_AppendsPrintableTextToTextBox() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form form = new() { Text = "Message Test Form", ShowInTaskbar = false };
+        using TextBox textBox = new();
+        form.Controls.Add(textBox);
+        form.Show();
+        textBox.CreateControl();
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        WindowControlInfo control = new() {
+            ParentWindowHandle = form.Handle,
+            Handle = textBox.Handle,
+            ClassName = "Edit",
+            Id = MonitorNativeMethods.GetDlgCtrlID(textBox.Handle),
+            Text = textBox.Text
+        };
+
+        WindowControlService.SendKeys(control, VirtualKey.VK_H, VirtualKey.VK_I, VirtualKey.VK_SPACE, VirtualKey.VK_1, VirtualKey.VK_2);
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        Assert.AreEqual("HI 12", textBox.Text);
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures direct control text updates still work for standard edit controls.
+    /// </summary>
+    public void WindowControlService_SetText_UpdatesTextBoxText() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form form = new() { Text = "SetText Test Form", ShowInTaskbar = false };
+        using TextBox textBox = new();
+        form.Controls.Add(textBox);
+        form.Show();
+        textBox.CreateControl();
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        WindowControlInfo control = new() {
+            ParentWindowHandle = form.Handle,
+            Handle = textBox.Handle,
+            ClassName = "Edit",
+            Id = MonitorNativeMethods.GetDlgCtrlID(textBox.Handle),
+            Text = textBox.Text
+        };
+
+        WindowControlService.SetText(control, "DesktopManager");
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        Assert.AreEqual("DesktopManager", textBox.Text);
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures control enumeration includes parent window metadata and shared capabilities.
+    /// </summary>
+    public void ControlEnumerator_EnumerateControls_PopulatesParentWindowMetadata() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form form = new() { Text = "Enumerator Test Form", ShowInTaskbar = false };
+        using TextBox textBox = new() { Text = "sample" };
+        using Button button = new() { Text = "Go" };
+        form.Controls.Add(textBox);
+        form.Controls.Add(button);
+        form.Show();
+        textBox.CreateControl();
+        button.CreateControl();
+        Application.DoEvents();
+        Thread.Sleep(100);
+
+        ControlEnumerator enumerator = new();
+        var controls = enumerator.EnumerateControls(form.Handle);
+
+        WindowControlInfo? textBoxControl = controls.FirstOrDefault(control => control.Handle == textBox.Handle);
+        Assert.IsNotNull(textBoxControl, "Expected the TextBox control to be enumerated.");
+        Assert.AreEqual(form.Handle, textBoxControl.ParentWindowHandle);
+        Assert.IsTrue(textBoxControl.SupportsBackgroundClick);
+        Assert.IsTrue(textBoxControl.SupportsBackgroundText);
+        Assert.IsTrue(textBoxControl.SupportsBackgroundKeys);
+        Assert.AreEqual(textBox.Text, textBoxControl.Value);
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowControlServiceTests.cs
+++ b/Sources/DesktopManager.Tests/WindowControlServiceTests.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -15,40 +14,38 @@ public class WindowControlServiceTests {
     
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
     public void ControlClick_CancelButton_ClosesDialog() {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        using Form targetForm = new() { Text = "Target Form", ShowInTaskbar = false };
+        using Button cancelButton = new() { Text = "Cancel" };
+        using Form foregroundForm = new() { Text = "Foreground Form", ShowInTaskbar = false };
+        bool clicked = false;
+        cancelButton.Click += (_, _) => clicked = true;
 
-        Process? process = null;
-        
-        try {
-            process = TestHelper.StartHiddenNotepad();
-            if (process == null) {
-                Assert.Inconclusive("Failed to start Notepad");
-            }
+        targetForm.Controls.Add(cancelButton);
+        targetForm.Show();
+        foregroundForm.Show();
+        cancelButton.CreateControl();
+        foregroundForm.Activate();
+        Application.DoEvents();
+        Thread.Sleep(100);
 
-            var manager = new WindowManager();
-            var window = manager.WaitWindow("*Notepad*", 10000);
-            KeyboardInputService.PressShortcut(0, VirtualKey.VK_CONTROL, VirtualKey.VK_O);
-            var dialog = manager.WaitWindow("*Open*", 5000);
+        WindowControlInfo control = new() {
+            ParentWindowHandle = targetForm.Handle,
+            Handle = cancelButton.Handle,
+            ClassName = "Button",
+            Id = MonitorNativeMethods.GetDlgCtrlID(cancelButton.Handle),
+            Text = cancelButton.Text
+        };
 
-            var enumerator = new ControlEnumerator();
-            var controls = enumerator.EnumerateControls(dialog.Handle);
-            var cancel = controls.FirstOrDefault(c => c.Text == "Cancel");
-            Assert.IsNotNull(cancel, "Cancel control not found");
+        WindowControlService.ControlClick(control, MouseButton.Left);
+        Application.DoEvents();
+        Thread.Sleep(100);
 
-            WindowControlService.ControlClick(cancel, MouseButton.Left);
-            Thread.Sleep(500);
-            var openDialogs = manager.GetWindows("*Open*");
-            Assert.AreEqual(0, openDialogs.Count, "Dialog was not closed");
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.IsTrue(clicked, "Button click handler was not invoked.");
     }
 }

--- a/Sources/DesktopManager.Tests/WindowControlServiceUnitTests.cs
+++ b/Sources/DesktopManager.Tests/WindowControlServiceUnitTests.cs
@@ -1,0 +1,62 @@
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Unit tests for printable-key translation in direct control messaging.
+/// </summary>
+public class WindowControlServiceUnitTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures letter keys translate to uppercase printable characters.
+    /// </summary>
+    public void TryGetPrintableCharacter_LetterKey_ReturnsUppercaseCharacter() {
+        bool translated = WindowControlService.TryGetPrintableCharacter(VirtualKey.VK_H, noModifiersHeld: true, out char character);
+
+        Assert.IsTrue(translated);
+        Assert.AreEqual('H', character);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures digit keys translate to printable characters.
+    /// </summary>
+    public void TryGetPrintableCharacter_DigitKey_ReturnsDigitCharacter() {
+        bool translated = WindowControlService.TryGetPrintableCharacter(VirtualKey.VK_7, noModifiersHeld: true, out char character);
+
+        Assert.IsTrue(translated);
+        Assert.AreEqual('7', character);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the space key translates to a printable space.
+    /// </summary>
+    public void TryGetPrintableCharacter_SpaceKey_ReturnsSpaceCharacter() {
+        bool translated = WindowControlService.TryGetPrintableCharacter(VirtualKey.VK_SPACE, noModifiersHeld: true, out char character);
+
+        Assert.IsTrue(translated);
+        Assert.AreEqual(' ', character);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures printable translation is blocked while modifiers are held.
+    /// </summary>
+    public void TryGetPrintableCharacter_WithModifiersHeld_ReturnsFalse() {
+        bool translated = WindowControlService.TryGetPrintableCharacter(VirtualKey.VK_A, noModifiersHeld: false, out char character);
+
+        Assert.IsFalse(translated);
+        Assert.AreEqual('\0', character);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures non-printable keys are not translated to characters.
+    /// </summary>
+    public void TryGetPrintableCharacter_NonPrintableKey_ReturnsFalse() {
+        bool translated = WindowControlService.TryGetPrintableCharacter(VirtualKey.VK_RETURN, noModifiersHeld: true, out char character);
+
+        Assert.IsFalse(translated);
+        Assert.AreEqual('\0', character);
+    }
+}

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using DesktopManager;
 
 namespace DesktopManager.Tests;
@@ -18,21 +19,17 @@ public class WindowLayoutTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        string title = $"Layout Harness {System.Guid.NewGuid():N}";
         var fullLayoutPath = System.IO.Path.GetTempFileName();
         var filteredLayoutPath = System.IO.Path.GetTempFileName();
 
         try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+            using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
 
             var manager = new WindowManager();
-            var original = manager.GetWindowPosition(window);
+            var original = manager.GetWindowPosition(harness.Window);
 
             manager.SaveLayout(fullLayoutPath);
 
@@ -73,9 +70,10 @@ public class WindowLayoutTests {
             manager.LoadLayout(filteredLayoutPath);
 
             System.Threading.Thread.Sleep(200);
+            Application.DoEvents();
 
-            var restored = manager.GetWindowPosition(window);
-            manager.ShowWindow(window, false);
+            var restored = manager.GetWindowPosition(harness.Window);
+            manager.ShowWindow(harness.Window, false);
             var leftTolerance = Math.Abs(newLeft - restored.Left);
             var topTolerance = Math.Abs(newTop - restored.Top);
 
@@ -90,7 +88,6 @@ public class WindowLayoutTests {
             if (System.IO.File.Exists(filteredLayoutPath)) {
                 System.IO.File.Delete(filteredLayoutPath);
             }
-            TestHelper.SafeKillProcess(process);
         }
     }
 

--- a/Sources/DesktopManager.Tests/WindowListAndGeometryCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/WindowListAndGeometryCommandOutputTests.cs
@@ -1,0 +1,111 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Collections.Generic;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window list and geometry text output.
+/// </summary>
+public class WindowListAndGeometryCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures window list output renders the expected table headers and row values.
+    /// </summary>
+    public void WriteWindowListResults_WritesWindowTable() {
+        var windows = new List<global::DesktopManager.Cli.WindowResult> {
+            new() {
+                ProcessId = 321,
+                Handle = "0x1234",
+                MonitorIndex = 1,
+                IsVisible = true,
+                State = "Normal",
+                Title = "DesktopManager Test App"
+            },
+            new() {
+                ProcessId = 654,
+                Handle = "0xABCD",
+                MonitorIndex = 2,
+                IsVisible = false,
+                State = "Minimized",
+                Title = "DesktopManager Command Surface"
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteWindowListResults(windows, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "PID");
+        StringAssert.Contains(output, "Handle");
+        StringAssert.Contains(output, "Mon");
+        StringAssert.Contains(output, "Visible");
+        StringAssert.Contains(output, "State");
+        StringAssert.Contains(output, "Title");
+        StringAssert.Contains(output, "321");
+        StringAssert.Contains(output, "1234");
+        StringAssert.Contains(output, "1");
+        StringAssert.Contains(output, "Yes");
+        StringAssert.Contains(output, "Normal");
+        StringAssert.Contains(output, "DesktopManager Test App");
+        StringAssert.Contains(output, "654");
+        StringAssert.Contains(output, "ABCD");
+        StringAssert.Contains(output, "No");
+        StringAssert.Contains(output, "Minimized");
+        StringAssert.Contains(output, "DesktopManager Command Surface");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures geometry output renders window bounds, client bounds, and client offsets.
+    /// </summary>
+    public void WriteWindowGeometryResults_WritesGeometrySummary() {
+        var geometries = new List<global::DesktopManager.Cli.WindowGeometryResult> {
+            new() {
+                Window = new global::DesktopManager.Cli.WindowResult {
+                    Title = "DesktopManager Test App",
+                    Handle = "0x1234"
+                },
+                WindowLeft = 10,
+                WindowTop = 20,
+                WindowWidth = 800,
+                WindowHeight = 600,
+                ClientLeft = 18,
+                ClientTop = 52,
+                ClientWidth = 784,
+                ClientHeight = 560,
+                ClientOffsetLeft = 8,
+                ClientOffsetTop = 32
+            }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteWindowGeometryResults(geometries, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "window: DesktopManager Test App (0x1234)");
+        StringAssert.Contains(output, "- Window: 10,20 800x600");
+        StringAssert.Contains(output, "- Client: 18,52 784x560");
+        StringAssert.Contains(output, "- ClientOffset: 8,32");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the empty window message stays explicit for list and geometry callers.
+    /// </summary>
+    public void WriteNoMatchingWindows_WritesExpectedMessage() {
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WindowCommands.WriteNoMatchingWindows(writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "No matching windows found.");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -84,7 +85,6 @@ public class WindowManagerFilterTests {
 
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
     /// <summary>
     /// Ensures filtering by process ID returns matching window.
     /// </summary>
@@ -93,25 +93,18 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
 
-        using var proc = TestHelper.StartHiddenNotepad();
-        if (proc == null) {
-            Assert.Inconclusive("Failed to start notepad");
-        }
+        string title = $"ProcessId Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+        using var process = Process.GetCurrentProcess();
 
-        try {
-            var manager = new WindowManager();
-            var windows = manager.GetWindows(processId: proc.Id);
-            Assert.IsTrue(windows.Any());
+        var manager = new WindowManager();
+        var windows = manager.GetWindows(processId: process.Id, includeHidden: true);
+        Assert.IsTrue(windows.Any(w => w.Handle == harness.Window.Handle));
 
-            var windows2 = manager.GetWindowsForProcess(proc);
-            Assert.IsTrue(windows2.Any());
-        } finally {
-            TestHelper.SafeKillProcess(proc);
-        }
+        var windows2 = manager.GetWindowsForProcess(process, includeHidden: true);
+        Assert.IsTrue(windows2.Any(w => w.Handle == harness.Window.Handle));
     }
 
     [TestMethod]
@@ -123,49 +116,16 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
+        TestHelper.RequireOwnedWindowUiTests();
+        string title = $"Class Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+
         var manager = new WindowManager();
-        var windows = manager.GetWindows(includeHidden: true);
-        if (windows.Count == 0) {
-            Assert.Inconclusive("No windows found to test");
-        }
-
-        // Find a window with a stable class name that we can reliably filter by
-        WindowInfo? selectedWindow = null;
-        string? selectedClassName = null;
-        
-        foreach (var w in windows) {
-            try {
-                var sb = new StringBuilder(256);
-                MonitorNativeMethods.GetClassName(w.Handle, sb, sb.Capacity);
-                var className = sb.ToString();
-                
-                // Skip empty or very complex class names
-                if (string.IsNullOrEmpty(className) || className.Length > 50 || className.Contains(":")) {
-                    continue;
-                }
-                
-                // Test if this class name actually returns results
-                var testFiltered = manager.GetWindows(className: className, includeHidden: true);
-                if (testFiltered.Any(tw => tw.Handle == w.Handle)) {
-                    selectedWindow = w;
-                    selectedClassName = className;
-                    break;
-                }
-            } catch {
-                continue;
-            }
-        }
-        
-        if (selectedWindow == null || string.IsNullOrEmpty(selectedClassName)) {
-            Assert.Inconclusive("No suitable window with filterable class name found for testing");
-            return;
-        }
-
-        string classNameFilter = selectedClassName!;
+        string classNameFilter = GetClassName(harness.Window.Handle);
         var filtered = manager.GetWindows(className: classNameFilter, includeHidden: true);
 
-        Assert.IsTrue(filtered.Any(w => w.Handle == selectedWindow.Handle),
-            $"Expected to find window {selectedWindow.Handle:X8} with class '{classNameFilter}' in filtered results");
+        Assert.IsTrue(filtered.Any(w => w.Handle == harness.Window.Handle),
+            $"Expected to find window {harness.Window.Handle:X8} with class '{classNameFilter}' in filtered results");
     }
 
     [TestMethod]
@@ -177,22 +137,15 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
+        TestHelper.RequireOwnedWindowUiTests();
+        string title = $"Regex Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+
         var manager = new WindowManager();
-        var windows = manager.GetWindows(includeHidden: true);
-        if (windows.Count == 0) {
-            Assert.Inconclusive("No windows found to test");
-        }
-
-        // Find a window with a non-empty title for regex matching
-        var window = windows.FirstOrDefault(w => !string.IsNullOrEmpty(w.Title));
-        if (window == null) {
-            Assert.Inconclusive("No windows with titles found to test");
-        }
-
-        var regex = new Regex(Regex.Escape(window.Title), RegexOptions.IgnoreCase);
+        var regex = new Regex(Regex.Escape(title), RegexOptions.IgnoreCase);
         var filtered = manager.GetWindows(regex: regex, includeHidden: true);
-        Assert.IsTrue(filtered.Any(w => w.Handle == window.Handle),
-            $"Expected to find window {window.Handle:X8} with title '{window.Title}' in regex filtered results");
+        Assert.IsTrue(filtered.Any(w => w.Handle == harness.Window.Handle),
+            $"Expected to find window {harness.Window.Handle:X8} with title '{title}' in regex filtered results");
     }
 
     [TestMethod]
@@ -204,67 +157,31 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
+        TestHelper.RequireOwnedWindowUiTests();
+        string title = $"Combined Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+        using var process = Process.GetCurrentProcess();
+
         var manager = new WindowManager();
-        var windows = manager.GetWindows(includeHidden: true);
-        if (windows.Count == 0) {
-            Assert.Inconclusive("No windows found to test");
-        }
-
-        WindowInfo? selectedWindow = null;
-        string? selectedClassName = null;
-        string? selectedProcessName = null;
-
-        foreach (var w in windows) {
-            if (string.IsNullOrEmpty(w.Title)) {
-                continue;
-            }
-
-            if (w.ProcessId == 0 || w.ProcessId > int.MaxValue) {
-                continue;
-            }
-
-            try {
-                var sb = new StringBuilder(256);
-                MonitorNativeMethods.GetClassName(w.Handle, sb, sb.Capacity);
-                var className = sb.ToString();
-                if (string.IsNullOrEmpty(className) || className.Length > 50 || className.Contains(":")) {
-                    continue;
-                }
-
-                using var proc = Process.GetProcessById((int)w.ProcessId);
-                if (string.IsNullOrWhiteSpace(proc.ProcessName)) {
-                    continue;
-                }
-
-                selectedWindow = w;
-                selectedClassName = className;
-                selectedProcessName = proc.ProcessName;
-                break;
-            } catch {
-                continue;
-            }
-        }
-
-        if (selectedWindow == null || selectedClassName == null || selectedProcessName == null) {
-            Assert.Inconclusive("No suitable window found for combined filter test");
-        }
+        string selectedClassName = GetClassName(harness.Window.Handle);
+        string selectedProcessName = process.ProcessName;
 
         var options = new WindowQueryOptions {
-            TitlePattern = selectedWindow.Title,
+            TitlePattern = title,
             ProcessNamePattern = selectedProcessName,
             ClassNamePattern = selectedClassName,
-            ProcessId = (int)selectedWindow.ProcessId,
+            ProcessId = process.Id,
             IncludeHidden = true,
             IncludeCloaked = true,
             IncludeOwned = true,
-            IsVisible = selectedWindow.IsVisible,
-            State = selectedWindow.State,
-            IsTopMost = selectedWindow.IsTopMost
+            IsVisible = harness.Window.IsVisible,
+            State = harness.Window.State,
+            IsTopMost = harness.Window.IsTopMost
         };
 
         var filtered = manager.GetWindows(options);
-        Assert.IsTrue(filtered.Any(w => w.Handle == selectedWindow.Handle),
-            $"Expected to find window {selectedWindow.Handle:X8} using combined filters");
+        Assert.IsTrue(filtered.Any(w => w.Handle == harness.Window.Handle),
+            $"Expected to find window {harness.Window.Handle:X8} using combined filters");
     }
 
     [TestMethod]
@@ -276,14 +193,13 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        var manager = new WindowManager();
-        var window = manager.GetWindows(includeHidden: true).FirstOrDefault();
-        if (window == null) {
-            Assert.Inconclusive("No windows found to test");
-        }
+        TestHelper.RequireOwnedWindowUiTests();
+        string title = $"Handle Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
 
+        var manager = new WindowManager();
         var filtered = manager.GetWindows(new WindowQueryOptions {
-            Handle = window.Handle,
+            Handle = harness.Window.Handle,
             IncludeHidden = true,
             IncludeCloaked = true,
             IncludeOwned = true,
@@ -291,7 +207,7 @@ public class WindowManagerFilterTests {
         });
 
         Assert.AreEqual(1, filtered.Count, "Expected an exact handle filter to return a single window.");
-        Assert.AreEqual(window.Handle, filtered[0].Handle, "Expected the filtered window to match the requested handle.");
+        Assert.AreEqual(harness.Window.Handle, filtered[0].Handle, "Expected the filtered window to match the requested handle.");
     }
 
     [TestMethod]
@@ -343,6 +259,12 @@ public class WindowManagerFilterTests {
 
         Assert.IsTrue(filtered.All(w => w.ZOrder >= min && w.ZOrder <= max),
             "Expected all windows to be within the specified Z-order range");
+    }
+
+    private static string GetClassName(IntPtr handle) {
+        var sb = new StringBuilder(256);
+        MonitorNativeMethods.GetClassName(handle, sb, sb.Capacity);
+        return sb.ToString();
     }
 }
 

--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -18,28 +18,19 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position RoundTrip Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        var original = manager.GetWindowPosition(harness.Window);
 
-            var manager = new WindowManager();
-            var original = manager.GetWindowPosition(window);
+        manager.SetWindowPosition(harness.Window, original.Left, original.Top);
+        Application.DoEvents();
+        var updated = manager.GetWindowPosition(harness.Window);
 
-            manager.SetWindowPosition(window, original.Left, original.Top);
-            var updated = manager.GetWindowPosition(window);
-
-            Assert.AreEqual(original.Left, updated.Left);
-            Assert.AreEqual(original.Top, updated.Top);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.AreEqual(original.Left, updated.Left);
+        Assert.AreEqual(original.Top, updated.Top);
     }
 
     [TestMethod]
@@ -50,31 +41,22 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager ZOrder Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        var windowsBefore = manager.GetWindows(includeHidden: true);
+        int indexBefore = windowsBefore.FindIndex(w => w.Handle == harness.Window.Handle);
 
-            var manager = new WindowManager();
-            var windowsBefore = manager.GetWindows(includeHidden: true);
-            int indexBefore = windowsBefore.FindIndex(w => w.Handle == window.Handle);
+        var original = manager.GetWindowPosition(harness.Window);
+        manager.SetWindowPosition(harness.Window, original.Left + 1, original.Top + 1);
+        Application.DoEvents();
 
-            var original = manager.GetWindowPosition(window);
-            manager.SetWindowPosition(window, original.Left + 1, original.Top + 1);
+        var windowsAfterMove = manager.GetWindows(includeHidden: true);
+        int indexAfterMove = windowsAfterMove.FindIndex(w => w.Handle == harness.Window.Handle);
 
-            var windowsAfterMove = manager.GetWindows(includeHidden: true);
-            int indexAfterMove = windowsAfterMove.FindIndex(w => w.Handle == window.Handle);
-
-            Assert.AreEqual(indexBefore, indexAfterMove);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.AreEqual(indexBefore, indexAfterMove);
     }
 
     [TestMethod]
@@ -99,31 +81,20 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Same Monitor Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
-
-            var manager = new WindowManager();
-            var monitors = new Monitors().GetMonitors(index: window.MonitorIndex);
-            var monitor = monitors.FirstOrDefault();
-            if (monitor == null) {
-                Assert.Inconclusive("Monitor not found");
-                return;
-            }
-
-            bool moved = manager.MoveWindowToMonitor(window, monitor);
-
-            Assert.IsFalse(moved);
-        } finally {
-            TestHelper.SafeKillProcess(process);
+        var manager = new WindowManager();
+        var monitors = new Monitors().GetMonitors(index: harness.Window.MonitorIndex);
+        var monitor = monitors.FirstOrDefault();
+        if (monitor == null) {
+            Assert.Inconclusive("Monitor not found");
         }
+
+        bool moved = manager.MoveWindowToMonitor(harness.Window, monitor);
+
+        Assert.IsFalse(moved);
     }
 
     [TestMethod]
@@ -134,30 +105,20 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
         var monitors = new Monitors().GetMonitors();
         if (monitors.Count < 2) {
             Assert.Inconclusive("Need at least two monitors");
         }
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Different Monitor Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        var target = monitors.First(m => m.Index != harness.Window.MonitorIndex);
 
-            var manager = new WindowManager();
-            var target = monitors.First(m => m.Index != window.MonitorIndex);
+        bool moved = manager.MoveWindowToMonitor(harness.Window, target);
 
-            bool moved = manager.MoveWindowToMonitor(window, target);
-
-            Assert.IsTrue(moved);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.IsTrue(moved);
     }
 }

--- a/Sources/DesktopManager.Tests/WindowProcessInfoTests.cs
+++ b/Sources/DesktopManager.Tests/WindowProcessInfoTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DesktopManager.Tests;
@@ -25,33 +26,24 @@ public class WindowProcessInfoTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
-        TestHelper.RequireInteractive();
+        TestHelper.RequireOwnedWindowUiTests();
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("Process Info Harness");
 
-        if (!TestHelper.TryStartNotepadWindow(out var process, out var window, hideWindow: true) ||
-            process == null ||
-            window == null) {
-            Assert.Inconclusive("Failed to start Notepad window");
-        }
+        var manager = new WindowManager();
+        var info = manager.GetWindowProcessInfo(harness.Window);
+        using var currentProcess = Process.GetCurrentProcess();
 
-        try {
-            var manager = new WindowManager();
-            var info = manager.GetWindowProcessInfo(window);
+        Assert.AreEqual((uint)currentProcess.Id, info.ProcessId);
+        Assert.IsTrue(info.ThreadId > 0);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(info.ProcessName));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(info.ProcessPath));
+        Assert.IsTrue(info.IsElevated.HasValue);
+        Assert.IsTrue(info.IsWow64.HasValue);
 
-            Assert.AreEqual((uint)process.Id, info.ProcessId);
-            Assert.IsTrue(info.ThreadId > 0);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(info.ProcessName));
-            Assert.IsTrue(info.ProcessPath != null &&
-                          info.ProcessPath.EndsWith("notepad.exe", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(info.IsElevated.HasValue);
-            Assert.IsTrue(info.IsWow64.HasValue);
+        var threadId = manager.GetWindowThreadId(harness.Window);
+        Assert.AreEqual(info.ThreadId, threadId);
 
-            var threadId = manager.GetWindowThreadId(window);
-            Assert.AreEqual(info.ThreadId, threadId);
-
-            var modulePath = manager.GetWindowModulePath(window);
-            Assert.AreEqual(info.ProcessPath, modulePath);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        var modulePath = manager.GetWindowModulePath(harness.Window);
+        Assert.AreEqual(info.ProcessPath, modulePath);
     }
 }

--- a/Sources/DesktopManager.Tests/WindowQueryAndGeometryMappingTests.cs
+++ b/Sources/DesktopManager.Tests/WindowQueryAndGeometryMappingTests.cs
@@ -1,0 +1,129 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window query mapping and geometry result shaping.
+/// </summary>
+public class WindowQueryAndGeometryMappingTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures default window criteria keep empty-title filtering enabled when no explicit selector is supplied.
+    /// </summary>
+    public void CreateWindowQuery_DefaultCriteria_ExcludeEmptyTitlesByDefault() {
+        var criteria = new global::DesktopManager.Cli.WindowSelectionCriteria {
+            TitlePattern = "*",
+            ProcessNamePattern = "*",
+            ClassNamePattern = "*",
+            IncludeHidden = false,
+            IncludeCloaked = true,
+            IncludeOwned = true,
+            IncludeEmptyTitles = false,
+            Active = false
+        };
+
+        WindowQueryOptions query = global::DesktopManager.Cli.DesktopOperations.CreateWindowQuery(criteria);
+
+        Assert.AreEqual("*", query.TitlePattern);
+        Assert.AreEqual("*", query.ProcessNamePattern);
+        Assert.AreEqual("*", query.ClassNamePattern);
+        Assert.AreEqual(false, query.IncludeHidden);
+        Assert.AreEqual(true, query.IncludeCloaked);
+        Assert.AreEqual(true, query.IncludeOwned);
+        Assert.AreEqual(false, query.IncludeEmptyTitles);
+        Assert.AreEqual(0, query.ProcessId);
+        Assert.IsNull(query.Handle);
+        Assert.IsFalse(query.ActiveWindow);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures explicit window selectors preserve null empty-title filtering so exact matches can include untitled windows.
+    /// </summary>
+    public void CreateWindowQuery_ExplicitSelector_PreservesNullableEmptyTitleFilter() {
+        var criteria = new global::DesktopManager.Cli.WindowSelectionCriteria {
+            TitlePattern = "DesktopManager*",
+            ProcessNamePattern = "*",
+            ClassNamePattern = "*",
+            IncludeHidden = true,
+            IncludeCloaked = false,
+            IncludeOwned = false,
+            IncludeEmptyTitles = false,
+            ProcessId = 321,
+            Handle = "0x1234",
+            Active = true
+        };
+
+        WindowQueryOptions query = global::DesktopManager.Cli.DesktopOperations.CreateWindowQuery(criteria);
+
+        Assert.AreEqual("DesktopManager*", query.TitlePattern);
+        Assert.AreEqual(true, query.IncludeHidden);
+        Assert.AreEqual(false, query.IncludeCloaked);
+        Assert.AreEqual(false, query.IncludeOwned);
+        Assert.IsNull(query.IncludeEmptyTitles);
+        Assert.AreEqual(321, query.ProcessId);
+        Assert.AreEqual(new IntPtr(0x1234), query.Handle);
+        Assert.IsTrue(query.ActiveWindow);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures CLI geometry mapping preserves both top-level window metadata and client-area measurements.
+    /// </summary>
+    public void MapWindowGeometry_MapsWindowAndClientBounds() {
+        var geometry = new DesktopWindowGeometry {
+            Window = new WindowInfo {
+                Title = "DesktopManager Test App",
+                Handle = new IntPtr(0x5678),
+                ProcessId = 444,
+                ThreadId = 555,
+                IsVisible = true,
+                IsTopMost = true,
+                State = WindowState.Normal,
+                Left = 100,
+                Top = 200,
+                Right = 900,
+                Bottom = 700,
+                MonitorIndex = 2,
+                MonitorDeviceName = @"\\.\\DISPLAY2"
+            },
+            WindowLeft = 100,
+            WindowTop = 200,
+            WindowWidth = 800,
+            WindowHeight = 500,
+            ClientLeft = 108,
+            ClientTop = 232,
+            ClientWidth = 784,
+            ClientHeight = 460,
+            ClientOffsetLeft = 8,
+            ClientOffsetTop = 32
+        };
+
+        global::DesktopManager.Cli.WindowGeometryResult result = global::DesktopManager.Cli.DesktopOperations.MapWindowGeometry(geometry);
+
+        Assert.AreEqual("DesktopManager Test App", result.Window.Title);
+        Assert.AreEqual("0x5678", result.Window.Handle);
+        Assert.AreEqual((uint)444, result.Window.ProcessId);
+        Assert.AreEqual((uint)555, result.Window.ThreadId);
+        Assert.IsTrue(result.Window.IsVisible);
+        Assert.IsTrue(result.Window.IsTopMost);
+        Assert.AreEqual("Normal", result.Window.State);
+        Assert.AreEqual(100, result.Window.Left);
+        Assert.AreEqual(200, result.Window.Top);
+        Assert.AreEqual(800, result.Window.Width);
+        Assert.AreEqual(500, result.Window.Height);
+        Assert.AreEqual(2, result.Window.MonitorIndex);
+        Assert.AreEqual(@"\\.\\DISPLAY2", result.Window.MonitorDeviceName);
+        Assert.AreEqual(100, result.WindowLeft);
+        Assert.AreEqual(200, result.WindowTop);
+        Assert.AreEqual(800, result.WindowWidth);
+        Assert.AreEqual(500, result.WindowHeight);
+        Assert.AreEqual(108, result.ClientLeft);
+        Assert.AreEqual(232, result.ClientTop);
+        Assert.AreEqual(784, result.ClientWidth);
+        Assert.AreEqual(460, result.ClientHeight);
+        Assert.AreEqual(8, result.ClientOffsetLeft);
+        Assert.AreEqual(32, result.ClientOffsetTop);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -16,28 +16,20 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager State Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        bool initialMinimized = IsMinimized(harness.Window.Handle);
 
-            var manager = new WindowManager();
-            bool initialMinimized = IsMinimized(window.Handle);
+        manager.MinimizeWindows(new[] { harness.Window }, ignoreErrors: false);
+        Application.DoEvents();
+        Assert.IsTrue(IsMinimized(harness.Window.Handle) || initialMinimized);
 
-            manager.MinimizeWindows(new[] { window }, ignoreErrors: false);
-            Assert.IsTrue(IsMinimized(window.Handle) || initialMinimized);
-
-            manager.RestoreWindows(new[] { window }, ignoreErrors: false);
-            Assert.IsFalse(IsMinimized(window.Handle));
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        manager.RestoreWindows(new[] { harness.Window }, ignoreErrors: false);
+        Application.DoEvents();
+        Assert.IsFalse(IsMinimized(harness.Window.Handle));
     }
 
     [TestMethod]
@@ -48,33 +40,24 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager OnScreen Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        manager.SetWindowPosition(harness.Window, -5000, -5000);
 
-            var manager = new WindowManager();
-            manager.SetWindowPosition(window, -5000, -5000);
+        bool moved = manager.EnsureWindowOnScreen(harness.Window);
+        Application.DoEvents();
+        Assert.IsTrue(moved);
 
-            bool moved = manager.EnsureWindowOnScreen(window);
-            Assert.IsTrue(moved);
-
-            Assert.IsTrue(MonitorNativeMethods.GetWindowRect(window.Handle, out RECT rect));
-            var monitors = new Monitors().GetMonitors();
-            if (monitors.Count == 0) {
-                Assert.Inconclusive("No monitors found for verification");
-            }
-
-            Assert.IsTrue(IsRectOnAnyMonitor(rect, monitors));
-        } finally {
-            TestHelper.SafeKillProcess(process);
+        Assert.IsTrue(MonitorNativeMethods.GetWindowRect(harness.Window.Handle, out RECT rect));
+        var monitors = new Monitors().GetMonitors();
+        if (monitors.Count == 0) {
+            Assert.Inconclusive("No monitors found for verification");
         }
+
+        Assert.IsTrue(IsRectOnAnyMonitor(rect, monitors));
     }
 
     private static bool IsMinimized(IntPtr handle) {

--- a/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace DesktopManager.Tests;
 
@@ -39,33 +39,23 @@ public class WindowStyleModificationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Style Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        long original = manager.GetWindowStyle(harness.Window, true);
+        bool isTop = (original & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
-            var manager = new WindowManager();
-            long original = manager.GetWindowStyle(window, true);
-            bool isTop = (original & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
+        manager.SetWindowStyle(harness.Window, MonitorNativeMethods.WS_EX_TOPMOST, !isTop, true);
 
-            manager.SetWindowStyle(window, MonitorNativeMethods.WS_EX_TOPMOST, !isTop, true);
+        // Give the system time to process the change
+        Thread.Sleep(100);
 
-            // Give the system time to process the change
-            System.Threading.Thread.Sleep(100);
+        long toggled = manager.GetWindowStyle(harness.Window, true);
+        bool newIsTop = (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
-            long toggled = manager.GetWindowStyle(window, true);
-            bool newIsTop = (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
-
-            Assert.AreEqual(!isTop, newIsTop);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        Assert.AreEqual(!isTop, newIsTop);
     }
 }
 

--- a/Sources/DesktopManager.Tests/WindowTextFallbackTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTextFallbackTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace DesktopManager.Tests;
@@ -20,7 +19,6 @@ public class WindowTextFallbackTests {
     
     [TestMethod]
     [TestCategory("UITest")]
-    [Ignore("Disabled: UI test with Notepad - window enumeration needs fixing")]
     /// <summary>
     /// Ensures SendMessageTimeout fallback works when bitness differs.
     /// </summary>
@@ -32,50 +30,39 @@ public class WindowTextFallbackTests {
             Assert.Inconclusive("Test requires 64-bit process");
         }
 
-        if (TestHelper.ShouldSkipUITests()) {
-            Assert.Inconclusive("UI tests skipped in local development. Set RUN_UI_TESTS=true to run.");
+        TestHelper.RequireOwnedWindowUiTests();
+        string title = $"Window Text Fallback Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+
+        string expected = title;
+
+        string? deploymentDir = TestContext?.DeploymentDirectory;
+        if (string.IsNullOrEmpty(deploymentDir)) {
+            deploymentDir = AppContext.BaseDirectory;
         }
-        
-        using var proc = TestHelper.StartHiddenNotepad();
-        if (proc == null) {
-            Assert.Inconclusive("Failed to start notepad");
+
+        string helperDir = Path.Combine(deploymentDir, "WindowTextHelper32");
+        string helperPath = Path.Combine(helperDir, "WindowTextHelper32.exe");
+        if (!File.Exists(helperPath)) {
+            helperDir = Path.Combine(AppContext.BaseDirectory, "WindowTextHelper32");
+            helperPath = Path.Combine(helperDir, "WindowTextHelper32.exe");
+        }
+        if (!File.Exists(helperPath)) {
+            Assert.Inconclusive("Helper executable not found");
         }
 
-        try {
-            var manager = new WindowManager();
-            var window = manager.GetWindows(processId: proc.Id).First();
-            string expected = window.Title;
-
-            string? deploymentDir = TestContext?.DeploymentDirectory;
-            if (string.IsNullOrEmpty(deploymentDir)) {
-                deploymentDir = AppContext.BaseDirectory;
-            }
-
-            string helperDir = Path.Combine(deploymentDir, "WindowTextHelper32");
-            string helperPath = Path.Combine(helperDir, "WindowTextHelper32.exe");
-            if (!File.Exists(helperPath)) {
-                helperDir = Path.Combine(AppContext.BaseDirectory, "WindowTextHelper32");
-                helperPath = Path.Combine(helperDir, "WindowTextHelper32.exe");
-            }
-            if (!File.Exists(helperPath)) {
-                Assert.Inconclusive("Helper executable not found");
-            }
-
-            using var helper = Process.Start(new ProcessStartInfo(helperPath, window.Handle.ToInt64().ToString()) {
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                WorkingDirectory = helperDir
-            });
-            if (helper == null) {
-                Assert.Inconclusive("Failed to start helper");
-            }
-
-            string output = helper.StandardOutput.ReadToEnd().Trim();
-            helper.WaitForExit();
-
-            Assert.AreEqual(expected, output);
-        } finally {
-            TestHelper.SafeKillProcess(proc);
+        using var helper = Process.Start(new ProcessStartInfo(helperPath, harness.Window.Handle.ToInt64().ToString()) {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            WorkingDirectory = helperDir
+        });
+        if (helper == null) {
+            Assert.Inconclusive("Failed to start helper");
         }
+
+        string output = helper.StandardOutput.ReadToEnd().Trim();
+        helper.WaitForExit();
+
+        Assert.AreEqual(expected, output);
     }
 }

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace DesktopManager.Tests;
 
@@ -8,71 +9,55 @@ namespace DesktopManager.Tests;
 /// <summary>
 /// Test class for WindowTopMostActivationTests.
 /// </summary>
-public class WindowTopMostActivationTests
-{
+public class WindowTopMostActivationTests {
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
     /// Test for SetWindowTopMost_TogglesState.
     /// </summary>
-    public void SetWindowTopMost_TogglesState()
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
+    public void SetWindowTopMost_TogglesState() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        // Launch a notepad instance that we can control
-        System.Diagnostics.Process? notepadProcess = null;
-        WindowInfo? window = null;
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out notepadProcess, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start notepad for testing");
-                return;
-            }
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager TopMost Harness");
 
-            var manager = new WindowManager();
+        var manager = new WindowManager();
 
-            long originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
-            bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
+        long originalStyle = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
-            // Set to opposite of current state
-            manager.SetWindowTopMost(window, !wasTop);
-            
-            // Give the system time to process the change
-            System.Threading.Thread.Sleep(100);
-            
-            long toggled = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
-            bool newIsTop = (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
-            
-            Assert.AreEqual(!wasTop, newIsTop, $"Expected topmost to change from {wasTop} to {!wasTop}, but got {newIsTop}");
-            
-            // Test changing back
-            manager.SetWindowTopMost(window, wasTop);
-            System.Threading.Thread.Sleep(100);
-            
-            long restored = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
-            bool restoredIsTop = (restored & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
-            
-            Assert.AreEqual(wasTop, restoredIsTop, $"Expected topmost to restore to {wasTop}, but got {restoredIsTop}");
-            
-        } finally {
-            TestHelper.SafeKillProcess(notepadProcess);
-        }
+        // Set to opposite of current state
+        manager.SetWindowTopMost(harness.Window, !wasTop);
+
+        // Give the system time to process the change
+        Thread.Sleep(100);
+
+        long toggled = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        bool newIsTop = (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
+
+        Assert.AreEqual(!wasTop, newIsTop, $"Expected topmost to change from {wasTop} to {!wasTop}, but got {newIsTop}");
+
+        // Test changing back
+        manager.SetWindowTopMost(harness.Window, wasTop);
+        Thread.Sleep(100);
+
+        long restored = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        bool restoredIsTop = (restored & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
+
+        Assert.AreEqual(wasTop, restoredIsTop, $"Expected topmost to restore to {wasTop}, but got {restoredIsTop}");
     }
 
     [TestMethod]
     /// <summary>
     /// Test for ActivateWindow_BringsToFront.
     /// </summary>
-    public void ActivateWindow_BringsToFront()
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
+    public void ActivateWindow_BringsToFront() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
         var manager = new WindowManager();
         var originalForeground = MonitorNativeMethods.GetForegroundWindow();
@@ -93,7 +78,7 @@ public class WindowTopMostActivationTests
             manager.ActivateWindow(window);
 
             // Give Windows time to process the activation
-            System.Threading.Thread.Sleep(100);
+            Thread.Sleep(100);
 
             var newForeground = MonitorNativeMethods.GetForegroundWindow();
             if (newForeground == IntPtr.Zero) {

--- a/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -18,33 +17,26 @@ public class WindowTransparencyTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Transparency Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        long originalStyle = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        uint key;
+        byte origAlpha;
+        uint flags;
+        MonitorNativeMethods.GetLayeredWindowAttributes(harness.Window.Handle, out key, out origAlpha, out flags);
 
-            var manager = new WindowManager();
-            long originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
-            uint key; byte origAlpha; uint flags;
-            MonitorNativeMethods.GetLayeredWindowAttributes(window.Handle, out key, out origAlpha, out flags);
+        manager.SetWindowTransparency(harness.Window, 128);
+        Application.DoEvents();
+        long layeredStyle = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        MonitorNativeMethods.GetLayeredWindowAttributes(harness.Window.Handle, out key, out byte newAlpha, out flags);
 
-            manager.SetWindowTransparency(window, 128);
-            long layeredStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
-            MonitorNativeMethods.GetLayeredWindowAttributes(window.Handle, out key, out byte newAlpha, out flags);
+        Assert.IsTrue((layeredStyle & MonitorNativeMethods.WS_EX_LAYERED) != 0);
+        Assert.AreEqual((byte)128, newAlpha);
 
-            Assert.IsTrue((layeredStyle & MonitorNativeMethods.WS_EX_LAYERED) != 0);
-            Assert.AreEqual((byte)128, newAlpha);
-
-            MonitorNativeMethods.SetLayeredWindowAttributes(window.Handle, 0, origAlpha, MonitorNativeMethods.LWA_ALPHA);
-            MonitorNativeMethods.SetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE, new IntPtr(originalStyle));
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        MonitorNativeMethods.SetLayeredWindowAttributes(harness.Window.Handle, 0, origAlpha, MonitorNativeMethods.LWA_ALPHA);
+        MonitorNativeMethods.SetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE, new IntPtr(originalStyle));
     }
 }

--- a/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
+++ b/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -18,30 +18,22 @@ public class WindowVisibilityTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireInteractive();
+        TestHelper.RequireDesktopChanges();
 
-        Process? process = null;
-        WindowInfo? window = null;
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Visibility Harness");
 
-        try {
-            if (!TestHelper.TryStartNotepadWindow(out process, out window, hideWindow: true) || window == null) {
-                Assert.Inconclusive("Failed to start Notepad for testing");
-                return;
-            }
+        var manager = new WindowManager();
+        bool wasVisible = MonitorNativeMethods.IsWindowVisible(harness.Window.Handle);
 
-            var manager = new WindowManager();
-            bool wasVisible = MonitorNativeMethods.IsWindowVisible(window.Handle);
+        manager.ShowWindow(harness.Window, !wasVisible);
+        Application.DoEvents();
+        bool toggled = MonitorNativeMethods.IsWindowVisible(harness.Window.Handle);
+        Assert.AreEqual(!wasVisible, toggled);
 
-            manager.ShowWindow(window, !wasVisible);
-            bool toggled = MonitorNativeMethods.IsWindowVisible(window.Handle);
-            Assert.AreEqual(!wasVisible, toggled);
-
-            manager.ShowWindow(window, wasVisible);
-            bool reverted = MonitorNativeMethods.IsWindowVisible(window.Handle);
-            Assert.AreEqual(wasVisible, reverted);
-        } finally {
-            TestHelper.SafeKillProcess(process);
-        }
+        manager.ShowWindow(harness.Window, wasVisible);
+        Application.DoEvents();
+        bool reverted = MonitorNativeMethods.IsWindowVisible(harness.Window.Handle);
+        Assert.AreEqual(wasVisible, reverted);
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/WorkflowCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/WorkflowCommandOutputTests.cs
@@ -1,0 +1,103 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI workflow text output.
+/// </summary>
+public class WorkflowCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures workflow text output prefers focused window details and includes minimized/artifact metadata.
+    /// </summary>
+    public void WriteWorkflowResult_WritesFocusedWindowAndArtifacts() {
+        var result = new global::DesktopManager.Cli.WorkflowResult {
+            Action = "prepare-for-coding",
+            Success = true,
+            ElapsedMilliseconds = 250,
+            LayoutName = "Pairing",
+            LayoutApplied = true,
+            FocusedWindow = new global::DesktopManager.Cli.WindowResult {
+                Title = "Editor",
+                ProcessId = 100
+            },
+            ResolvedWindow = new global::DesktopManager.Cli.WindowResult {
+                Title = "Fallback",
+                ProcessId = 101
+            },
+            MinimizedWindows = new[] {
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Chat",
+                    ProcessId = 200
+                },
+                new global::DesktopManager.Cli.WindowResult {
+                    Title = "Mail",
+                    ProcessId = 201
+                }
+            },
+            BeforeScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            AfterScreenshots = new[] {
+                new global::DesktopManager.Cli.ScreenshotResult(),
+                new global::DesktopManager.Cli.ScreenshotResult()
+            },
+            ArtifactWarnings = new[] { "Capture path normalized." },
+            Notes = new[] { "Prepared coding layout." }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WorkflowCommands.WriteWorkflowResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, "prepare-for-coding: success=True elapsed-ms=250");
+        StringAssert.Contains(output, "layout: applied Pairing");
+        StringAssert.Contains(output, "focused: Editor [PID 100]");
+        Assert.IsFalse(output.Contains("resolved: Fallback"));
+        StringAssert.Contains(output, "minimized: 2 window(s)");
+        StringAssert.Contains(output, "- Chat [PID 200]");
+        StringAssert.Contains(output, "- Mail [PID 201]");
+        StringAssert.Contains(output, "artifacts: before=1 after=2");
+        StringAssert.Contains(output, "warning: Capture path normalized.");
+        StringAssert.Contains(output, "note: Prepared coding layout.");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures workflow text output falls back to resolved window details and omits empty optional sections.
+    /// </summary>
+    public void WriteWorkflowResult_WritesResolvedWindowFallbackAndOmitsEmptySections() {
+        var result = new global::DesktopManager.Cli.WorkflowResult {
+            Action = "clean-up-distractions",
+            Success = false,
+            ElapsedMilliseconds = 90,
+            LayoutName = "Sharing",
+            LayoutApplied = false,
+            ResolvedWindow = new global::DesktopManager.Cli.WindowResult {
+                Title = "Browser",
+                ProcessId = 300
+            },
+            Notes = new[] { "Nothing to minimize." }
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.WorkflowCommands.WriteWorkflowResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(2, exitCode);
+        StringAssert.Contains(output, "clean-up-distractions: success=False elapsed-ms=90");
+        StringAssert.Contains(output, "layout: not-applied Sharing");
+        StringAssert.Contains(output, "resolved: Browser [PID 300]");
+        Assert.IsFalse(output.Contains("focused:"));
+        Assert.IsFalse(output.Contains("minimized:"));
+        Assert.IsFalse(output.Contains("artifacts:"));
+        Assert.IsFalse(output.Contains("warning:"));
+        StringAssert.Contains(output, "note: Nothing to minimize.");
+    }
+}
+#endif

--- a/Sources/DesktopManager.sln
+++ b/Sources/DesktopManager.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowTextHelper32", "Windo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopManager.Cli", "DesktopManager.Cli\DesktopManager.Cli.csproj", "{78933CF2-0CAF-45FA-A6F6-293071CD482C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesktopManager.TestApp", "DesktopManager.TestApp\DesktopManager.TestApp.csproj", "{4F1D18B1-7A8D-4C78-90F3-91F72497D14A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
                 {78933CF2-0CAF-45FA-A6F6-293071CD482C}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {78933CF2-0CAF-45FA-A6F6-293071CD482C}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {78933CF2-0CAF-45FA-A6F6-293071CD482C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4F1D18B1-7A8D-4C78-90F3-91F72497D14A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4F1D18B1-7A8D-4C78-90F3-91F72497D14A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4F1D18B1-7A8D-4C78-90F3-91F72497D14A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4F1D18B1-7A8D-4C78-90F3-91F72497D14A}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/DesktopManager/ControlEnumerator.cs
+++ b/Sources/DesktopManager/ControlEnumerator.cs
@@ -15,6 +15,7 @@ public class ControlEnumerator {
         List<WindowControlInfo> controls = new List<WindowControlInfo>();
         MonitorNativeMethods.EnumChildWindows(parent, (hWnd, lParam) => {
             WindowControlInfo info = new WindowControlInfo {
+                ParentWindowHandle = parent,
                 Handle = hWnd,
                 Id = MonitorNativeMethods.GetDlgCtrlID(hWnd),
                 Source = WindowControlSource.Win32,

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -726,12 +726,9 @@ public sealed class DesktopAutomationService {
                 return;
             }
 
-            if (!control.SupportsForegroundInputFallback) {
-                throw new InvalidOperationException("The selected UI Automation control does not expose direct value setting and is not keyboard-focusable for foreground input fallback.");
-            }
-
-            if (!allowForegroundInputFallback) {
-                throw new InvalidOperationException("The UI Automation control does not support direct value setting. Enable foreground input fallback only when you intentionally allow focused input for modern app controls.");
+            string? validationError = ValidateUiAutomationTextFallback(control, allowForegroundInputFallback);
+            if (validationError != null) {
+                throw new InvalidOperationException(validationError);
             }
 
             if (!uiAutomation.TrySetText(window, control, text, ensureForegroundWindow)) {
@@ -747,12 +744,9 @@ public sealed class DesktopAutomationService {
     private void SendControlKeys(WindowInfo window, WindowControlInfo control, IReadOnlyList<VirtualKey> keys, bool ensureForegroundWindow, bool allowForegroundInputFallback) {
         var uiAutomation = new UiAutomationControlService();
         if (control.Source == WindowControlSource.UiAutomation && control.Handle == IntPtr.Zero) {
-            if (!control.SupportsForegroundInputFallback) {
-                throw new InvalidOperationException("The selected UI Automation control is not keyboard-focusable and cannot receive foreground fallback key input.");
-            }
-
-            if (!allowForegroundInputFallback) {
-                throw new InvalidOperationException("The selected UI Automation control does not expose a Win32 handle. Enable foreground input fallback only when you intentionally allow focused input for modern app controls.");
+            string? validationError = ValidateUiAutomationKeyFallback(control, allowForegroundInputFallback);
+            if (validationError != null) {
+                throw new InvalidOperationException(validationError);
             }
 
             if (!uiAutomation.TrySendKeys(window, control, keys, ensureForegroundWindow)) {
@@ -763,6 +757,46 @@ public sealed class DesktopAutomationService {
         }
 
         _windowManager.SendControlKeys(control, keys.ToArray());
+    }
+
+    internal static string? ValidateUiAutomationTextFallback(WindowControlInfo control, bool allowForegroundInputFallback) {
+        if (control == null) {
+            throw new ArgumentNullException(nameof(control));
+        }
+
+        if (control.Source != WindowControlSource.UiAutomation || control.Handle != IntPtr.Zero) {
+            return null;
+        }
+
+        if (!control.SupportsForegroundInputFallback) {
+            return "The selected UI Automation control does not expose direct value setting and is not keyboard-focusable for foreground input fallback.";
+        }
+
+        if (!allowForegroundInputFallback) {
+            return "The UI Automation control does not support direct value setting. Enable foreground input fallback only when you intentionally allow focused input for modern app controls.";
+        }
+
+        return null;
+    }
+
+    internal static string? ValidateUiAutomationKeyFallback(WindowControlInfo control, bool allowForegroundInputFallback) {
+        if (control == null) {
+            throw new ArgumentNullException(nameof(control));
+        }
+
+        if (control.Source != WindowControlSource.UiAutomation || control.Handle != IntPtr.Zero) {
+            return null;
+        }
+
+        if (!control.SupportsForegroundInputFallback) {
+            return "The selected UI Automation control is not keyboard-focusable and cannot receive foreground fallback key input.";
+        }
+
+        if (!allowForegroundInputFallback) {
+            return "The selected UI Automation control does not expose a Win32 handle. Enable foreground input fallback only when you intentionally allow focused input for modern app controls.";
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -1178,10 +1212,11 @@ public sealed class DesktopAutomationService {
 
         foreach (WindowInfo window in _windowManager.GetWindows(new WindowQueryOptions {
             ProcessId = launcherProcessId,
-            IncludeHidden = true,
-            IncludeCloaked = true,
-            IncludeOwned = true,
-            IncludeEmptyTitles = true
+            IncludeHidden = false,
+            IncludeCloaked = false,
+            IncludeOwned = false,
+            IncludeEmptyTitles = false,
+            IsVisible = true
         })) {
             candidates.Add(new LaunchWindowCandidate(
                 window,
@@ -1194,10 +1229,11 @@ public sealed class DesktopAutomationService {
             string resolvedProcessNameHint = processNameHints[hintIndex];
             foreach (WindowInfo window in _windowManager.GetWindows(new WindowQueryOptions {
                 ProcessNamePattern = resolvedProcessNameHint,
-                IncludeHidden = true,
-                IncludeCloaked = true,
-                IncludeOwned = true,
-                IncludeEmptyTitles = true
+                IncludeHidden = false,
+                IncludeCloaked = false,
+                IncludeOwned = false,
+                IncludeEmptyTitles = false,
+                IsVisible = true
             })) {
                 if (candidates.Any(candidate => candidate.Window.Handle == window.Handle)) {
                     continue;

--- a/Sources/DesktopManager/DesktopStateStore.cs
+++ b/Sources/DesktopManager/DesktopStateStore.cs
@@ -9,6 +9,31 @@ namespace DesktopManager;
 /// Provides naming and storage conventions for DesktopManager state files and captures.
 /// </summary>
 public static class DesktopStateStore {
+    private static readonly HashSet<string> ReservedDeviceNames = new(StringComparer.OrdinalIgnoreCase) {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9"
+    };
+
     /// <summary>
     /// Gets the captures directory.
     /// </summary>
@@ -83,8 +108,11 @@ public static class DesktopStateStore {
             ? Path.Combine(GetCapturesDirectory(), $"{prefix}-{DateTime.UtcNow:yyyyMMdd-HHmmssfff}.png")
             : outputPath!;
 
-        if (string.IsNullOrWhiteSpace(Path.GetExtension(path))) {
+        string extension = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(extension)) {
             path += ".png";
+        } else if (!extension.Equals(".png", StringComparison.OrdinalIgnoreCase)) {
+            path = Path.ChangeExtension(path, ".png");
         }
 
         string fullPath = Path.GetFullPath(path);
@@ -125,9 +153,12 @@ public static class DesktopStateStore {
             buffer.Add(character);
         }
 
-        string sanitized = new string(buffer.ToArray());
+        string sanitized = new string(buffer.ToArray()).TrimEnd(' ', '.');
         if (string.IsNullOrWhiteSpace(sanitized)) {
             throw new ArgumentException($"The name '{name}' does not produce a valid file name.", nameof(name));
+        }
+        if (ReservedDeviceNames.Contains(sanitized)) {
+            throw new ArgumentException($"The name '{name}' resolves to a reserved Windows file name.", nameof(name));
         }
 
         return sanitized;

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -283,6 +283,19 @@ public static partial class MonitorNativeMethods
         out IntPtr lpdwResult);
 
     /// <summary>
+    /// Sends a message with a timeout using a string parameter.
+    /// </summary>
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint Msg,
+        IntPtr wParam,
+        string lParam,
+        uint fuFlags,
+        uint uTimeout,
+        out IntPtr lpdwResult);
+
+    /// <summary>
     /// Sends a message with a timeout using a string buffer parameter.
     /// </summary>
     [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/Sources/DesktopManager/WindowControlService.cs
+++ b/Sources/DesktopManager/WindowControlService.cs
@@ -67,7 +67,18 @@ public static class WindowControlService {
             throw new ArgumentException("Invalid control handle", nameof(control));
         }
 
+        bool originalState = GetCheckState(control);
+        if (originalState == check) {
+            return;
+        }
+
         SendMessageWithTimeout(control.Handle, MonitorNativeMethods.BM_SETCHECK, check ? 1u : 0u, 0u);
+        if (GetCheckStateForHandle(control.Handle) == check) {
+            return;
+        }
+
+        // Some controls ignore BM_SETCHECK unless they are toggled through their standard click path.
+        SendMessageWithTimeout(control.Handle, MonitorNativeMethods.BM_CLICK, 0u, 0u);
     }
 
     /// <summary>
@@ -88,18 +99,15 @@ public static class WindowControlService {
             throw new ArgumentException("Invalid control handle", nameof(control));
         }
 
-        var buffer = new StringBuilder(text);
-        IntPtr result = MonitorNativeMethods.SendMessageTimeout(
-            control.Handle,
-            MonitorNativeMethods.WM_SETTEXT,
-            IntPtr.Zero,
-            buffer,
-            MonitorNativeMethods.SMTO_ABORTIFHUNG,
-            MessageTimeoutMilliseconds,
-            out _);
-        if (result == IntPtr.Zero) {
+        if (!TrySendStringMessageWithTimeout(control.Handle, MonitorNativeMethods.WM_SETTEXT, IntPtr.Zero, text)) {
             MonitorNativeMethods.SendMessage(control.Handle, MonitorNativeMethods.WM_SETTEXT, IntPtr.Zero, text);
         }
+
+        if (ControlTextMatches(control.Handle, text)) {
+            return;
+        }
+
+        ReplaceAllText(control.Handle, text);
     }
 
     /// <summary>
@@ -121,22 +129,21 @@ public static class WindowControlService {
         }
 
         var heldModifiers = new List<VirtualKey>();
+        var printableBuffer = new StringBuilder();
         for (int index = 0; index < keys.Length; index++) {
             VirtualKey key = keys[index];
             bool hasTrailingKey = index < keys.Length - 1;
             if (IsModifierKey(key) && hasTrailingKey) {
+                FlushPrintableBuffer(control.Handle, printableBuffer);
                 SendMessageWithTimeout(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
                 heldModifiers.Add(key);
                 continue;
             }
 
-            if (IsPrintableKey(key) && heldModifiers.Count == 0) {
-                uint end = unchecked((uint)0xFFFFFFFF);
-                SendMessageWithTimeout(control.Handle, MonitorNativeMethods.EM_SETSEL, end, end);
-                if (!TrySendMessageWithTimeout(control.Handle, MonitorNativeMethods.WM_CHAR, (uint)key, 0)) {
-                    MonitorNativeMethods.PostMessage(control.Handle, MonitorNativeMethods.WM_CHAR, (uint)key, 0);
-                }
+            if (TryGetPrintableCharacter(key, heldModifiers.Count == 0, out char character)) {
+                printableBuffer.Append(character);
             } else {
+                FlushPrintableBuffer(control.Handle, printableBuffer);
                 SendMessageWithTimeout(control.Handle, MonitorNativeMethods.WM_KEYDOWN, (uint)key, 0);
                 SendMessageWithTimeout(control.Handle, MonitorNativeMethods.WM_KEYUP, (uint)key, 0);
             }
@@ -144,6 +151,7 @@ public static class WindowControlService {
             ReleaseHeldModifiers(control.Handle, heldModifiers);
         }
 
+        FlushPrintableBuffer(control.Handle, printableBuffer);
         ReleaseHeldModifiers(control.Handle, heldModifiers);
     }
 
@@ -164,6 +172,30 @@ public static class WindowControlService {
     private static bool IsPrintableKey(VirtualKey key) {
         return (key >= VirtualKey.VK_SPACE && key <= VirtualKey.VK_Z) ||
             (key >= VirtualKey.VK_0 && key <= VirtualKey.VK_9);
+    }
+
+    internal static bool TryGetPrintableCharacter(VirtualKey key, bool noModifiersHeld, out char character) {
+        character = '\0';
+        if (!noModifiersHeld || !IsPrintableKey(key)) {
+            return false;
+        }
+
+        if (key >= VirtualKey.VK_A && key <= VirtualKey.VK_Z) {
+            character = (char)('A' + (key - VirtualKey.VK_A));
+            return true;
+        }
+
+        if (key >= VirtualKey.VK_0 && key <= VirtualKey.VK_9) {
+            character = (char)('0' + (key - VirtualKey.VK_0));
+            return true;
+        }
+
+        if (key == VirtualKey.VK_SPACE) {
+            character = ' ';
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsModifierKey(VirtualKey key) {
@@ -188,8 +220,39 @@ public static class WindowControlService {
         heldModifiers.Clear();
     }
 
+    private static void FlushPrintableBuffer(IntPtr handle, StringBuilder printableBuffer) {
+        if (printableBuffer.Length == 0) {
+            return;
+        }
+
+        ReplaceSelectedText(handle, printableBuffer.ToString(), appendToEnd: true);
+        printableBuffer.Clear();
+    }
+
+    private static void ReplaceAllText(IntPtr handle, string text) {
+        ReplaceSelectedText(handle, text, appendToEnd: false);
+    }
+
+    private static void ReplaceSelectedText(IntPtr handle, string text, bool appendToEnd) {
+        uint start = appendToEnd ? unchecked((uint)0xFFFFFFFF) : 0u;
+        uint end = unchecked((uint)0xFFFFFFFF);
+        SendMessageWithTimeout(handle, MonitorNativeMethods.EM_SETSEL, start, end);
+        if (!TrySendStringMessageWithTimeout(handle, MonitorNativeMethods.EM_REPLACESEL, new IntPtr(1), text)) {
+            MonitorNativeMethods.SendMessage(handle, MonitorNativeMethods.EM_REPLACESEL, new IntPtr(1), text);
+        }
+    }
+
+    private static bool ControlTextMatches(IntPtr handle, string expectedText) {
+        return string.Equals(WindowTextHelper.GetWindowText(handle), expectedText, StringComparison.Ordinal);
+    }
+
     private static void SendMessageWithTimeout(IntPtr handle, uint message, uint wParam, uint lParam) {
         TrySendMessageWithTimeout(handle, message, wParam, lParam);
+    }
+
+    private static bool GetCheckStateForHandle(IntPtr handle) {
+        int state = (int)MonitorNativeMethods.SendMessage(handle, MonitorNativeMethods.BM_GETCHECK, 0u, 0u);
+        return state != 0;
     }
 
     private static bool TrySendMessageWithTimeout(IntPtr handle, uint message, uint wParam, uint lParam) {
@@ -198,6 +261,18 @@ public static class WindowControlService {
             message,
             new IntPtr(unchecked((int)wParam)),
             new IntPtr(unchecked((int)lParam)),
+            MonitorNativeMethods.SMTO_ABORTIFHUNG,
+            MessageTimeoutMilliseconds,
+            out _);
+        return result != IntPtr.Zero;
+    }
+
+    private static bool TrySendStringMessageWithTimeout(IntPtr handle, uint message, IntPtr wParam, string text) {
+        IntPtr result = MonitorNativeMethods.SendMessageTimeout(
+            handle,
+            message,
+            wParam,
+            text,
             MonitorNativeMethods.SMTO_ABORTIFHUNG,
             MessageTimeoutMilliseconds,
             out _);

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -130,7 +130,7 @@ public partial class WindowManager {
 
                 if (!string.IsNullOrEmpty(options.ProcessNamePattern) && options.ProcessNamePattern != "*") {
                     try {
-                        var process = Process.GetProcessById((int)windowProcessId);
+                        using var process = Process.GetProcessById((int)windowProcessId);
                         if (!MatchesWildcard(process.ProcessName, options.ProcessNamePattern)) {
                             continue;
                         }
@@ -253,8 +253,9 @@ public partial class WindowManager {
         /// </summary>
         /// <param name="process">Process whose windows to retrieve.</param>
         /// <param name="includeHidden">Whether to include hidden windows.</param>
+        /// <param name="includeRelatedProcesses">Whether helper processes with the same name should also be searched when the exact process has no windows.</param>
         /// <returns>List of windows owned by the process.</returns>
-        public List<WindowInfo> GetWindowsForProcess(Process process, bool includeHidden = false) {
+        public List<WindowInfo> GetWindowsForProcess(Process process, bool includeHidden = false, bool includeRelatedProcesses = false) {
             if (process == null) {
                 throw new ArgumentNullException(nameof(process));
             }
@@ -271,8 +272,9 @@ public partial class WindowManager {
                 }
             }
             
-            // For modern Windows apps, also check child processes
-            if (windows.Count == 0) {
+            // Some modern apps surface a window from a broker or helper process.
+            // Keep this behavior opt-in so the default method stays exact-process safe.
+            if (windows.Count == 0 && includeRelatedProcesses) {
                 try {
                     // Get all processes with the same name
                     var relatedProcesses = Process.GetProcessesByName(process.ProcessName);
@@ -291,6 +293,16 @@ public partial class WindowManager {
             return windows;
         }
 
+        /// <summary>
+        /// Gets windows belonging to the specified process or related helper processes with the same name.
+        /// </summary>
+        /// <param name="process">Process whose windows to retrieve.</param>
+        /// <param name="includeHidden">Whether to include hidden windows.</param>
+        /// <returns>List of windows owned by the process family.</returns>
+        public List<WindowInfo> GetWindowsForProcessFamily(Process process, bool includeHidden = false) {
+            return GetWindowsForProcess(process, includeHidden, includeRelatedProcesses: true);
+        }
+        
         /// <summary>
         /// Gets the position of a window.
         /// </summary>


### PR DESCRIPTION
## Summary
- isolate desktop-mutating and external-app UI tests behind explicit gates and move more coverage onto owned harness windows
- add a repo-local DesktopManager.TestApp for MCP/UI scenarios instead of relying on Notepad/Edge
- expand non-UI CLI contract coverage for help, dispatch, parsing, output formatting, and adapter mapping
- harden several desktop automation paths around process/window targeting, screenshots, and control input handling

## Testing
- dotnet test Sources/DesktopManager.sln --nologo -m:1
- dotnet test Sources/DesktopManager.sln --nologo -m:1 --filter "FullyQualifiedName~CliApplicationTests|FullyQualifiedName~HelpTextTests"