### PR TITLE
feat(automation): ✨ add net10 support, verified mutations, and safer UI test gates

### DIFF
--- a/Build/Get-HostedSessionDiagnostic.ps1
+++ b/Build/Get-HostedSessionDiagnostic.ps1
@@ -1,0 +1,163 @@
+param(
+    [string] $ArtifactDirectory = (Join-Path $PSScriptRoot '..\Artifacts\HostedSessionTyping'),
+    [string] $ArtifactPath,
+    [switch] $SummaryOnly,
+    [switch] $AsJson
+)
+
+function Get-HostedSessionDiagnostic {
+    <#
+    .SYNOPSIS
+    Reads the latest hosted-session diagnostic artifact or a specific artifact file.
+
+    .DESCRIPTION
+    Reads repo-local hosted-session typing diagnostics from Artifacts\HostedSessionTyping.
+    Prefers the companion summary file when one exists and falls back to the JSON artifact content otherwise.
+
+    .PARAMETER ArtifactDirectory
+    The directory containing hosted-session diagnostic JSON artifacts and summary companion files.
+
+    .PARAMETER ArtifactPath
+    A specific hosted-session diagnostic JSON artifact path to read.
+
+    .PARAMETER SummaryOnly
+    Returns only the resolved summary text instead of a diagnostic object.
+
+    .PARAMETER AsJson
+    Serializes the resolved diagnostic object as JSON.
+
+    .EXAMPLE
+    .\Build\Get-HostedSessionDiagnostic.ps1
+
+    .EXAMPLE
+    .\Build\Get-HostedSessionDiagnostic.ps1 -SummaryOnly
+
+    .EXAMPLE
+    .\Build\Get-HostedSessionDiagnostic.ps1 -ArtifactPath "C:\Repo\DesktopManager\Artifacts\HostedSessionTyping\sample.json" -AsJson
+
+    .NOTES
+    The latest JSON artifact is selected by LastWriteTimeUtc when ArtifactPath is not supplied.
+    #>
+    [CmdletBinding()]
+    param(
+        [string] $ArtifactDirectory,
+        [string] $ArtifactPath,
+        [switch] $SummaryOnly,
+        [switch] $AsJson
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ArtifactPath)) {
+        if ([string]::IsNullOrWhiteSpace($ArtifactDirectory)) {
+            throw "ArtifactDirectory cannot be null or empty."
+        }
+        if (-not (Test-Path -LiteralPath $ArtifactDirectory -PathType Container)) {
+            throw "Hosted-session diagnostic directory not found: $ArtifactDirectory"
+        }
+
+        $artifact = Get-ChildItem -LiteralPath $ArtifactDirectory -Filter '*.json' -File |
+            Sort-Object -Property LastWriteTimeUtc, FullName -Descending |
+            Select-Object -First 1
+        if ($null -eq $artifact) {
+            throw "No hosted-session diagnostic artifacts were found in: $ArtifactDirectory"
+        }
+
+        $ArtifactPath = $artifact.FullName
+    } elseif (-not (Test-Path -LiteralPath $ArtifactPath -PathType Leaf)) {
+        throw "Hosted-session diagnostic artifact not found: $ArtifactPath"
+    }
+
+    $artifactDirectoryPath = Split-Path -Path $ArtifactPath -Parent
+    $artifactStem = [System.IO.Path]::GetFileNameWithoutExtension($ArtifactPath)
+    $summaryCandidate = Get-ChildItem -LiteralPath $artifactDirectoryPath -Filter ($artifactStem + '*.summary.txt') -File |
+        Sort-Object -Property @{ Expression = { ($_.Name -split '\.').Count } }, Name |
+        Select-Object -First 1
+    $summaryPath = $null
+    $summaryText = $null
+
+    if ($null -ne $summaryCandidate) {
+        $summaryPath = $summaryCandidate.FullName
+        $summaryText = Get-Content -LiteralPath $summaryPath -Raw
+    }
+
+    $artifactObject = Get-Content -LiteralPath $ArtifactPath -Raw | ConvertFrom-Json
+    if ($null -eq $artifactObject) {
+        throw "Hosted-session diagnostic artifact could not be deserialized: $ArtifactPath"
+    }
+
+    $reason = [string] $artifactObject.Reason
+    $createdUtc = [string] $artifactObject.CreatedUtc
+    $policyReport = [string] $artifactObject.PolicyReport
+    $retryHistoryCategory = [string] $artifactObject.RetryHistoryReport.CategoryHint
+    $retryHistorySummary = [string] $artifactObject.RetryHistoryReport.Summary
+    $retryHistoryExternalCount = 0
+    $retryHistoryDistinctFingerprintCount = 0
+    $statusObject = $artifactObject.Status
+
+    if ($artifactObject.PSObject.Properties.Match('WindowTitle').Count -gt 0 -and $artifactObject.PSObject.Properties.Match('Status').Count -eq 0) {
+        $statusObject = $artifactObject
+        $reason = 'Legacy hosted-session diagnostic artifact'
+        $createdUtc = ''
+        if ([string]::IsNullOrWhiteSpace($policyReport)) {
+            if (-not [string]::IsNullOrWhiteSpace([string] $statusObject.LastObservedForegroundClass) -and
+                [string] $statusObject.LastObservedForegroundClass -match 'Chrome_WidgetWin_1|Chrome_RenderWidgetHostHWND|MozillaWindowClass|ApplicationFrameWindow') {
+                $policyReport = "category='browser-electron'"
+                $retryHistoryCategory = 'browser-electron'
+            } elseif (-not [string]::IsNullOrWhiteSpace([string] $statusObject.LastObservedForegroundTitle)) {
+                $policyReport = "category='unknown'"
+                $retryHistoryCategory = 'unknown'
+            } else {
+                $policyReport = "category='none'"
+                $retryHistoryCategory = 'none'
+            }
+        }
+    }
+
+    if ($artifactObject.PSObject.Properties.Match('RetryHistoryReport').Count -gt 0 -and $null -ne $artifactObject.RetryHistoryReport) {
+        $retryHistoryExternalCount = [int] $artifactObject.RetryHistoryReport.ExternalCount
+        $retryHistoryDistinctFingerprintCount = [int] $artifactObject.RetryHistoryReport.DistinctFingerprintCount
+    }
+
+    if ([string]::IsNullOrWhiteSpace($summaryText)) {
+        if (-not [string]::IsNullOrWhiteSpace([string] $artifactObject.Summary)) {
+            $summaryText = [string] $artifactObject.Summary
+        } else {
+            $summaryText =
+                "reason='" + $reason + "', " +
+                "category='" + $retryHistoryCategory + "', " +
+                "externalCount=" + $retryHistoryExternalCount + ", " +
+                "distinctFingerprintCount=" + $retryHistoryDistinctFingerprintCount + ", " +
+                "policy='" + $policyReport + "', " +
+                "windowTitle='" + [string] $statusObject.WindowTitle + "', " +
+                "statusText='" + [string] $statusObject.StatusText + "'"
+        }
+    }
+
+    if ($SummaryOnly) {
+        $summaryText
+        return
+    }
+
+    $result = [pscustomobject] @{
+        ArtifactPath                     = $ArtifactPath
+        SummaryPath                      = $summaryPath
+        SummaryText                      = $summaryText
+        Reason                           = $reason
+        CreatedUtc                       = $createdUtc
+        RetryHistoryCategory             = $retryHistoryCategory
+        RetryHistorySummary              = $retryHistorySummary
+        RetryHistoryExternalCount        = $retryHistoryExternalCount
+        RetryHistoryDistinctFingerprintCount = $retryHistoryDistinctFingerprintCount
+        PolicyReport                     = $policyReport
+        WindowTitle                      = [string] $statusObject.WindowTitle
+        StatusText                       = [string] $statusObject.StatusText
+    }
+
+    if ($AsJson) {
+        $result | ConvertTo-Json -Depth 5
+        return
+    }
+
+    $result
+}
+
+Get-HostedSessionDiagnostic -ArtifactDirectory $ArtifactDirectory -ArtifactPath $ArtifactPath -SummaryOnly:$SummaryOnly -AsJson:$AsJson

--- a/Docs/Build.Runbook.md
+++ b/Docs/Build.Runbook.md
@@ -81,7 +81,7 @@ Publish a specific CLI runtime:
 
 - `Build-Project.ps1` is the only package and release entrypoint in this repo.
 - `Build-Project.ps1 -Plan` skips the module build execution because the module path does not expose the same standalone plan surface here.
-- The CLI publish target packages `Sources/DesktopManager.Cli/DesktopManager.Cli.csproj` as `desktopmanager.exe`.
+- The CLI publish targets package `Sources/DesktopManager.Cli/DesktopManager.Cli.csproj` as `desktopmanager.exe` for both `net8.0-windows` and `net10.0-windows`.
 - The CLI includes the MCP server entrypoint exposed by:
 
 ```powershell
@@ -109,7 +109,7 @@ dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-w
 dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn
 ```
 
-- Those live MCP desktop tests intentionally run under `net8.0-windows` only because they all drive the shared `DesktopManager.Cli.exe` host and the same real desktop session.
+- Those live MCP desktop tests intentionally run under `net8.0-windows` in the runbook examples because they all drive the shared `DesktopManager.Cli.exe` host and the same real desktop session; the same flows can also be exercised under `net10.0-windows` when validating the newer runtime target.
 - The safety-policy harness now covers one allowed scoped mutation, one denied scoped mutation, and one dry-run scoped mutation preview against a disposable Notepad window.
 - The stable live MCP desktop pack now stays on the Notepad-backed flows, while both Chromium-style foreground-input harnesses live behind `RUN_EXPERIMENTAL_UI_TESTS=true` so they can be exercised manually without destabilizing regular regression runs.
 - When the experimental Chromium opt-in harness goes inconclusive, it now keeps a screenshot plus control-diagnostic bundle under `%TEMP%\DesktopManager.Tests\McpE2E\Experimental`, exercises temporary named window/control targets so the fallback path stays aligned with the shared targeting workflow, and writes `decision-trace.txt` plus `comparison.txt` for follow-up analysis.

--- a/Docs/Build.Runbook.md
+++ b/Docs/Build.Runbook.md
@@ -91,25 +91,88 @@ desktopmanager mcp serve --allow-mutations --allow-process notepad
 ```
 
 - Fast MCP contract verification lives in `McpServerTests`.
+- UI test gates are intentionally split so operators can enable only the risk level they want:
+
+| Gate | Purpose | Notes |
+| ---- | ------- | ----- |
+| `RUN_UI_TESTS` | Owned-window UI tests | Uses repo-created harness windows only |
+| `RUN_DESTRUCTIVE_UI_TESTS` | Owned-window mutation tests | Move/resize/hide/snap/transparency on harness windows |
+| `RUN_FOREGROUND_UI_TESTS` | Foreground-focus tests | Intentionally steals focus to prove active-window behavior |
+| `RUN_SYSTEM_UI_TESTS` | System-wide desktop mutations | Wallpaper, brightness, resolution, and other monitor/session changes |
+| `RUN_EXTERNAL_UI_TESTS` | External application harnesses | Launches real desktop apps when a test requires them |
+| `RUN_EXPERIMENTAL_UI_TESTS` | Experimental live harnesses | Extra manual-validation paths, not part of the stable pack |
+
 - The disposable live-app MCP harness lives in `McpServerEndToEndTests` and is gated by:
 
 ```powershell
 $env:RUN_UI_TESTS = "true"
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
+$env:RUN_EXTERNAL_UI_TESTS = "true"
 $env:RUN_EXPERIMENTAL_UI_TESTS = "true"
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadRoundTrip
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadTargetAreaRoundTrip
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWindowMutationRoundTrip
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWorkflowRoundTrip
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadAllowedProcessPolicy
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDeniedProcessPolicy
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDryRunPolicy
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_NotepadRoundTrip|McpServer_NotepadTargetAreaRoundTrip|McpServer_NotepadWindowMutationRoundTrip|McpServer_NotepadWorkflowRoundTrip|McpServer_NotepadAllowedProcessPolicy|McpServer_NotepadDeniedProcessPolicy|McpServer_NotepadDryRunPolicy"
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_TestApp"
 ```
 
 - Those live MCP desktop tests intentionally run under `net8.0-windows` in the runbook examples because they all drive the shared `DesktopManager.Cli.exe` host and the same real desktop session; the same flows can also be exercised under `net10.0-windows` when validating the newer runtime target.
-- The safety-policy harness now covers one allowed scoped mutation, one denied scoped mutation, and one dry-run scoped mutation preview against a disposable Notepad window.
-- The stable live MCP desktop pack now stays on the Notepad-backed flows, while both Chromium-style foreground-input harnesses live behind `RUN_EXPERIMENTAL_UI_TESTS=true` so they can be exercised manually without destabilizing regular regression runs.
-- When the experimental Chromium opt-in harness goes inconclusive, it now keeps a screenshot plus control-diagnostic bundle under `%TEMP%\DesktopManager.Tests\McpE2E\Experimental`, exercises temporary named window/control targets so the fallback path stays aligned with the shared targeting workflow, and writes `decision-trace.txt` plus `comparison.txt` for follow-up analysis.
+- The stable live MCP pack is now repo-owned `DesktopManager.TestApp` coverage rather than external Notepad/Edge coverage.
+- Foreground and hosted-session validations should only be enabled in sacrificial or explicitly prepared sessions.
+
+Owned-window mutation slice without system-wide or foreground changes:
+
+```powershell
+$env:RUN_UI_TESTS = "true"
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "WindowPositionTests|WindowStateHelpersTests|WindowVisibilityTests|WindowTransparencyTests|WindowStyleModificationTests|WindowLayoutTests|WindowActivationPositioningTests"
+```
+
+Foreground-window slice:
+
+```powershell
+$env:RUN_UI_TESTS = "true"
+$env:RUN_DESTRUCTIVE_UI_TESTS = "true"
+$env:RUN_FOREGROUND_UI_TESTS = "true"
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "DesktopAutomationAssertionTests|WindowManagerFilterTests|WindowTopMostActivationTests"
+```
+
+System-wide desktop mutation slice:
+
+```powershell
+$env:RUN_UI_TESTS = "true"
+$env:RUN_DESTRUCTIVE_UI_TESTS = "true"
+$env:RUN_SYSTEM_UI_TESTS = "true"
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "BackgroundColorTests|MonitorBrightnessTests|MonitorFallbackTests|MonitorResolutionOrientationTests|LogonWallpaperTests"
+```
+
+## Hosted-Session Diagnostics
+
+When the repo-owned hosted-session typing harness goes inconclusive, inspect artifacts in this order:
+
+1. Open the newest `Artifacts\HostedSessionTyping\*.summary.txt` companion first.
+2. Use the `RetryHistory` line to decide whether the interruption was a repeated single culprit or mixed contention.
+3. Only open the matching `.json` snapshot if the summary is not enough.
+
+Common summary categories:
+
+- `browser-electron`
+  Usually means Edge, Codex, ChatGPT, or another Chromium/Electron-style window kept stealing focus.
+- `mixed`
+  More than one foreground category interrupted the run, so the desktop session was generally noisy.
+- `none`
+  No retained external culprit was captured, so use the raw JSON snapshot and `LastObservedForeground*` fields for follow-up.
+
+Artifact behavior:
+
+- Each hosted-session diagnostic set includes one `.json` snapshot and one companion `*.summary.txt` file.
+- The companion summary filename now carries the retry-history category hint when available.
+- Older hosted-session diagnostic sets are trimmed automatically and the newest sets are kept.
+
+Quick PowerShell inspection flow:
+
+```powershell
+.\Build\Get-HostedSessionDiagnostic.ps1 -SummaryOnly
+```
+
+JSON fallback for the newest hosted-session artifact:
+
+```powershell
+.\Build\Get-HostedSessionDiagnostic.ps1
+.\Build\Get-HostedSessionDiagnostic.ps1 -AsJson
+```

--- a/Docs/DesktopManager.Architecture.md
+++ b/Docs/DesktopManager.Architecture.md
@@ -1,0 +1,185 @@
+# DesktopManager Architecture
+
+DesktopManager exposes one shared desktop-automation core through several different surfaces. This document shows how the C# library, PowerShell module, CLI executable, and MCP server relate to each other, where state is stored, and how request and verification flows are shared.
+
+## Surface Overview
+
+| Surface | Audience | Strengths | Typical entrypoint |
+| ------- | -------- | --------- | ------------------ |
+| C# library | App developers | Direct API access, strongest typing, reusable inside your own code | `DesktopManager.dll` |
+| PowerShell module | Operators and scripters | Cmdlet UX, object pipeline, easy admin automation | `Install-Module DesktopManager` |
+| CLI | Humans, shell scripts, JSON-oriented tooling | Simple commands, process isolation, direct manual use, MCP host entrypoint | `desktopmanager.exe` |
+| MCP server | Agents and desktop copilots | Inspect-first safety model, process scoping, dry-run and mutation controls | `desktopmanager mcp serve` |
+
+```mermaid
+flowchart TD
+    A["Your .NET app"] --> E["DesktopManager core library"]
+    B["PowerShell cmdlets"] --> E
+    C["desktopmanager.exe CLI"] --> F["DesktopOperations"]
+    D["MCP over stdio"] --> C
+
+    F --> E
+
+    E --> G["WindowManager"]
+    E --> H["DesktopAutomationService"]
+    E --> I["Monitor and screenshot services"]
+    E --> J["WindowInputService and verification helpers"]
+```
+```
+
+## What Runs Where
+
+The important design choice is that DesktopManager tries hard to keep desktop behavior in the shared C# library instead of re-implementing it in each surface.
+
+- The **C# library** owns the real desktop behavior.
+- The **PowerShell module** wraps that behavior in cmdlets and PowerShell-friendly records.
+- The **CLI** wraps it in command parsing, JSON/text formatting, and desktop-oriented workflows.
+- The **MCP server** is hosted by the CLI executable and reuses the same `DesktopOperations` layer as normal CLI commands.
+
+```mermaid
+flowchart LR
+    A["Operator / script / agent request"] --> B{"Chosen surface"}
+    B -->|".NET"| C["DesktopManager API"]
+    B -->|"PowerShell"| D["Cmdlet wrapper"]
+    B -->|"CLI"| E["Command parser"]
+    B -->|"MCP"| F["MCP tool schema + desktopmanager mcp serve"]
+
+    D --> C
+    E --> G["DesktopOperations"]
+    F --> G
+    G --> C
+
+    C --> H["Shared Windows actions"]
+    H --> I["Window and control input"]
+    H --> J["Monitor and wallpaper state"]
+    H --> K["Saved targets, layouts, snapshots"]
+```
+
+## CLI and MCP Relationship
+
+The MCP server is not a separate desktop engine. It is a hosted mode of `desktopmanager.exe` that exposes the same operation layer over stdio.
+
+```mermaid
+flowchart TD
+    A["desktopmanager window/control/monitor/process/..."] --> B["DesktopOperations"]
+    C["desktopmanager mcp serve"] --> D["MCP catalog and safety policy"]
+    D --> B
+    E["Saved state on disk"] --> B
+    B --> F["DesktopManager core library"]
+    F --> G["Windows desktop APIs"]
+```
+
+That means:
+
+- CLI and MCP share result shaping, saved-state conventions, and mutation behavior.
+- MCP safety flags such as `--allow-mutations`, `--allow-process`, and `--dry-run` are layered around the same underlying operations.
+- Fixes in the shared library usually benefit CLI, MCP, and PowerShell together.
+
+## Manual Use vs Agent Use
+
+| Scenario | Best surface | Why |
+| -------- | ------------ | --- |
+| Embed DesktopManager in your own product | C# library | You want direct APIs and full control in-process |
+| Run a repeatable operator script | PowerShell module | Native PowerShell objects and cmdlet ergonomics |
+| Run one-off commands manually or from CI | CLI | Simple command syntax and optional JSON output |
+| Let an agent inspect and then mutate cautiously | MCP | Read-only by default with explicit mutation controls |
+
+For manual work, the CLI is the most direct path:
+
+```text
+desktopmanager window list
+desktopmanager window geometry --process notepad --json
+desktopmanager control diagnose --window-title "Codex" --json
+desktopmanager process start-and-wait notepad.exe --window-title "*Notepad*" --json
+desktopmanager mcp serve --allow-mutations
+```
+
+For repeatable operator automation, the PowerShell module is usually the best fit:
+
+```powershell
+Get-DesktopWindow
+Get-DesktopWindowControl -Name "*Notepad*"
+Set-DesktopWindow -Name "*Notepad*" -Left 0 -Top 0 -Width 1200 -Height 900
+Set-DesktopWindowText -Name "*Notepad*" -Text "Hello world"
+```
+
+## Shared State and Artifacts
+
+DesktopManager uses the same core storage concepts across surfaces.
+
+| Kind | Purpose | Typical location |
+| ---- | ------- | ---------------- |
+| Layouts | Saved window arrangements | `%AppData%\DesktopManager\layouts` |
+| Snapshots | Saved desktop/window state | `%AppData%\DesktopManager\snapshots` |
+| Targets | Reusable window-relative click/drag/screenshot areas | `%AppData%\DesktopManager\targets` |
+| Control targets | Reusable control selectors | `%AppData%\DesktopManager\control-targets` |
+| Captures | Screenshots and evidence | `%AppData%\DesktopManager\captures` or caller-provided artifact directory |
+| Hosted-session diagnostics | Focus-steal and retry diagnostics from test harnesses | `Artifacts\HostedSessionTyping` in the repo |
+
+```mermaid
+flowchart LR
+    A["Mutating command or tool call"] --> B["DesktopOperations / shared services"]
+    B --> C["Desktop action"]
+    B --> D["Optional verification"]
+    B --> E["Optional screenshots and artifacts"]
+    B --> F["Optional saved state read/write"]
+
+    F --> G["layouts"]
+    F --> H["snapshots"]
+    F --> I["targets"]
+    F --> J["control-targets"]
+    E --> K["captures / hosted-session diagnostics"]
+```
+
+## Verification and Feedback Flow
+
+DesktopManager is moving away from a bare "request succeeded" model and toward optional post-action verification.
+
+- CLI mutating commands can opt into `--verify`.
+- MCP mutating tools can request verification in structured results.
+- PowerShell cmdlets can opt into `-Verify` and `-PassThru`.
+
+That verification is shared wherever possible:
+
+- geometry-sensitive actions can verify observed position and size
+- focus-sensitive actions can verify the foreground window
+- minimize-style actions can verify state
+- higher-risk typing or pointer actions can still return honest presence-oriented observation, even when perfect proof is not available
+
+## Safety Model
+
+DesktopManager now uses a more explicit safety split for tests and agent/operator sessions.
+
+| Area | Safety idea |
+| ---- | ----------- |
+| MCP | Read-only by default, mutations require `--allow-mutations` |
+| Risky control fallback | Explicit `--allow-foreground-input` |
+| Hosted-session typing | Explicit foreground/scancode modes with abort-on-focus-drift behavior |
+| Tests | Separate gates for owned-window UI, destructive owned-window mutation, foreground focus, system-wide changes, external apps, and experiments |
+| Mutation feedback | CLI, MCP, and PowerShell can opt into richer verification instead of trusting a bare success path |
+
+## Test and Harness Relationship
+
+The repo also includes a local desktop harness app so DesktopManager can validate tricky UI flows without defaulting to live third-party apps.
+
+```mermaid
+flowchart TD
+    A["DesktopManager.TestApp"] --> B["Repo-owned test windows and controls"]
+    C["DesktopManager.Tests"] --> B
+    C --> D["Hosted-session diagnostics"]
+    D --> E["Artifacts/HostedSessionTyping"]
+    C --> F["Shared DesktopManager core"]
+```
+```
+
+This is why current UI tests are safer than earlier generations of the suite:
+
+- many tests now touch repo-owned WinForms/WPF harness windows instead of your live apps
+- foreground-stealing and system-wide tests are separately gated
+- hosted-session experiments leave structured diagnostics instead of silently failing
+
+## Where to Read Next
+
+- [Docs/DesktopManager.Cli.md](DesktopManager.Cli.md)
+- [Docs/DesktopManager.Mcp.md](DesktopManager.Mcp.md)
+- [Docs/Build.Runbook.md](Build.Runbook.md)

--- a/Docs/DesktopManager.Cli.md
+++ b/Docs/DesktopManager.Cli.md
@@ -104,8 +104,17 @@ desktopmanager mcp serve --dry-run
 - zero-handle UIA text and key fallback paths are now shared too, but they are intentionally opt-in because they rely on focused foreground input for modern apps.
 - when zero-handle UIA text fallback is enabled, the shared library now prefers a focused replace-and-paste flow with verification before it falls back to raw typed input, which is notably more reliable for Chromium-style edit fields.
 - `window type` sends text to the target window, either by simulated typing or clipboard paste.
+- `window type --foreground-input` requires real foreground keyboard delivery and fails instead of silently falling back to background window messaging, which is a better fit for remote-session hosts such as RDP, Hyper-V, and Remote Desktop Manager.
+- `window type --physical-keys` adds a layout-aware physical-key typing mode for foreground targets, which is often closer to how password managers "type" into hosted remote sessions.
+- `window type --hosted-session` is a convenience profile for RDP, Hyper-V, and Remote Desktop Manager style targets. It enables a US-style foreground scancode path with slower defaults that are safer for hosted editors.
+- `window type --script` preserves multiline formatting, chunks long lines into smaller typed segments, and can be combined with either the default delivery path or the stricter foreground typing modes.
+- mutating `window` commands now support `--verify`, which re-queries the mutated window after the action and reports an observed postcondition instead of only the request outcome.
+- `--verify-tolerance-px` tunes geometry verification for commands like `window move`; specifying it also implies `--verify`.
+- the verification block is action-aware for `window move`, `window focus`, and `window minimize`, and falls back to honest presence-only observation for other window mutations such as typing and pointer input.
+- hosted-session live diagnostics now write repo-local artifacts under `Artifacts\HostedSessionTyping`, including a raw JSON snapshot and a companion `*.summary.txt` file with the likely focus-culprit category and retry summary.
+- hosted-session diagnostic artifacts now trim older entries automatically, keeping the newest artifact sets so the folder stays readable during repeated harness runs.
 - `window keys` sends key chords or single keys to the target window after activating it, which is the safer shared follow-up path for Enter, Escape, and similar actions when modern controls stop being structurally reusable after text entry.
-- mutating `window` and `control` commands can now return shared verification metadata: `success`, `elapsedMilliseconds`, `safetyMode`, optional target name/kind, best-effort before/after screenshots, and artifact warnings.
+- mutating `window` and `control` commands can now return shared verification metadata: `success`, `elapsedMilliseconds`, `safetyMode`, optional target name/kind, best-effort before/after screenshots, artifact warnings, and for verified window mutations an explicit `verification` block with observed counts, summary text, and notes.
 - those mutating commands now also accept `--capture-before`, `--capture-after`, and `--artifact-directory` so CLI, MCP, and agent workflows can ask for evidence without changing the core action logic.
 - `workflow prepare-coding` can optionally apply a named layout and then focus a likely editor or terminal window.
 - `workflow prepare-screen-sharing` can optionally apply a named layout, minimize common distractions, and then focus a likely sharing window.
@@ -129,7 +138,12 @@ desktopmanager mcp serve --dry-run
 - repeated UIA actions in the same long-lived process now also try a cached exact-match lookup before they fall back to a broader root walk.
 - the shared control wait path now prefers already-seen matching window handles inside the same process before it falls back to broad rediscovery, which is safer for stable modern-app windows.
 - `screenshot window` now prefers real window rendering before falling back to screen pixels, which improves captures for covered windows.
-- `window type` now falls back to direct message-based delivery when Windows refuses to foreground the target window, which avoids leaking `SendInput` text into whatever app currently owns focus.
+- `window type` still falls back to direct message-based delivery by default when Windows refuses to foreground the target window, which avoids leaking `SendInput` text into whatever app currently owns focus.
+- `window type --foreground-input` disables that fallback and skips direct `WM_SETTEXT` verification, so it behaves more like deliberate keyboard typing than background control mutation.
+- `window type --physical-keys` builds on the strict foreground path and prefers real keyboard-layout key combinations before it falls back to Unicode packets for characters that have no physical-key mapping.
+- `window type --hosted-session` currently wraps a foreground US-style scancode path with slower pacing defaults. It requires the hosted editor surface to already own focus before typing starts, and it now aborts immediately if foreground ownership changes while typing.
+- `window type --script --foreground-input` is the preferred shared path when you need to type a multiline script into an RDP, Hyper-V, or Remote Desktop Manager hosted editor without relying on clipboard paste.
+- when the hosted-session harness goes inconclusive, inspect the matching `Artifacts\HostedSessionTyping\*.summary.txt` companion first. It now calls out whether the interruption looked like a repeated browser/Electron focus steal, mixed contention, or no retained external culprit.
 - `process start` now prefers windows from the launched process and then newer post-launch window handles for the target app, which is safer than binding to any older matching window.
 - `process start --require-window` is now a useful shared primitive for unattended workflows that need a validated target window instead of a best-effort launcher result.
 - `mcp serve` hosts a stdio MCP server.

--- a/README.MD
+++ b/README.MD
@@ -193,17 +193,40 @@ Install-Module DesktopManager -Force -Verbose
 
 UI-impacting tests are opt-in to avoid opening windows or changing the desktop during local development. Use the environment variables below to control behavior:
 
-- `RUN_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_UI_TESTS=true`) enables UI tests.
-- `RUN_DESTRUCTIVE_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true`) enables tests that change desktop state, including the live MCP Notepad round-trip harness and tests that change wallpapers, brightness, or resolution.
+- `RUN_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_UI_TESTS=true`) enables owned-window UI tests that use repo-created harness windows.
+- `RUN_DESTRUCTIVE_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true`) enables owned-window mutation tests such as move, resize, hide, snap, and transparency changes against repo-created harness windows.
+- `RUN_FOREGROUND_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_FOREGROUND_UI_TESTS=true`) enables tests that intentionally steal foreground focus, even when they only target repo-created harness windows.
+- `RUN_SYSTEM_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_SYSTEM_UI_TESTS=true`) enables system-wide desktop changes such as wallpapers, brightness, resolution, and other monitor-level mutations that can affect your current session.
+- `RUN_EXTERNAL_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_EXTERNAL_UI_TESTS=true`) enables live external-application UI tests and MCP end-to-end harnesses that launch real desktop apps.
 - `RUN_EXPERIMENTAL_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_EXPERIMENTAL_UI_TESTS=true`) enables experimental live UI harnesses that are useful for manual validation but are not part of the stable regression pack.
 - `SKIP_UI_TESTS=true` (or `DESKTOPMANAGER_SKIP_UI_TESTS=true`) forces UI tests to skip, even if enabled elsewhere.
 
+The gates compose intentionally:
+
+| Gate | What it permits | Typical impact |
+| ---- | --------------- | -------------- |
+| `RUN_UI_TESTS` | Repo-owned WinForms/WPF harness windows | Low |
+| `RUN_DESTRUCTIVE_UI_TESTS` | Mutations against owned harness windows | Medium |
+| `RUN_FOREGROUND_UI_TESTS` | Tests that intentionally take foreground focus | Medium to high |
+| `RUN_SYSTEM_UI_TESTS` | System-wide desktop changes | High |
+| `RUN_EXTERNAL_UI_TESTS` | Launching real desktop apps | Medium to high |
+| `RUN_EXPERIMENTAL_UI_TESTS` | Experimental live harnesses | Varies |
+
 ```powershell
-# Run UI tests
+# Run owned-window UI tests
 $env:RUN_UI_TESTS = "true"
 
-# Run tests that change desktop settings
+# Run repo-owned window mutation tests
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
+
+# Run tests that intentionally steal foreground focus
+$env:RUN_FOREGROUND_UI_TESTS = "true"
+
+# Run system-wide desktop mutations
+$env:RUN_SYSTEM_UI_TESTS = "true"
+
+# Run live external-application harnesses
+$env:RUN_EXTERNAL_UI_TESTS = "true"
 
 # Run experimental live UI harnesses
 $env:RUN_EXPERIMENTAL_UI_TESTS = "true"
@@ -211,38 +234,17 @@ $env:RUN_EXPERIMENTAL_UI_TESTS = "true"
 # Force skip
 $env:SKIP_UI_TESTS = "true"
 
-# Run the live MCP Notepad end-to-end harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadRoundTrip
+# Run the repo-owned window mutation slice
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "WindowPositionTests|WindowStateHelpersTests|WindowVisibilityTests|WindowTransparencyTests|WindowStyleModificationTests|WindowLayoutTests"
 
-# Run the live MCP target-area capture harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadTargetAreaRoundTrip
+# Run the foreground-window slice
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "DesktopAutomationAssertionTests|WindowManagerFilterTests|WindowTopMostActivationTests"
 
-# Run the live MCP window-move and geometry verification harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWindowMutationRoundTrip
-
-# Run the live MCP workflow harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadWorkflowRoundTrip
-
-# Run the live MCP allowlisted process-policy harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadAllowedProcessPolicy
-
-# Run the live MCP denied-process policy harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDeniedProcessPolicy
-
-# Run the live MCP dry-run policy harness (net8 only)
-dotnet test Sources/DesktopManager.sln -f net8.0-windows --filter McpServer_NotepadDryRunPolicy
-
-# Run the stable live MCP desktop pack (net8 only)
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_NotepadRoundTrip|McpServer_NotepadTargetAreaRoundTrip|McpServer_NotepadWindowMutationRoundTrip|McpServer_NotepadWorkflowRoundTrip|McpServer_NotepadAllowedProcessPolicy|McpServer_NotepadDeniedProcessPolicy|McpServer_NotepadDryRunPolicy"
-
-# Run the experimental live MCP blocked foreground-input Edge harness (net8 only)
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_BlocksOmniboxEnterWithoutServerOptIn
-
-# Run the experimental live MCP foreground-input opt-in Edge harness (net8 only)
-dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter McpServer_EdgeForegroundInputPolicy_AllowsOmniboxEnterWithServerOptIn
+# Run the live MCP desktop pack backed by the repo-owned DesktopManager.TestApp harness
+dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "McpServer_TestApp"
 ```
 
-When the experimental Chromium opt-in harness skips because the omnibox never becomes reliably discoverable, it now leaves a screenshot plus control-diagnostic bundle under `%TEMP%\DesktopManager.Tests\McpE2E\Experimental` and uses temporary named window/control targets so the fallback path matches the shared targeting model. Each bundle now also includes `decision-trace.txt` and `comparison.txt`.
+When the hosted-session or experimental live harnesses skip because focus or discoverability never stabilize, they now leave structured diagnostics and artifacts rather than failing silently. See [Docs/Build.Runbook.md](Docs/Build.Runbook.md) for the hosted-session artifact flow and gate guidance.
 
 ### Usage
 

--- a/README.MD
+++ b/README.MD
@@ -521,7 +521,7 @@ WindowKeepAlive.Instance.StopAll();
 
 ### C# API Highlights
 
-DesktopManager ships as a .NET library targeting `net472`, `netstandard2.0` and `net8.0`. The main entry points are:
+DesktopManager ships as a .NET library targeting `net472`, `netstandard2.0`, `net8.0-windows`, and `net10.0-windows`. The main entry points are:
 
 - `Monitors` for monitor enumeration, wallpaper management, brightness, resolution, orientation and slideshow control.
 - `WindowManager` for window enumeration, positioning, resizing and layout persistence.

--- a/README.MD
+++ b/README.MD
@@ -59,8 +59,72 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 
 - [Docs/DesktopManager.Cli.md](Docs/DesktopManager.Cli.md)
 - [Docs/DesktopManager.Mcp.md](Docs/DesktopManager.Mcp.md)
+- [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md)
 - [.agents/skills/desktopmanager-operator/SKILL.md](.agents/skills/desktopmanager-operator/SKILL.md)
 - [.agents/skills/desktopmanager-build/SKILL.md](.agents/skills/desktopmanager-build/SKILL.md)
+
+## Which Surface Should You Use?
+
+| Surface | Best for | Typical entrypoint |
+| ------- | -------- | ------------------ |
+| C# library | Embedding DesktopManager into your own .NET app or service | `DesktopManager.dll` |
+| PowerShell module | Scripts, operators, admin workflows, repeatable task automation | `Install-Module DesktopManager` |
+| CLI executable | Manual use, shell automation, JSON output, and MCP hosting | `desktopmanager.exe` |
+| MCP server | Agent-driven automation over stdio with an inspect-first safety model | `desktopmanager mcp serve` |
+
+## How It Fits Together
+
+DesktopManager now has one shared core and several operator-facing surfaces on top of it.
+
+```mermaid
+flowchart LR
+    A["Your .NET app"] --> B["DesktopManager library"]
+    C["PowerShell module"] --> B
+    D["desktopmanager.exe CLI"] --> B
+    E["MCP server"] --> D
+    B --> F["Windows desktop APIs"]
+    F --> G["Monitors / wallpapers / brightness"]
+    F --> H["Windows / controls / input"]
+    F --> I["Layouts / snapshots / targets"]
+```
+
+If you want the fuller component and request-flow diagrams, see [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md).
+
+The practical rule of thumb is:
+
+- use the library when DesktopManager is part of your own application
+- use PowerShell when you want scriptable admin/operator automation
+- use the CLI when you want a human-friendly or JSON-friendly command surface
+- use MCP when an agent should inspect first and mutate only through an explicit server session
+
+## Common Entry Points
+
+| Goal | Recommended entrypoint |
+| ---- | ---------------------- |
+| Add DesktopManager features to your own code | Reference the `DesktopManager` NuGet package |
+| Run manual desktop operations from a terminal | `desktopmanager.exe` |
+| Use it from PowerShell scripts | `DesktopManager` PowerShell module |
+| Connect an agent/tooling layer | `desktopmanager mcp serve` |
+| Understand the overall wiring | [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md) |
+
+## Request Flow at a Glance
+
+```mermaid
+flowchart LR
+    A["User, script, or agent"] --> B{"Surface"}
+    B -->|".NET"| C["DesktopManager library"]
+    B -->|"PowerShell"| D["Cmdlets"]
+    B -->|"CLI"| E["desktopmanager.exe"]
+    B -->|"MCP"| F["desktopmanager mcp serve"]
+
+    D --> C
+    E --> G["DesktopOperations"]
+    F --> G
+    G --> C
+    C --> H["Win32, UI Automation, monitor, screenshot, and input services"]
+```
+
+The important part is that CLI, MCP, and PowerShell are meant to stay aligned by reusing the same shared C# behavior rather than inventing separate desktop logic in each surface.
 
 
 ### Available PowerShell Cmdlets

--- a/Sources/DesktopManager.Cli/CliApplication.cs
+++ b/Sources/DesktopManager.Cli/CliApplication.cs
@@ -18,6 +18,9 @@ internal static class CliApplication {
 
             string group = parsed.GetCommandPart(0)?.ToLowerInvariant() ?? string.Empty;
             string action = parsed.GetCommandPart(1)?.ToLowerInvariant() ?? string.Empty;
+            if (RequiresAction(group) && string.IsNullOrWhiteSpace(action)) {
+                throw new CommandLineException($"Missing required {group} command.");
+            }
 
             return group switch {
                 "window" => WindowCommands.Run(action, parsed),
@@ -43,6 +46,23 @@ internal static class CliApplication {
             error.WriteLine($"Unhandled error: {ex.Message}");
             return 1;
         }
+    }
+
+    internal static bool RequiresAction(string? group) {
+        return group?.ToLowerInvariant() switch {
+            "window" => true,
+            "control" => true,
+            "monitor" => true,
+            "process" => true,
+            "screenshot" => true,
+            "target" => true,
+            "control-target" => true,
+            "layout" => true,
+            "snapshot" => true,
+            "workflow" => true,
+            "mcp" => true,
+            _ => false
+        };
     }
 
     internal static string GetHelpText(string? topic) {

--- a/Sources/DesktopManager.Cli/DesktopManager.Cli.csproj
+++ b/Sources/DesktopManager.Cli/DesktopManager.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Sources/DesktopManager.Cli/DesktopModels.cs
+++ b/Sources/DesktopManager.Cli/DesktopModels.cs
@@ -16,6 +16,18 @@ internal sealed class WindowSelectionCriteria {
     public bool All { get; set; }
 }
 
+internal sealed class WindowTextCommandOptions {
+    public string Text { get; set; } = string.Empty;
+    public bool Paste { get; set; }
+    public int DelayMilliseconds { get; set; }
+    public bool ForegroundInput { get; set; }
+    public bool PhysicalKeys { get; set; }
+    public bool HostedSession { get; set; }
+    public bool ScriptMode { get; set; }
+    public int ScriptChunkLength { get; set; } = 120;
+    public int ScriptLineDelayMilliseconds { get; set; }
+}
+
 internal sealed class ControlSelectionCriteria {
     public string ClassNamePattern { get; set; } = "*";
     public string TextPattern { get; set; } = "*";
@@ -66,6 +78,7 @@ internal sealed class WindowChangeResult {
     public IReadOnlyList<ScreenshotResult> AfterScreenshots { get; set; } = new List<ScreenshotResult>();
     public IReadOnlyList<string> ArtifactWarnings { get; set; } = new List<string>();
     public IReadOnlyList<WindowResult> Windows { get; set; } = new List<WindowResult>();
+    public WindowMutationVerificationResult? Verification { get; set; }
 }
 
 internal sealed class WindowGeometryResult {
@@ -430,6 +443,22 @@ internal sealed class MutationArtifactOptions {
     public bool CaptureBefore { get; set; }
     public bool CaptureAfter { get; set; }
     public string? ArtifactDirectory { get; set; }
+    public bool VerifyAfter { get; set; }
+    public int VerificationTolerancePixels { get; set; } = 10;
+}
+
+internal sealed class WindowMutationVerificationResult {
+    public bool Verified { get; set; }
+    public string Mode { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public int ExpectedCount { get; set; }
+    public int ObservedCount { get; set; }
+    public int MatchedCount { get; set; }
+    public int MismatchCount { get; set; }
+    public int TolerancePixels { get; set; }
+    public WindowResult? ActiveWindow { get; set; }
+    public IReadOnlyList<string> Notes { get; set; } = new List<string>();
+    public IReadOnlyList<WindowResult> ObservedWindows { get; set; } = new List<WindowResult>();
 }
 
 internal sealed class WorkflowResult {

--- a/Sources/DesktopManager.Cli/DesktopOperations.Mutations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.Mutations.cs
@@ -1,13 +1,15 @@
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace DesktopManager.Cli;
 
 internal static partial class DesktopOperations {
-    private static WindowChangeResult ExecuteWindowMutation(string action, WindowSelectionCriteria criteria, string safetyMode, MutationArtifactOptions? artifactOptions, Func<DesktopAutomationService, IReadOnlyList<WindowInfo>> mutation, string? targetName = null, string? targetKind = null) {
+    private static WindowChangeResult ExecuteWindowMutation(string action, WindowSelectionCriteria criteria, string safetyMode, MutationArtifactOptions? artifactOptions, Func<DesktopAutomationService, IReadOnlyList<WindowInfo>> mutation, string? targetName = null, string? targetKind = null, Func<DesktopAutomationService, IReadOnlyList<WindowInfo>, MutationArtifactOptions, WindowMutationVerificationResult?>? verify = null) {
         return ExecuteCore(() => {
             var automation = new DesktopAutomationService();
             var warnings = new List<string>();
@@ -19,13 +21,14 @@ internal static partial class DesktopOperations {
                 : Array.Empty<ScreenshotResult>();
 
             IReadOnlyList<WindowInfo> windows = mutation(automation);
+            WindowMutationVerificationResult? verification = VerifyWindowMutation(automation, action, windows, options, verify, warnings);
 
             IReadOnlyList<ScreenshotResult> afterScreenshots = options.CaptureAfter
                 ? CaptureWindowArtifacts(automation, windows, action, "after", options, warnings)
                 : Array.Empty<ScreenshotResult>();
 
             stopwatch.Stop();
-            return BuildWindowChangeResult(action, windows, (int)stopwatch.ElapsedMilliseconds, safetyMode, targetName, targetKind, beforeScreenshots, afterScreenshots, warnings);
+            return BuildWindowChangeResult(action, windows, (int)stopwatch.ElapsedMilliseconds, safetyMode, targetName, targetKind, beforeScreenshots, afterScreenshots, warnings, verification);
         });
     }
 
@@ -171,6 +174,60 @@ internal static partial class DesktopOperations {
     private static string FormatWindowLabel(WindowInfo window) {
         string title = string.IsNullOrWhiteSpace(window.Title) ? "<untitled>" : window.Title;
         return $"{title} ({window.Handle.ToInt64():X})";
+    }
+
+    private static WindowMutationVerificationResult? VerifyWindowMutation(DesktopAutomationService automation, string action, IReadOnlyList<WindowInfo> windows, MutationArtifactOptions options, Func<DesktopAutomationService, IReadOnlyList<WindowInfo>, MutationArtifactOptions, WindowMutationVerificationResult?>? verify, List<string> warnings) {
+        if (!options.VerifyAfter) {
+            return null;
+        }
+
+        try {
+            Thread.Sleep(75);
+            if (verify != null) {
+                return verify(automation, windows, options);
+            }
+
+            return BuildWindowPresenceVerificationResult(action, windows, ObserveWindowsByHandle(automation, windows), tolerancePixels: options.VerificationTolerancePixels);
+        } catch (Exception ex) when (IsArtifactWarning(ex) || ex is Win32Exception || ex is TimeoutException) {
+            warnings.Add($"Post-mutation verification failed for '{action}': {ex.Message}");
+            return new WindowMutationVerificationResult {
+                Verified = false,
+                Mode = "verification-error",
+                Summary = $"The '{action}' mutation completed, but DesktopManager could not verify the final state.",
+                ExpectedCount = windows.Count,
+                ObservedCount = 0,
+                MatchedCount = 0,
+                MismatchCount = windows.Count,
+                TolerancePixels = options.VerificationTolerancePixels,
+                Notes = new[] { ex.Message }
+            };
+        }
+    }
+
+    private static IReadOnlyList<WindowInfo> ObserveWindowsByHandle(DesktopAutomationService automation, IReadOnlyList<WindowInfo> windows) {
+        if (windows.Count == 0) {
+            return Array.Empty<WindowInfo>();
+        }
+
+        var observedWindows = new List<WindowInfo>(windows.Count);
+        foreach (WindowInfo window in windows) {
+            if (window.Handle == IntPtr.Zero) {
+                continue;
+            }
+
+            IReadOnlyList<WindowInfo> matches = automation.GetWindows(new WindowQueryOptions {
+                Handle = window.Handle,
+                IncludeHidden = true,
+                IncludeCloaked = true,
+                IncludeOwned = true,
+                IncludeEmptyTitles = true
+            });
+            if (matches.Count > 0) {
+                observedWindows.Add(matches[0]);
+            }
+        }
+
+        return observedWindows;
     }
 
     private static bool IsArtifactWarning(Exception exception) {

--- a/Sources/DesktopManager.Cli/DesktopOperations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -36,7 +37,19 @@ internal static partial class DesktopOperations {
             criteria,
             activate ? "window-management-activate" : "window-management",
             artifactOptions,
-            automation => automation.MoveWindows(CreateWindowQuery(criteria), monitorIndex, x, y, width, height, activate, criteria.All));
+            automation => automation.MoveWindows(CreateWindowQuery(criteria), monitorIndex, x, y, width, height, activate, criteria.All),
+            verify: (automation, windows, options) => BuildWindowPostconditionVerificationResult(
+                "move",
+                windows,
+                ObserveWindowsByHandle(automation, windows),
+                SafeGetActiveWindowInfo(automation),
+                options.VerificationTolerancePixels,
+                monitorIndex,
+                x,
+                y,
+                width,
+                height,
+                activate));
     }
 
     public static WindowChangeResult FocusWindow(WindowSelectionCriteria criteria, MutationArtifactOptions? artifactOptions = null) {
@@ -45,7 +58,14 @@ internal static partial class DesktopOperations {
             criteria,
             "window-management-activate",
             artifactOptions,
-            automation => automation.FocusWindows(CreateWindowQuery(criteria), criteria.All));
+            automation => automation.FocusWindows(CreateWindowQuery(criteria), criteria.All),
+            verify: (automation, windows, options) => BuildWindowPostconditionVerificationResult(
+                "focus",
+                windows,
+                ObserveWindowsByHandle(automation, windows),
+                SafeGetActiveWindowInfo(automation),
+                options.VerificationTolerancePixels,
+                requireForegroundMatch: true));
     }
 
     public static WindowChangeResult ClickWindowPoint(WindowSelectionCriteria criteria, int? x, int? y, double? xRatio, double? yRatio, string button, bool activate, bool clientArea, MutationArtifactOptions? artifactOptions = null) {
@@ -118,7 +138,13 @@ internal static partial class DesktopOperations {
             criteria,
             "window-management",
             artifactOptions,
-            automation => automation.MinimizeWindows(CreateWindowQuery(criteria), criteria.All));
+            automation => automation.MinimizeWindows(CreateWindowQuery(criteria), criteria.All),
+            verify: (automation, windows, options) => BuildWindowPostconditionVerificationResult(
+                "minimize",
+                windows,
+                ObserveWindowsByHandle(automation, windows),
+                SafeGetActiveWindowInfo(automation),
+                options.VerificationTolerancePixels));
     }
 
     public static WindowChangeResult SnapWindow(WindowSelectionCriteria criteria, string position, MutationArtifactOptions? artifactOptions = null) {
@@ -134,17 +160,68 @@ internal static partial class DesktopOperations {
             automation => automation.SnapWindows(CreateWindowQuery(criteria), snapPosition, criteria.All));
     }
 
-    public static WindowChangeResult TypeWindowText(WindowSelectionCriteria criteria, string text, bool paste, int delayMilliseconds, MutationArtifactOptions? artifactOptions = null) {
-        if (text == null) {
+    public static WindowChangeResult TypeWindowText(WindowSelectionCriteria criteria, WindowTextCommandOptions options, MutationArtifactOptions? artifactOptions = null) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (options.Text == null) {
             throw new CommandLineException("Text is required.");
         }
 
+        if (options.Paste && options.ForegroundInput) {
+            throw new CommandLineException("Cannot combine '--paste' with '--foreground-input'.");
+        }
+
+        if (options.Paste && options.PhysicalKeys) {
+            throw new CommandLineException("Cannot combine '--paste' with '--physical-keys'.");
+        }
+
+        if (options.Paste && options.ScriptMode) {
+            throw new CommandLineException("Cannot combine '--paste' with '--script'.");
+        }
+
+        string action = options.Paste
+            ? "paste-text"
+            : options.ScriptMode && options.HostedSession
+                ? "type-script-hosted-session"
+            : options.ScriptMode && options.PhysicalKeys
+                ? "type-script-physical-keys"
+            : options.ScriptMode && options.ForegroundInput
+                ? "type-script-foreground"
+            : options.ScriptMode
+                ? "type-script"
+            : options.HostedSession
+                ? "type-text-hosted-session"
+            : options.PhysicalKeys
+                ? "type-text-physical-keys"
+            : options.ForegroundInput
+                ? "type-text-foreground"
+                : "type-text";
+        string safetyMode = options.Paste
+            ? "window-text-paste"
+            : options.ScriptMode && options.HostedSession
+                ? "window-script-hosted-session-input"
+            : options.ScriptMode && options.PhysicalKeys
+                ? "window-script-physical-key-input"
+            : options.ScriptMode && options.ForegroundInput
+                ? "window-script-foreground-input"
+            : options.ScriptMode
+                ? "window-script-input"
+            : options.HostedSession
+                ? "window-text-hosted-session-input"
+            : options.PhysicalKeys
+                ? "window-text-physical-key-input"
+            : options.ForegroundInput
+                ? "window-text-foreground-input"
+                : "window-text-input";
+
         return ExecuteWindowMutation(
-            paste ? "paste-text" : "type-text",
+            action,
             criteria,
-            paste ? "window-text-paste" : "window-text-input",
+            safetyMode,
             artifactOptions,
-            automation => automation.TypeWindowText(CreateWindowQuery(criteria), text, paste, delayMilliseconds, criteria.All));
+            automation => automation.TypeWindowText(CreateWindowQuery(criteria), options.Text, options.Paste, options.DelayMilliseconds, options.ForegroundInput, options.PhysicalKeys, options.HostedSession, options.ScriptMode, options.ScriptChunkLength, options.ScriptLineDelayMilliseconds, criteria.All));
     }
 
     public static WindowChangeResult SendWindowKeys(WindowSelectionCriteria criteria, IReadOnlyList<string> keys, bool activate, MutationArtifactOptions? artifactOptions = null) {
@@ -626,7 +703,15 @@ internal static partial class DesktopOperations {
         }
     }
 
-    private static WindowChangeResult BuildWindowChangeResult(string action, IReadOnlyList<WindowInfo> windows, int elapsedMilliseconds, string safetyMode, string? targetName, string? targetKind, IReadOnlyList<ScreenshotResult> beforeScreenshots, IReadOnlyList<ScreenshotResult> afterScreenshots, IReadOnlyList<string> artifactWarnings) {
+    private static WindowInfo? SafeGetActiveWindowInfo(DesktopAutomationService automation) {
+        try {
+            return automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
+        } catch {
+            return null;
+        }
+    }
+
+    private static WindowChangeResult BuildWindowChangeResult(string action, IReadOnlyList<WindowInfo> windows, int elapsedMilliseconds, string safetyMode, string? targetName, string? targetKind, IReadOnlyList<ScreenshotResult> beforeScreenshots, IReadOnlyList<ScreenshotResult> afterScreenshots, IReadOnlyList<string> artifactWarnings, WindowMutationVerificationResult? verification) {
         return new WindowChangeResult {
             Action = action,
             Success = true,
@@ -638,8 +723,193 @@ internal static partial class DesktopOperations {
             BeforeScreenshots = beforeScreenshots,
             AfterScreenshots = afterScreenshots,
             ArtifactWarnings = artifactWarnings,
-            Windows = windows.Select(MapWindow).ToArray()
+            Windows = windows.Select(MapWindow).ToArray(),
+            Verification = verification
         };
+    }
+
+    internal static WindowMutationVerificationResult BuildWindowPresenceVerificationResult(string action, IReadOnlyList<WindowInfo> expectedWindows, IReadOnlyList<WindowInfo> observedWindows, int tolerancePixels) {
+        WindowResult[] expected = expectedWindows.Select(MapWindow).ToArray();
+        WindowResult[] observed = observedWindows.Select(MapWindow).ToArray();
+        int observedMatches = CountObservedHandles(expected, observed);
+        bool verified = expected.Length == observedMatches;
+
+        return new WindowMutationVerificationResult {
+            Verified = verified,
+            Mode = "presence",
+            Summary = expected.Length == 0
+                ? $"The '{action}' mutation did not report any windows, so there was nothing to verify."
+                : verified
+                    ? $"Observed all {observedMatches} mutated window(s) after '{action}'."
+                    : $"Observed {observedMatches} of {expected.Length} mutated window(s) after '{action}'.",
+            ExpectedCount = expected.Length,
+            ObservedCount = observed.Length,
+            MatchedCount = observedMatches,
+            MismatchCount = Math.Max(0, expected.Length - observedMatches),
+            TolerancePixels = tolerancePixels,
+            Notes = expected.Length > observedMatches
+                ? BuildMissingHandleNotes(expected, observed)
+                : Array.Empty<string>(),
+            ObservedWindows = observed
+        };
+    }
+
+    internal static WindowMutationVerificationResult BuildWindowPostconditionVerificationResult(string action, IReadOnlyList<WindowInfo> expectedWindows, IReadOnlyList<WindowInfo> observedWindows, WindowInfo? activeWindow, int tolerancePixels, int? monitorIndex = null, int? x = null, int? y = null, int? width = null, int? height = null, bool requireForegroundMatch = false) {
+        WindowResult[] expected = expectedWindows.Select(MapWindow).ToArray();
+        WindowResult[] observed = observedWindows.Select(MapWindow).ToArray();
+        WindowResult? active = activeWindow == null ? null : MapWindow(activeWindow);
+
+        if (action.Equals("focus", StringComparison.OrdinalIgnoreCase)) {
+            return BuildWindowFocusVerificationResult(expected, observed, active, tolerancePixels);
+        }
+
+        if (action.Equals("minimize", StringComparison.OrdinalIgnoreCase)) {
+            return BuildWindowStateVerificationResult(action, expected, observed, active, tolerancePixels, "Minimize");
+        }
+
+        bool hasGeometryExpectation = monitorIndex.HasValue || x.HasValue || y.HasValue || width.HasValue || height.HasValue;
+        if (!hasGeometryExpectation && !requireForegroundMatch) {
+            return BuildWindowPresenceVerificationResult(action, expectedWindows, observedWindows, tolerancePixels);
+        }
+
+        var observedByHandle = observed.ToDictionary(window => window.Handle, StringComparer.OrdinalIgnoreCase);
+        var notes = new List<string>();
+        int matchedCount = 0;
+        foreach (WindowResult expectedWindow in expected) {
+            if (!observedByHandle.TryGetValue(expectedWindow.Handle, out WindowResult? observedWindow)) {
+                notes.Add($"Window {expectedWindow.Handle} is no longer observable after '{action}'.");
+                continue;
+            }
+
+            bool windowMatched = true;
+            if (monitorIndex.HasValue && observedWindow.MonitorIndex != monitorIndex.Value) {
+                notes.Add($"Window {observedWindow.Handle} ended on monitor {observedWindow.MonitorIndex} instead of {monitorIndex.Value}.");
+                windowMatched = false;
+            }
+            if (x.HasValue && Math.Abs(observedWindow.Left - x.Value) > tolerancePixels) {
+                notes.Add($"Window {observedWindow.Handle} left={observedWindow.Left} did not reach requested x={x.Value} within {tolerancePixels}px.");
+                windowMatched = false;
+            }
+            if (y.HasValue && Math.Abs(observedWindow.Top - y.Value) > tolerancePixels) {
+                notes.Add($"Window {observedWindow.Handle} top={observedWindow.Top} did not reach requested y={y.Value} within {tolerancePixels}px.");
+                windowMatched = false;
+            }
+            if (width.HasValue && Math.Abs(observedWindow.Width - width.Value) > tolerancePixels) {
+                notes.Add($"Window {observedWindow.Handle} width={observedWindow.Width} did not reach requested width={width.Value} within {tolerancePixels}px.");
+                windowMatched = false;
+            }
+            if (height.HasValue && Math.Abs(observedWindow.Height - height.Value) > tolerancePixels) {
+                notes.Add($"Window {observedWindow.Handle} height={observedWindow.Height} did not reach requested height={height.Value} within {tolerancePixels}px.");
+                windowMatched = false;
+            }
+
+            if (windowMatched) {
+                matchedCount++;
+            }
+        }
+
+        bool foregroundMatched = !requireForegroundMatch || active != null && expected.Any(window => string.Equals(window.Handle, active.Handle, StringComparison.OrdinalIgnoreCase));
+        if (requireForegroundMatch && !foregroundMatched) {
+            notes.Add(active == null
+                ? "Windows did not report an active foreground window after the mutation."
+                : $"Foreground window was {active.Title} [{active.Handle}] instead of one of the mutated windows.");
+        }
+
+        bool verified = matchedCount == expected.Length && foregroundMatched;
+        return new WindowMutationVerificationResult {
+            Verified = verified,
+            Mode = requireForegroundMatch ? "geometry-and-foreground" : "geometry",
+            Summary = verified
+                ? $"Observed {matchedCount} of {expected.Length} mutated window(s) at the requested post-mutation geometry."
+                : $"Only {matchedCount} of {expected.Length} mutated window(s) matched the requested post-mutation geometry.",
+            ExpectedCount = expected.Length,
+            ObservedCount = observed.Length,
+            MatchedCount = matchedCount,
+            MismatchCount = Math.Max(0, expected.Length - matchedCount) + (foregroundMatched ? 0 : 1),
+            TolerancePixels = tolerancePixels,
+            ActiveWindow = active,
+            Notes = notes,
+            ObservedWindows = observed
+        };
+    }
+
+    private static WindowMutationVerificationResult BuildWindowFocusVerificationResult(IReadOnlyList<WindowResult> expected, IReadOnlyList<WindowResult> observed, WindowResult? activeWindow, int tolerancePixels) {
+        int observedMatches = CountObservedHandles(expected, observed);
+        bool foregroundMatched = activeWindow != null && expected.Any(window => string.Equals(window.Handle, activeWindow.Handle, StringComparison.OrdinalIgnoreCase));
+        var notes = new List<string>();
+        if (observedMatches != expected.Count) {
+            notes.AddRange(BuildMissingHandleNotes(expected, observed));
+        }
+        if (!foregroundMatched) {
+            notes.Add(activeWindow == null
+                ? "Windows did not report an active foreground window after the focus request."
+                : $"Foreground window was {activeWindow.Title} [{activeWindow.Handle}] instead of one of the requested windows.");
+        }
+
+        bool verified = expected.Count == 0 || observedMatches == expected.Count && foregroundMatched;
+        return new WindowMutationVerificationResult {
+            Verified = verified,
+            Mode = "foreground",
+            Summary = verified
+                ? $"Observed the requested window in the foreground after 'focus'."
+                : $"DesktopManager requested focus, but the foreground window did not match the requested target.",
+            ExpectedCount = expected.Count,
+            ObservedCount = observed.Count,
+            MatchedCount = foregroundMatched ? 1 : 0,
+            MismatchCount = verified ? 0 : 1,
+            TolerancePixels = tolerancePixels,
+            ActiveWindow = activeWindow,
+            Notes = notes,
+            ObservedWindows = observed
+        };
+    }
+
+    private static WindowMutationVerificationResult BuildWindowStateVerificationResult(string action, IReadOnlyList<WindowResult> expected, IReadOnlyList<WindowResult> observed, WindowResult? activeWindow, int tolerancePixels, string expectedState) {
+        var observedByHandle = observed.ToDictionary(window => window.Handle, StringComparer.OrdinalIgnoreCase);
+        var notes = new List<string>();
+        int matchedCount = 0;
+        foreach (WindowResult expectedWindow in expected) {
+            if (!observedByHandle.TryGetValue(expectedWindow.Handle, out WindowResult? observedWindow)) {
+                notes.Add($"Window {expectedWindow.Handle} is no longer observable after '{action}'.");
+                continue;
+            }
+
+            if (string.Equals(observedWindow.State, expectedState, StringComparison.OrdinalIgnoreCase)) {
+                matchedCount++;
+            } else {
+                notes.Add($"Window {observedWindow.Handle} reported state '{observedWindow.State ?? "<unknown>"}' instead of '{expectedState}'.");
+            }
+        }
+
+        bool verified = matchedCount == expected.Count;
+        return new WindowMutationVerificationResult {
+            Verified = verified,
+            Mode = "window-state",
+            Summary = verified
+                ? $"Observed {matchedCount} of {expected.Count} mutated window(s) in state '{expectedState}'."
+                : $"Only {matchedCount} of {expected.Count} mutated window(s) reported state '{expectedState}'.",
+            ExpectedCount = expected.Count,
+            ObservedCount = observed.Count,
+            MatchedCount = matchedCount,
+            MismatchCount = Math.Max(0, expected.Count - matchedCount),
+            TolerancePixels = tolerancePixels,
+            ActiveWindow = activeWindow,
+            Notes = notes,
+            ObservedWindows = observed
+        };
+    }
+
+    private static int CountObservedHandles(IReadOnlyList<WindowResult> expected, IReadOnlyList<WindowResult> observed) {
+        var observedHandles = new HashSet<string>(observed.Select(window => window.Handle), StringComparer.OrdinalIgnoreCase);
+        return expected.Count(window => observedHandles.Contains(window.Handle));
+    }
+
+    private static IReadOnlyList<string> BuildMissingHandleNotes(IReadOnlyList<WindowResult> expected, IReadOnlyList<WindowResult> observed) {
+        var observedHandles = new HashSet<string>(observed.Select(window => window.Handle), StringComparer.OrdinalIgnoreCase);
+        return expected
+            .Where(window => !observedHandles.Contains(window.Handle))
+            .Select(window => $"Window {window.Handle} is no longer observable after the mutation.")
+            .ToArray();
     }
 
     internal static ProcessLaunchResult BuildProcessLaunchResult(DesktopProcessLaunchInfo result) {

--- a/Sources/DesktopManager.Cli/DesktopOperations.cs
+++ b/Sources/DesktopManager.Cli/DesktopOperations.cs
@@ -1,8 +1,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -919,12 +917,12 @@ internal static partial class DesktopOperations {
 
     private static ScreenshotResult SaveScreenshot(DesktopCapture capture, string prefix, string? outputPath) {
         string path = DesktopStateStore.ResolveCapturePath(prefix, outputPath);
-        capture.Bitmap.Save(path, ImageFormat.Png);
+        capture.Save(path);
         return new ScreenshotResult {
             Kind = capture.Kind,
             Path = path,
-            Width = capture.Bitmap.Width,
-            Height = capture.Bitmap.Height,
+            Width = capture.Width,
+            Height = capture.Height,
             MonitorIndex = capture.MonitorIndex,
             MonitorDeviceName = capture.MonitorDeviceName,
             Window = capture.Window == null ? null : MapWindow(capture.Window),

--- a/Sources/DesktopManager.Cli/HelpText.cs
+++ b/Sources/DesktopManager.Cli/HelpText.cs
@@ -61,15 +61,15 @@ Window commands:
   desktopmanager window geometry [selector] [--all] [--json]
   desktopmanager window exists [selector] [--json]
   desktopmanager window active-matches [selector] [--json]
-  desktopmanager window move [selector] [--monitor <index>] [--x <value>] [--y <value>] [--width <value>] [--height <value>] [--activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window click [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) [--button <left|right>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window drag [selector] (((--start-x <value> --start-y <value>) | (--start-x-ratio <value> --start-y-ratio <value>)) ((--end-x <value> --end-y <value>) | (--end-x-ratio <value> --end-y-ratio <value>)) | (--start-target <name> --end-target <name>)) [--button <left|right>] [--step-delay-ms <value>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window scroll [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) --delta <value> [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window focus [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window minimize [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window snap [selector] --position <left|right|top-left|top-right|bottom-left|bottom-right> [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window type [selector] --text <value> [--paste] [--delay-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
-  desktopmanager window keys [selector] --keys <value>[,<value>...] [--no-activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--all] [--json]
+  desktopmanager window move [selector] [--monitor <index>] [--x <value>] [--y <value>] [--width <value>] [--height <value>] [--activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window click [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) [--button <left|right>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window drag [selector] (((--start-x <value> --start-y <value>) | (--start-x-ratio <value> --start-y-ratio <value>)) ((--end-x <value> --end-y <value>) | (--end-x-ratio <value> --end-y-ratio <value>)) | (--start-target <name> --end-target <name>)) [--button <left|right>] [--step-delay-ms <value>] [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window scroll [selector] ((--x <value> --y <value> | --x-ratio <value> --y-ratio <value>) | --target <name>) --delta <value> [--activate] [--client-area] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window focus [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window minimize [selector] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window snap [selector] --position <left|right|top-left|top-right|bottom-left|bottom-right> [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window type [selector] --text <value> [--paste] [--foreground-input] [--physical-keys] [--hosted-session] [--script] [--chunk-size <value>] [--line-delay-ms <value>] [--delay-ms <value>] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
+  desktopmanager window keys [selector] --keys <value>[,<value>...] [--no-activate] [--capture-before] [--capture-after] [--artifact-directory <path>] [--verify] [--verify-tolerance-px <value>] [--all] [--json]
   desktopmanager window wait [selector] [--timeout-ms <value>] [--interval-ms <value>] [--all] [--json]
 
 Selectors:
@@ -83,6 +83,8 @@ Selectors:
   --capture-before
   --capture-after
   --artifact-directory <path>
+  --verify
+  --verify-tolerance-px <value>
 
 Examples:
   desktopmanager window list --title "*Notepad*" --json
@@ -99,11 +101,22 @@ Examples:
   desktopmanager window scroll --process notepad --x-ratio 0.5 --y-ratio 0.5 --delta -120 --client-area
   desktopmanager window scroll --process notepad --target editor-center --delta -120
   desktopmanager window type --active --text "Hello world"
+  desktopmanager window type --process Devolutions.RemoteDesktopManager --text "safe probe" --foreground-input
+  desktopmanager window type --process Devolutions.RemoteDesktopManager --text "safe probe" --physical-keys
+  desktopmanager window type --process Devolutions.RemoteDesktopManager --text "safe probe" --hosted-session
+  desktopmanager window type --process Devolutions.RemoteDesktopManager --text "Write-Host 'hi'`nGet-Date" --script --foreground-input --line-delay-ms 20
   desktopmanager window move --title "Visual Studio Code" --x 0 --y 0 --width 1920 --height 1400 --activate
+  desktopmanager window move --title "Visual Studio Code" --x 0 --y 0 --width 1920 --height 1400 --verify --verify-tolerance-px 12
   desktopmanager window snap --process notepad --position left
   desktopmanager window type --process notepad --text "Hello world"
   desktopmanager window keys --process msedge --keys VK_RETURN
   desktopmanager window wait --process notepad --timeout-ms 5000
+
+Notes:
+  --hosted-session expects the target editor surface to already own focus.
+  Hosted-session typing stops immediately if foreground ownership changes mid-input.
+  Hosted-session harness diagnostics are written under Artifacts\HostedSessionTyping with a .json snapshot and a companion .summary.txt file.
+  --verify re-queries the mutated window and reports observed postconditions instead of only the request outcome.
 """;
     }
 

--- a/Sources/DesktopManager.Cli/McpCatalog.cs
+++ b/Sources/DesktopManager.Cli/McpCatalog.cs
@@ -523,6 +523,12 @@ internal static class McpCatalog {
                     ["activeWindow"] = CreateBooleanSchema("Target only the current foreground window."),
                     ["text"] = CreateStringSchema("Text to send to the window."),
                     ["paste"] = CreateBooleanSchema("Use clipboard paste instead of typed characters."),
+                    ["foregroundInput"] = CreateBooleanSchema("Require real foreground keyboard input and fail instead of falling back to background messages."),
+                    ["physicalKeys"] = CreateBooleanSchema("Prefer layout-aware physical key presses for foreground typing and fall back to Unicode packets only when no keyboard mapping exists."),
+                    ["hostedSession"] = CreateBooleanSchema("Enable the hosted-session typing profile for RDP, Hyper-V, and Remote Desktop Manager style targets."),
+                    ["script"] = CreateBooleanSchema("Preserve multiline formatting and chunk long lines into smaller typed segments."),
+                    ["chunkSize"] = CreateIntegerSchema("Maximum characters to send in each script chunk."),
+                    ["lineDelayMs"] = CreateIntegerSchema("Delay in milliseconds after each scripted line break."),
                     ["delayMs"] = CreateIntegerSchema("Delay in milliseconds between typed characters."),
                     ["all"] = CreateBooleanSchema("Apply to all matching windows instead of the first match.")
                 }), new[] { "text" }), readOnly: false, destructive: false, idempotent: false),
@@ -1032,9 +1038,17 @@ internal static class McpCatalog {
                         ReadMutationArtifactOptions(arguments)),
                 "type_window_text" => DesktopOperations.TypeWindowText(
                     ReadWindowCriteria(arguments, true),
-                    ReadRequiredString(arguments, "text"),
-                    ReadBool(arguments, "paste"),
-                    ReadInt(arguments, "delayMs") ?? 0,
+                    new WindowTextCommandOptions {
+                        Text = ReadRequiredString(arguments, "text"),
+                        Paste = ReadBool(arguments, "paste"),
+                        DelayMilliseconds = ReadInt(arguments, "delayMs") ?? (ReadBool(arguments, "hostedSession") ? 35 : 0),
+                        ForegroundInput = ReadBool(arguments, "foregroundInput") || ReadBool(arguments, "physicalKeys") || ReadBool(arguments, "hostedSession"),
+                        PhysicalKeys = ReadBool(arguments, "physicalKeys"),
+                        HostedSession = ReadBool(arguments, "hostedSession"),
+                        ScriptMode = ReadBool(arguments, "script"),
+                        ScriptChunkLength = ReadInt(arguments, "chunkSize") ?? 120,
+                        ScriptLineDelayMilliseconds = ReadInt(arguments, "lineDelayMs") ?? (ReadBool(arguments, "hostedSession") && ReadBool(arguments, "script") ? 120 : 0)
+                    },
                     ReadMutationArtifactOptions(arguments)),
                 "send_window_keys" => DesktopOperations.SendWindowKeys(
                     ReadWindowCriteria(arguments, true),
@@ -1322,6 +1336,8 @@ internal static class McpCatalog {
         properties["captureBefore"] = CreateBooleanSchema("Capture a best-effort screenshot before the mutation.");
         properties["captureAfter"] = CreateBooleanSchema("Capture a best-effort screenshot after the mutation.");
         properties["artifactDirectory"] = CreateStringSchema("Optional directory for mutation screenshots.");
+        properties["verifyAfter"] = CreateBooleanSchema("Re-query the mutated target and report the observed postcondition after the mutation.");
+        properties["verificationTolerancePixels"] = CreateIntegerSchema("Optional geometry verification tolerance in pixels. Providing it also enables post-mutation verification.");
         return properties;
     }
 
@@ -1470,14 +1486,18 @@ internal static class McpCatalog {
         bool captureBefore = ReadBool(element, "captureBefore");
         bool captureAfter = ReadBool(element, "captureAfter");
         string? artifactDirectory = ReadOptionalString(element, "artifactDirectory");
-        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+        bool verifyAfter = ReadBool(element, "verifyAfter") || ReadInt(element, "verificationTolerancePixels").HasValue;
+        int verificationTolerancePixels = ReadInt(element, "verificationTolerancePixels") ?? 10;
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory) && !verifyAfter) {
             return null;
         }
 
         return new MutationArtifactOptions {
             CaptureBefore = captureBefore,
             CaptureAfter = captureAfter,
-            ArtifactDirectory = artifactDirectory
+            ArtifactDirectory = artifactDirectory,
+            VerifyAfter = verifyAfter,
+            VerificationTolerancePixels = verificationTolerancePixels
         };
     }
 

--- a/Sources/DesktopManager.Cli/WindowCommands.cs
+++ b/Sources/DesktopManager.Cli/WindowCommands.cs
@@ -210,9 +210,7 @@ internal static class WindowCommands {
             arguments,
             DesktopOperations.TypeWindowText(
                 CreateCriteria(arguments, includeEmptyDefault: true),
-                arguments.GetRequiredOption("text"),
-                arguments.GetBoolFlag("paste"),
-                arguments.GetIntOption("delay-ms") ?? 0,
+                CreateTypeOptions(arguments),
                 CreateArtifactOptions(arguments)));
     }
 
@@ -261,6 +259,18 @@ internal static class WindowCommands {
             writer.WriteLine($"target: {payload.TargetKind ?? "selector"} {payload.TargetName}");
         }
 
+        if (payload.Verification != null) {
+            writer.WriteLine($"verification: verified={payload.Verification.Verified} mode={payload.Verification.Mode} observed={payload.Verification.ObservedCount}/{payload.Verification.ExpectedCount} matched={payload.Verification.MatchedCount} mismatches={payload.Verification.MismatchCount} tolerance-px={payload.Verification.TolerancePixels}");
+            writer.WriteLine($"verification-summary: {payload.Verification.Summary}");
+            if (payload.Verification.ActiveWindow != null) {
+                writer.WriteLine($"verification-active: {payload.Verification.ActiveWindow.Title} [PID {payload.Verification.ActiveWindow.ProcessId}]");
+            }
+
+            foreach (string note in payload.Verification.Notes) {
+                writer.WriteLine($"verification-note: {note}");
+            }
+        }
+
         if (payload.BeforeScreenshots.Count > 0 || payload.AfterScreenshots.Count > 0) {
             writer.WriteLine($"artifacts: before={payload.BeforeScreenshots.Count} after={payload.AfterScreenshots.Count}");
         }
@@ -295,18 +305,22 @@ internal static class WindowCommands {
         return 0;
     }
 
-    private static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
+    internal static MutationArtifactOptions? CreateArtifactOptions(CommandLineArguments arguments) {
         bool captureBefore = arguments.GetBoolFlag("capture-before");
         bool captureAfter = arguments.GetBoolFlag("capture-after");
         string? artifactDirectory = arguments.GetOption("artifact-directory");
-        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory)) {
+        bool verifyAfter = arguments.GetBoolFlag("verify") || arguments.GetIntOption("verify-tolerance-px").HasValue;
+        int verificationTolerancePixels = arguments.GetIntOption("verify-tolerance-px") ?? 10;
+        if (!captureBefore && !captureAfter && string.IsNullOrWhiteSpace(artifactDirectory) && !verifyAfter) {
             return null;
         }
 
         return new MutationArtifactOptions {
             CaptureBefore = captureBefore,
             CaptureAfter = captureAfter,
-            ArtifactDirectory = artifactDirectory
+            ArtifactDirectory = artifactDirectory,
+            VerifyAfter = verifyAfter,
+            VerificationTolerancePixels = verificationTolerancePixels
         };
     }
 
@@ -351,6 +365,25 @@ internal static class WindowCommands {
             IncludeOwned = !arguments.GetBoolFlag("exclude-owned"),
             IncludeEmptyTitles = arguments.GetBoolFlag("include-empty") || includeEmptyDefault,
             All = arguments.GetBoolFlag("all")
+        };
+    }
+
+    internal static WindowTextCommandOptions CreateTypeOptions(CommandLineArguments arguments) {
+        bool hostedSession = arguments.GetBoolFlag("hosted-session");
+        bool physicalKeys = arguments.GetBoolFlag("physical-keys");
+        bool scriptMode = arguments.GetBoolFlag("script");
+        int? delayMilliseconds = arguments.GetIntOption("delay-ms");
+        int? scriptLineDelayMilliseconds = arguments.GetIntOption("line-delay-ms");
+        return new WindowTextCommandOptions {
+            Text = arguments.GetRequiredOption("text"),
+            Paste = arguments.GetBoolFlag("paste"),
+            DelayMilliseconds = delayMilliseconds ?? (hostedSession ? 35 : 0),
+            ForegroundInput = arguments.GetBoolFlag("foreground-input") || physicalKeys || hostedSession,
+            PhysicalKeys = physicalKeys,
+            HostedSession = hostedSession,
+            ScriptMode = scriptMode,
+            ScriptChunkLength = arguments.GetIntOption("chunk-size") ?? 120,
+            ScriptLineDelayMilliseconds = scriptLineDelayMilliseconds ?? (hostedSession && scriptMode ? 120 : 0)
         };
     }
 }

--- a/Sources/DesktopManager.Example/DesktopManager.Example.csproj
+++ b/Sources/DesktopManager.Example/DesktopManager.Example.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowClick.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowClick.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Management.Automation;
+using System.Linq;
 
 namespace DesktopManager.PowerShell;
 
@@ -69,6 +72,24 @@ public sealed class CmdletInvokeDesktopWindowClick : PSCmdlet {
     [Parameter]
     public SwitchParameter ClientArea { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the target window after the click and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Geometry verification tolerance in pixels.</para>
+    /// </summary>
+    [Parameter]
+    public int VerificationTolerancePixels { get; set; } = 10;
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the clicked window.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         var automation = new DesktopAutomationService();
@@ -87,11 +108,48 @@ public sealed class CmdletInvokeDesktopWindowClick : PSCmdlet {
                 ? $"{X},{Y}"
                 : $"{XRatio},{YRatio}";
         if (ShouldProcess(ActiveWindow ? "active window" : Name, $"Click point {targetText}")) {
-            if (!string.IsNullOrWhiteSpace(TargetName)) {
-                WriteObject(automation.ClickWindowTarget(options, TargetName, Button, Activate, all: false), true);
-            } else {
-                WriteObject(automation.ClickWindowPoint(options, X, Y, XRatio, YRatio, Button, Activate, ClientArea, all: false), true);
+            WindowInfo requestedWindow = automation.GetWindows(options).FirstOrDefault();
+            try {
+                IReadOnlyList<WindowInfo> windows = !string.IsNullOrWhiteSpace(TargetName)
+                    ? automation.ClickWindowTarget(options, TargetName, Button, Activate, all: false)
+                    : automation.ClickWindowPoint(options, X, Y, XRatio, YRatio, Button, Activate, ClientArea, all: false);
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    WriteObject(windows, true);
+                    return;
+                }
+
+                WriteMutationResult(automation, windows, requestedWindow);
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to click window '{requestedWindow?.Title ?? Name}': {ex.Message}");
+                if (requestedWindow != null) {
+                    WriteObject(DesktopWindowMutationVerifier.CreateFailureRecord("click", requestedWindow, ex.Message, Verify.IsPresent, VerificationTolerancePixels));
+                }
             }
+        }
+    }
+
+    private void WriteMutationResult(DesktopAutomationService automation, IReadOnlyList<WindowInfo> windows, WindowInfo requestedWindow) {
+        if (windows.Count == 0 && requestedWindow != null) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "click",
+                requestedWindow,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
+            return;
+        }
+
+        foreach (WindowInfo window in windows) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "click",
+                window,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowDrag.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowDrag.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Management.Automation;
+using System.Linq;
 
 namespace DesktopManager.PowerShell;
 
@@ -105,6 +108,24 @@ public sealed class CmdletInvokeDesktopWindowDrag : PSCmdlet {
     [Parameter]
     public SwitchParameter ClientArea { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the target window after the drag and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Geometry verification tolerance in pixels.</para>
+    /// </summary>
+    [Parameter]
+    public int VerificationTolerancePixels { get; set; } = 10;
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the dragged window.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         var automation = new DesktopAutomationService();
@@ -125,11 +146,48 @@ public sealed class CmdletInvokeDesktopWindowDrag : PSCmdlet {
         string startText = useNamedTargets ? $"target '{StartTargetName}'" : StartX.HasValue && StartY.HasValue ? $"{StartX},{StartY}" : $"{StartXRatio},{StartYRatio}";
         string endText = useNamedTargets ? $"target '{EndTargetName}'" : EndX.HasValue && EndY.HasValue ? $"{EndX},{EndY}" : $"{EndXRatio},{EndYRatio}";
         if (ShouldProcess(ActiveWindow ? "active window" : Name, $"Drag from {startText} to {endText}")) {
-            if (useNamedTargets) {
-                WriteObject(automation.DragWindowTargets(options, StartTargetName, EndTargetName, Button, StepDelayMilliseconds, Activate, all: false), true);
-            } else {
-                WriteObject(automation.DragWindowPoints(options, StartX, StartY, StartXRatio, StartYRatio, EndX, EndY, EndXRatio, EndYRatio, Button, StepDelayMilliseconds, Activate, ClientArea, all: false), true);
+            WindowInfo requestedWindow = automation.GetWindows(options).FirstOrDefault();
+            try {
+                IReadOnlyList<WindowInfo> windows = useNamedTargets
+                    ? automation.DragWindowTargets(options, StartTargetName, EndTargetName, Button, StepDelayMilliseconds, Activate, all: false)
+                    : automation.DragWindowPoints(options, StartX, StartY, StartXRatio, StartYRatio, EndX, EndY, EndXRatio, EndYRatio, Button, StepDelayMilliseconds, Activate, ClientArea, all: false);
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    WriteObject(windows, true);
+                    return;
+                }
+
+                WriteMutationResult(automation, windows, requestedWindow);
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to drag window '{requestedWindow?.Title ?? Name}': {ex.Message}");
+                if (requestedWindow != null) {
+                    WriteObject(DesktopWindowMutationVerifier.CreateFailureRecord("drag", requestedWindow, ex.Message, Verify.IsPresent, VerificationTolerancePixels));
+                }
             }
+        }
+    }
+
+    private void WriteMutationResult(DesktopAutomationService automation, IReadOnlyList<WindowInfo> windows, WindowInfo requestedWindow) {
+        if (windows.Count == 0 && requestedWindow != null) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "drag",
+                requestedWindow,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
+            return;
+        }
+
+        foreach (WindowInfo window in windows) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "drag",
+                window,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowScroll.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopWindowScroll.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Management.Automation;
+using System.Linq;
 
 namespace DesktopManager.PowerShell;
 
@@ -69,6 +72,24 @@ public sealed class CmdletInvokeDesktopWindowScroll : PSCmdlet {
     [Parameter]
     public SwitchParameter ClientArea { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the target window after the scroll action and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Geometry verification tolerance in pixels.</para>
+    /// </summary>
+    [Parameter]
+    public int VerificationTolerancePixels { get; set; } = 10;
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the scrolled window.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         var automation = new DesktopAutomationService();
@@ -87,11 +108,48 @@ public sealed class CmdletInvokeDesktopWindowScroll : PSCmdlet {
                 ? $"{X},{Y}"
                 : $"{XRatio},{YRatio}";
         if (ShouldProcess(ActiveWindow ? "active window" : Name, $"Scroll {Delta} at {targetText}")) {
-            if (!string.IsNullOrWhiteSpace(TargetName)) {
-                WriteObject(automation.ScrollWindowTarget(options, TargetName, Delta, Activate, all: false), true);
-            } else {
-                WriteObject(automation.ScrollWindowPoint(options, X, Y, XRatio, YRatio, Delta, Activate, ClientArea, all: false), true);
+            WindowInfo requestedWindow = automation.GetWindows(options).FirstOrDefault();
+            try {
+                IReadOnlyList<WindowInfo> windows = !string.IsNullOrWhiteSpace(TargetName)
+                    ? automation.ScrollWindowTarget(options, TargetName, Delta, Activate, all: false)
+                    : automation.ScrollWindowPoint(options, X, Y, XRatio, YRatio, Delta, Activate, ClientArea, all: false);
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    WriteObject(windows, true);
+                    return;
+                }
+
+                WriteMutationResult(automation, windows, requestedWindow);
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to scroll window '{requestedWindow?.Title ?? Name}': {ex.Message}");
+                if (requestedWindow != null) {
+                    WriteObject(DesktopWindowMutationVerifier.CreateFailureRecord("scroll", requestedWindow, ex.Message, Verify.IsPresent, VerificationTolerancePixels));
+                }
             }
+        }
+    }
+
+    private void WriteMutationResult(DesktopAutomationService automation, IReadOnlyList<WindowInfo> windows, WindowInfo requestedWindow) {
+        if (windows.Count == 0 && requestedWindow != null) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "scroll",
+                requestedWindow,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
+            return;
+        }
+
+        foreach (WindowInfo window in windows) {
+            WriteObject(DesktopWindowMutationVerifier.Verify(
+                automation,
+                "scroll",
+                window,
+                VerificationTolerancePixels,
+                requireForeground: Activate.IsPresent));
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindow.cs
@@ -75,10 +75,29 @@ namespace DesktopManager.PowerShell {
         public SwitchParameter Activate { get; set; }
 
         /// <summary>
+        /// <para type="description">Re-query the mutated window and report the observed postcondition instead of relying only on mutation success.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Verify { get; set; }
+
+        /// <summary>
+        /// <para type="description">Geometry verification tolerance in pixels.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public int VerificationTolerancePixels { get; set; } = 10;
+
+        /// <summary>
+        /// <para type="description">Return a structured mutation result object for each matching window.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter PassThru { get; set; }
+
+        /// <summary>
         /// Applies the requested window modifications.
         /// </summary>
         protected override void BeginProcessing() {
             var manager = new WindowManager();
+            var automation = new DesktopAutomationService();
             var windows = manager.GetWindows(Name);
 
             Monitor targetMonitor = null;
@@ -95,6 +114,8 @@ namespace DesktopManager.PowerShell {
                     action = $"Move to monitor {MonitorIndex.Value}" + (string.IsNullOrEmpty(action) ? string.Empty : $" and {action}");
                 }
                 if (ShouldProcess($"Window '{window.Title}'", action)) {
+                    DesktopWindowMutationRecord result = null;
+                    bool closedWindow = false;
                     try {
                         if (targetMonitor != null) {
                             manager.MoveWindowToMonitor(window, targetMonitor);
@@ -106,7 +127,8 @@ namespace DesktopManager.PowerShell {
                             switch (State.Value) {
                                 case WindowState.Close:
                                     manager.CloseWindow(window);
-                                    continue; // Skip any position/size changes
+                                    closedWindow = true;
+                                    break;
                                 case WindowState.Minimize:
                                     manager.MinimizeWindow(window);
                                     break;
@@ -118,17 +140,67 @@ namespace DesktopManager.PowerShell {
                                     break;
                             }
                         }
-                        if (TopMost.IsPresent) {
+                        if (!closedWindow && TopMost.IsPresent) {
                             manager.SetWindowTopMost(window, true);
                         }
-                        if (Activate.IsPresent) {
+                        if (!closedWindow && Activate.IsPresent) {
                             manager.ActivateWindow(window);
+                        }
+
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.Verify(
+                                automation,
+                                ResolveActionName(),
+                                window,
+                                VerificationTolerancePixels,
+                                expectedMonitorIndex: targetMonitor?.Index ?? MonitorIndex,
+                                expectedLeft: Left >= 0 ? Left : null,
+                                expectedTop: Top >= 0 ? Top : null,
+                                expectedWidth: Width >= 0 ? Width : null,
+                                expectedHeight: Height >= 0 ? Height : null,
+                                expectedState: closedWindow ? null : State,
+                                expectedTopMost: !closedWindow && TopMost.IsPresent ? true : null,
+                                requireForeground: !closedWindow && Activate.IsPresent,
+                                expectClosed: closedWindow);
                         }
                     } catch (Exception ex) {
                         WriteWarning($"Failed to modify window '{window.Title}': {ex.Message}");
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.CreateFailureRecord(ResolveActionName(), window, ex.Message, Verify.IsPresent, VerificationTolerancePixels);
+                        }
+                    }
+
+                    if (result != null) {
+                        WriteObject(result);
                     }
                 }
             }
+        }
+
+        private string ResolveActionName() {
+            if (State.HasValue) {
+                return State.Value switch {
+                    WindowState.Close => "close",
+                    WindowState.Minimize => "minimize",
+                    WindowState.Maximize => "maximize",
+                    WindowState.Normal => "restore",
+                    _ => "window-mutation"
+                };
+            }
+
+            if (MonitorIndex.HasValue || Left >= 0 || Top >= 0 || Width >= 0 || Height >= 0) {
+                return "move";
+            }
+
+            if (TopMost.IsPresent) {
+                return "topmost";
+            }
+
+            if (Activate.IsPresent) {
+                return "focus";
+            }
+
+            return "window-mutation";
         }
 
         private string GetActionDescription() {

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowSnap.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowSnap.cs
@@ -24,6 +24,24 @@ namespace DesktopManager.PowerShell {
         public SnapPosition Position { get; set; }
 
         /// <summary>
+        /// <para type="description">Re-query the snapped window and report the observed postcondition.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Verify { get; set; }
+
+        /// <summary>
+        /// <para type="description">Geometry verification tolerance in pixels for post-snap checks.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public int VerificationTolerancePixels { get; set; } = 10;
+
+        /// <summary>
+        /// <para type="description">Return a structured mutation result object for each matching window.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter PassThru { get; set; }
+
+        /// <summary>
         /// Snaps matching windows to the chosen position.
         /// </summary>
         protected override void BeginProcessing() {
@@ -33,6 +51,7 @@ namespace DesktopManager.PowerShell {
             });
             foreach (var window in windows) {
                 if (ShouldProcess($"Window '{window.Title}'", $"Snap {Position}")) {
+                    DesktopWindowMutationRecord result = null;
                     try {
                         automation.SnapWindows(new WindowQueryOptions {
                             Handle = window.Handle,
@@ -41,8 +60,23 @@ namespace DesktopManager.PowerShell {
                             IncludeOwned = true,
                             IncludeEmptyTitles = true
                         }, Position);
+
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.Verify(
+                                automation,
+                                "snap",
+                                window,
+                                VerificationTolerancePixels);
+                        }
                     } catch (Exception ex) {
                         WriteWarning($"Failed to snap window '{window.Title}': {ex.Message}");
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.CreateFailureRecord("snap", window, ex.Message, Verify.IsPresent, VerificationTolerancePixels);
+                        }
+                    }
+
+                    if (result != null) {
+                        WriteObject(result);
                     }
                 }
             }

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowText.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopWindowText.cs
@@ -51,6 +51,43 @@ public sealed class CmdletSetDesktopWindowText : PSCmdlet {
     public SwitchParameter UseMessage { get; set; }
 
     /// <summary>
+    /// <para type="description">Require real foreground keyboard input and fail instead of falling back to background message typing.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public SwitchParameter ForegroundInput { get; set; }
+
+    /// <summary>
+    /// <para type="description">Prefer layout-aware physical key presses over Unicode packets when typing in the foreground.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public SwitchParameter PhysicalKeys { get; set; }
+
+    /// <summary>
+    /// <para type="description">Use a hosted-session typing profile with a fixed US-style foreground scancode path and slower pacing defaults. The target surface must already own focus, and typing stops if focus drifts.</para>
+    /// <para type="description">When the repo-owned hosted-session harness is exercised, related diagnostics are written under Artifacts\HostedSessionTyping as a raw JSON snapshot plus a companion summary file.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public SwitchParameter HostedSession { get; set; }
+
+    /// <summary>
+    /// <para type="description">Preserve multiline formatting and chunk long lines into smaller typed segments.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public SwitchParameter Script { get; set; }
+
+    /// <summary>
+    /// <para type="description">Maximum number of characters to send in each script chunk.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public int ScriptChunkSize { get; set; } = 120;
+
+    /// <summary>
+    /// <para type="description">Delay in milliseconds after each scripted line break.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Type")]
+    public int ScriptLineDelayMilliseconds { get; set; }
+
+    /// <summary>
     /// <para type="description">Number of clipboard open retries.</para>
     /// </summary>
     [Parameter]
@@ -104,9 +141,22 @@ public sealed class CmdletSetDesktopWindowText : PSCmdlet {
     [Parameter]
     public SwitchParameter SafeMode { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the target window after the mutation and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for each matching window.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         var manager = new WindowManager();
+        var automation = new DesktopAutomationService();
         var windows = manager.GetWindows(Name);
 
         foreach (var window in windows) {
@@ -121,8 +171,14 @@ public sealed class CmdletSetDesktopWindowText : PSCmdlet {
                     ActivationRetryCount = ActivationRetryCount,
                     ActivationRetryDelayMilliseconds = ActivationRetryDelayMilliseconds,
                     InputRetryCount = InputRetryCount,
-                    KeyDelayMilliseconds = Delay,
-                    UseSendInput = !UseMessage
+                    KeyDelayMilliseconds = Delay > 0 ? Delay : HostedSession ? 35 : 0,
+                    UseSendInput = !UseMessage,
+                    RequireForegroundWindowForTyping = ForegroundInput || PhysicalKeys || HostedSession,
+                    UsePhysicalKeyboardLayout = PhysicalKeys,
+                    UseHostedSessionScanCodes = HostedSession,
+                    TypeTextAsScript = Script,
+                    ScriptChunkLength = ScriptChunkSize,
+                    ScriptLineDelayMilliseconds = ScriptLineDelayMilliseconds > 0 ? ScriptLineDelayMilliseconds : HostedSession && Script ? 120 : 0
                 };
 
                 if (SafeMode) {
@@ -131,15 +187,58 @@ public sealed class CmdletSetDesktopWindowText : PSCmdlet {
                     options.PreserveClipboard = true;
                 }
 
-                if (ParameterSetName == "Type" && !options.ActivateWindow && options.UseSendInput) {
+                if (ParameterSetName == "Type" && !options.ActivateWindow && options.UseSendInput && !options.RequireForegroundWindowForTyping && !options.UsePhysicalKeyboardLayout) {
                     options.UseSendInput = false;
                     WriteVerbose("NoActivate is set; using WM_CHAR to avoid typing into the foreground window.");
                 }
 
+                DesktopWindowMutationRecord result = null;
                 if (ParameterSetName == "Type") {
-                    manager.TypeText(window, Text, options);
+                    try {
+                        manager.TypeText(window, Text, options);
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.Verify(
+                                automation,
+                                options.UseHostedSessionScanCodes ? "type-text-hosted-session" : options.UsePhysicalKeyboardLayout ? "type-text-physical-keys" : options.RequireForegroundWindowForTyping ? "type-text-foreground" : "type-text",
+                                window,
+                                tolerancePixels: 10,
+                                requireForeground: options.RequireForegroundWindowForTyping && options.ActivateWindow);
+                        }
+                    } catch (Exception ex) {
+                        if (!Verify.IsPresent && !PassThru.IsPresent) {
+                            throw;
+                        }
+
+                        WriteWarning($"Failed to type text into '{window.Title}': {ex.Message}");
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.CreateFailureRecord("type-text", window, ex.Message, Verify.IsPresent, 10);
+                        }
+                    }
                 } else {
-                    manager.PasteText(window, Text, options);
+                    try {
+                        manager.PasteText(window, Text, options);
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.Verify(
+                                automation,
+                                "paste-text",
+                                window,
+                                tolerancePixels: 10,
+                                requireForeground: options.ActivateWindow);
+                        }
+                    } catch (Exception ex) {
+                        if (!Verify.IsPresent && !PassThru.IsPresent) {
+                            throw;
+                        }
+
+                        WriteWarning($"Failed to paste text into '{window.Title}': {ex.Message}");
+                        if (Verify.IsPresent || PassThru.IsPresent) {
+                            result = DesktopWindowMutationVerifier.CreateFailureRecord("paste-text", window, ex.Message, Verify.IsPresent, 10);
+                        }
+                    }
+                }
+
+                if (result != null) {
+                    WriteObject(result);
                 }
             }
         }

--- a/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
+++ b/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
@@ -31,6 +31,11 @@
         <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>DesktopManager.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+    <ItemGroup>
         <Using Include="System.Runtime.InteropServices" />
         <Using Include="System" />
         <Using Include="System.Collections.Generic" />

--- a/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
+++ b/Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net472;net8.0-windows;net10.0-windows</TargetFrameworks>
         <Description>PowerShell Module for working Windows Desktop</Description>
         <AssemblyName>DesktopManager.PowerShell</AssemblyName>
         <AssemblyTitle>DesktopManager.PowerShell</AssemblyTitle>
@@ -39,7 +39,7 @@
         <Using Include="DesktopManager" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'net10.0-windows'">
         <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. DLL itself
         will be removed/hidden -->
         <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">

--- a/Sources/DesktopManager.PowerShell/DesktopWindowMutationRecord.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopWindowMutationRecord.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Represents the outcome of a PowerShell window mutation.</summary>
+public sealed class DesktopWindowMutationRecord {
+    /// <summary>Gets or sets the action name.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the mutation call completed without throwing.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Gets or sets whether post-mutation verification was requested.</summary>
+    public bool VerificationPerformed { get; set; }
+
+    /// <summary>Gets or sets whether the post-mutation verification succeeded.</summary>
+    public bool? Verified { get; set; }
+
+    /// <summary>Gets or sets the verification mode.</summary>
+    public string VerificationMode { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the verification summary.</summary>
+    public string VerificationSummary { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the verification tolerance in pixels.</summary>
+    public int VerificationTolerancePixels { get; set; }
+
+    /// <summary>Gets or sets the originally targeted window.</summary>
+    public WindowInfo RequestedWindow { get; set; } = new();
+
+    /// <summary>Gets or sets the observed window after the mutation, when available.</summary>
+    public WindowInfo ObservedWindow { get; set; }
+
+    /// <summary>Gets or sets the active foreground window observed during verification, when available.</summary>
+    public WindowInfo ActiveWindow { get; set; }
+
+    /// <summary>Gets or sets verification notes.</summary>
+    public IReadOnlyList<string> VerificationNotes { get; set; } = new List<string>();
+}

--- a/Sources/DesktopManager.PowerShell/DesktopWindowMutationVerifier.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopWindowMutationVerifier.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+
+namespace DesktopManager.PowerShell;
+
+internal static class DesktopWindowMutationVerifier {
+    internal static DesktopWindowMutationRecord Verify(
+        DesktopAutomationService automation,
+        string action,
+        WindowInfo requestedWindow,
+        int tolerancePixels,
+        int? expectedMonitorIndex = null,
+        int? expectedLeft = null,
+        int? expectedTop = null,
+        int? expectedWidth = null,
+        int? expectedHeight = null,
+        WindowState? expectedState = null,
+        bool? expectedTopMost = null,
+        bool requireForeground = false,
+        bool expectClosed = false) {
+        WindowInfo observedWindow = ObserveWindowByHandle(automation, requestedWindow.Handle);
+        WindowInfo activeWindow = SafeGetActiveWindow(automation);
+        var notes = new List<string>();
+
+        if (expectClosed) {
+            bool closed = observedWindow == null;
+            return new DesktopWindowMutationRecord {
+                Action = action,
+                Success = true,
+                VerificationPerformed = true,
+                Verified = closed,
+                VerificationMode = "closed",
+                VerificationSummary = closed
+                    ? $"Observed the window closed after '{action}'."
+                    : $"DesktopManager requested '{action}', but the window is still observable afterward.",
+                VerificationTolerancePixels = tolerancePixels,
+                RequestedWindow = requestedWindow,
+                ObservedWindow = observedWindow,
+                ActiveWindow = activeWindow,
+                VerificationNotes = closed ? Array.Empty<string>() : new[] { $"Window '{requestedWindow.Title}' [{requestedWindow.Handle.ToInt64():X}] is still observable." }
+            };
+        }
+
+        if (observedWindow == null) {
+            return new DesktopWindowMutationRecord {
+                Action = action,
+                Success = true,
+                VerificationPerformed = true,
+                Verified = false,
+                VerificationMode = "presence",
+                VerificationSummary = $"DesktopManager requested '{action}', but the window was no longer observable afterward.",
+                VerificationTolerancePixels = tolerancePixels,
+                RequestedWindow = requestedWindow,
+                ActiveWindow = activeWindow,
+                VerificationNotes = new[] { $"Window '{requestedWindow.Title}' [{requestedWindow.Handle.ToInt64():X}] could not be re-queried after the mutation." }
+            };
+        }
+
+        bool hasSpecificExpectation = expectedMonitorIndex.HasValue ||
+            expectedLeft.HasValue ||
+            expectedTop.HasValue ||
+            expectedWidth.HasValue ||
+            expectedHeight.HasValue ||
+            expectedState.HasValue ||
+            expectedTopMost.HasValue ||
+            requireForeground;
+
+        if (!hasSpecificExpectation) {
+            return new DesktopWindowMutationRecord {
+                Action = action,
+                Success = true,
+                VerificationPerformed = true,
+                Verified = true,
+                VerificationMode = "presence",
+                VerificationSummary = $"Observed the window after '{action}'.",
+                VerificationTolerancePixels = tolerancePixels,
+                RequestedWindow = requestedWindow,
+                ObservedWindow = observedWindow,
+                ActiveWindow = activeWindow
+            };
+        }
+
+        bool verified = true;
+        string mode = "postcondition";
+        if (expectedMonitorIndex.HasValue && observedWindow.MonitorIndex != expectedMonitorIndex.Value) {
+            verified = false;
+            notes.Add($"Observed monitor index {observedWindow.MonitorIndex} instead of {expectedMonitorIndex.Value}.");
+            mode = "geometry";
+        }
+        if (expectedLeft.HasValue && Math.Abs(observedWindow.Left - expectedLeft.Value) > tolerancePixels) {
+            verified = false;
+            notes.Add($"Observed left={observedWindow.Left} instead of approximately {expectedLeft.Value}.");
+            mode = "geometry";
+        }
+        if (expectedTop.HasValue && Math.Abs(observedWindow.Top - expectedTop.Value) > tolerancePixels) {
+            verified = false;
+            notes.Add($"Observed top={observedWindow.Top} instead of approximately {expectedTop.Value}.");
+            mode = "geometry";
+        }
+        if (expectedWidth.HasValue && Math.Abs(observedWindow.Width - expectedWidth.Value) > tolerancePixels) {
+            verified = false;
+            notes.Add($"Observed width={observedWindow.Width} instead of approximately {expectedWidth.Value}.");
+            mode = "geometry";
+        }
+        if (expectedHeight.HasValue && Math.Abs(observedWindow.Height - expectedHeight.Value) > tolerancePixels) {
+            verified = false;
+            notes.Add($"Observed height={observedWindow.Height} instead of approximately {expectedHeight.Value}.");
+            mode = "geometry";
+        }
+        if (expectedState.HasValue && observedWindow.State != expectedState.Value) {
+            verified = false;
+            notes.Add($"Observed state '{observedWindow.State?.ToString() ?? "<unknown>"}' instead of '{expectedState.Value}'.");
+            mode = "state";
+        }
+        if (expectedTopMost.HasValue && observedWindow.IsTopMost != expectedTopMost.Value) {
+            verified = false;
+            notes.Add($"Observed IsTopMost={observedWindow.IsTopMost} instead of {expectedTopMost.Value}.");
+            mode = "topmost";
+        }
+        if (requireForeground) {
+            mode = mode == "postcondition" ? "foreground" : mode + "-foreground";
+            if (activeWindow == null || activeWindow.Handle != requestedWindow.Handle) {
+                verified = false;
+                notes.Add(activeWindow == null
+                    ? "Windows did not report an active foreground window after the mutation."
+                    : $"Foreground window was '{activeWindow.Title}' [{activeWindow.Handle.ToInt64():X}] instead of the requested window.");
+            }
+        }
+
+        return new DesktopWindowMutationRecord {
+            Action = action,
+            Success = true,
+            VerificationPerformed = true,
+            Verified = verified,
+            VerificationMode = mode,
+            VerificationSummary = verified
+                ? $"Observed the requested postcondition after '{action}'."
+                : $"DesktopManager requested '{action}', but the observed postcondition did not match.",
+            VerificationTolerancePixels = tolerancePixels,
+            RequestedWindow = requestedWindow,
+            ObservedWindow = observedWindow,
+            ActiveWindow = activeWindow,
+            VerificationNotes = notes
+        };
+    }
+
+    internal static DesktopWindowMutationRecord CreateFailureRecord(string action, WindowInfo requestedWindow, string message, bool verificationPerformed, int tolerancePixels) {
+        return new DesktopWindowMutationRecord {
+            Action = action,
+            Success = false,
+            VerificationPerformed = verificationPerformed,
+            Verified = verificationPerformed ? false : null,
+            VerificationMode = verificationPerformed ? "error" : string.Empty,
+            VerificationSummary = message,
+            VerificationTolerancePixels = tolerancePixels,
+            RequestedWindow = requestedWindow,
+            VerificationNotes = new[] { message }
+        };
+    }
+
+    private static WindowInfo ObserveWindowByHandle(DesktopAutomationService automation, IntPtr handle) {
+        if (handle == IntPtr.Zero) {
+            return null;
+        }
+
+        IReadOnlyList<WindowInfo> windows = automation.GetWindows(new WindowQueryOptions {
+            Handle = handle,
+            IncludeHidden = true,
+            IncludeCloaked = true,
+            IncludeOwned = true,
+            IncludeEmptyTitles = true
+        });
+        return windows.Count > 0 ? windows[0] : null;
+    }
+
+    private static WindowInfo SafeGetActiveWindow(DesktopAutomationService automation) {
+        try {
+            return automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
+        } catch {
+            return null;
+        }
+    }
+}

--- a/Sources/DesktopManager.TestApp/DesktopManager.TestApp.csproj
+++ b/Sources/DesktopManager.TestApp/DesktopManager.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Sources/DesktopManager.TestApp/MainForm.cs
+++ b/Sources/DesktopManager.TestApp/MainForm.cs
@@ -1,4 +1,9 @@
 using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Collections.Generic;
 using System.Windows.Forms.Integration;
 using WinFormsLabel = System.Windows.Forms.Label;
 using WinFormsTextBox = System.Windows.Forms.TextBox;
@@ -9,11 +14,43 @@ using WpfTextBox = System.Windows.Controls.TextBox;
 namespace DesktopManager.TestApp;
 
 internal sealed class MainForm : Form {
+    private const int ForegroundHistoryLimit = 12;
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
     private readonly string _baseTitle;
+    private readonly bool _useCommandBarSurface;
+    private readonly string? _statusFilePath;
+    private readonly string? _commandFilePath;
     private readonly WinFormsTextBox _editorTextBox;
     private readonly ElementHost _commandBarHost;
     private readonly WpfTextBox _commandBarTextBox;
     private readonly WinFormsLabel _statusLabel;
+    private SecondaryFocusForm? _secondaryForm;
+    private System.Windows.Forms.Timer? _statusTimer;
+    private DateTime _foregroundHoldUntilUtc;
+    private bool _foregroundHoldUseCommandBar;
+    private int _foregroundHoldRequestCount;
+    private int _foregroundHoldRecoveryCount;
+    private long _lastObservedForegroundHandle;
+    private string _lastObservedForegroundTitle = string.Empty;
+    private string _lastObservedForegroundClass = string.Empty;
+    private string _lastObservedForegroundChangedUtc = string.Empty;
+    private string _lastCommand = string.Empty;
+    private readonly List<string> _foregroundHistory = [];
 
     public MainForm(TestAppOptions options) {
         if (options == null) {
@@ -21,13 +58,15 @@ internal sealed class MainForm : Form {
         }
 
         _baseTitle = options.Title;
+        _useCommandBarSurface = string.Equals(options.Surface, "commandbar", StringComparison.OrdinalIgnoreCase);
+        _statusFilePath = options.StatusFilePath;
+        _commandFilePath = options.CommandFilePath;
         Text = options.Title;
         Name = "DesktopManagerMcpTestApp";
         StartPosition = FormStartPosition.CenterScreen;
         Width = 960;
         Height = 720;
         MinimumSize = new Size(640, 480);
-        bool useCommandBarSurface = string.Equals(options.Surface, "commandbar", StringComparison.OrdinalIgnoreCase);
 
         var titleLabel = new WinFormsLabel {
             AutoSize = true,
@@ -46,7 +85,7 @@ internal sealed class MainForm : Form {
             AutoSize = true,
             Name = "StatusLabel",
             AccessibleName = "StatusLabel",
-            Text = useCommandBarSurface
+            Text = _useCommandBarSurface
                 ? "Type a value into the command bar and press Enter."
                 : "Editor surface ready.",
             Margin = new Padding(0, 0, 0, 12)
@@ -87,7 +126,7 @@ internal sealed class MainForm : Form {
             Dock = DockStyle.Top,
             Height = 42,
             Child = commandBarPanel,
-            Visible = useCommandBarSurface
+            Visible = _useCommandBarSurface
         };
 
         var closeButton = new Button {
@@ -126,15 +165,34 @@ internal sealed class MainForm : Form {
         Controls.Add(contentPanel);
         Controls.Add(buttonPanel);
 
+        _editorTextBox.TextChanged += (_, _) => WriteStatusSnapshot();
+        _commandBarTextBox.TextChanged += (_, _) => WriteStatusSnapshot();
+        Activated += (_, _) => WriteStatusSnapshot();
+        Deactivate += (_, _) => WriteStatusSnapshot();
         Shown += (_, _) => {
-            if (useCommandBarSurface) {
-                _commandBarTextBox.Focus();
-                _commandBarTextBox.Select(_commandBarTextBox.Text.Length, 0);
-            } else {
-                _editorTextBox.Focus();
-                _editorTextBox.SelectionStart = _editorTextBox.TextLength;
-                _editorTextBox.SelectionLength = 0;
-            }
+            FocusSurface(_useCommandBarSurface);
+
+            var activationTimer = new System.Windows.Forms.Timer {
+                Interval = 250
+            };
+            int activationAttempts = 0;
+            activationTimer.Tick += (_, _) => {
+                activationAttempts++;
+                FocusSurface(_useCommandBarSurface);
+                if (ContainsFocus || activationAttempts >= 4) {
+                    activationTimer.Stop();
+                    activationTimer.Dispose();
+                }
+            };
+            activationTimer.Start();
+            StartStatusChannel();
+            WriteStatusSnapshot();
+        };
+        FormClosed += (_, _) => {
+            _statusTimer?.Stop();
+            _statusTimer?.Dispose();
+            _statusTimer = null;
+            WriteStatusSnapshot();
         };
     }
 
@@ -151,5 +209,269 @@ internal sealed class MainForm : Form {
             ? _baseTitle + " - Accepted"
             : _baseTitle + " - Accepted - " + command;
         e.Handled = true;
+    }
+
+    private void FocusSurface(bool useCommandBarSurface) {
+        TopMost = true;
+        BringToFront();
+        Activate();
+        BringWindowToTop(Handle);
+        SetForegroundWindow(Handle);
+        if (!IsForegroundHoldActive()) {
+            TopMost = false;
+        }
+
+        if (useCommandBarSurface) {
+            _commandBarTextBox.Focus();
+            _commandBarTextBox.Select(_commandBarTextBox.Text.Length, 0);
+            return;
+        }
+
+        _editorTextBox.Focus();
+        _editorTextBox.SelectionStart = _editorTextBox.TextLength;
+        _editorTextBox.SelectionLength = 0;
+        WriteStatusSnapshot();
+    }
+
+    private void StartStatusChannel() {
+        if (string.IsNullOrWhiteSpace(_statusFilePath) && string.IsNullOrWhiteSpace(_commandFilePath)) {
+            return;
+        }
+
+        _statusTimer = new System.Windows.Forms.Timer {
+            Interval = 100
+        };
+        _statusTimer.Tick += (_, _) => {
+            ProcessCommandFile();
+            MaintainForegroundHold();
+            WriteStatusSnapshot();
+        };
+        _statusTimer.Start();
+    }
+
+    private void ProcessCommandFile() {
+        if (string.IsNullOrWhiteSpace(_commandFilePath) || !File.Exists(_commandFilePath)) {
+            return;
+        }
+
+        string command;
+        try {
+            command = File.ReadAllText(_commandFilePath).Trim();
+            File.Delete(_commandFilePath);
+        } catch {
+            return;
+        }
+
+        _lastCommand = command;
+        AddForegroundHistoryEntry("command", command);
+
+        if (string.Equals(command, "focus-editor", StringComparison.OrdinalIgnoreCase)) {
+            FocusSurface(useCommandBarSurface: false);
+            return;
+        }
+
+        if (string.Equals(command, "focus-commandbar", StringComparison.OrdinalIgnoreCase)) {
+            FocusSurface(useCommandBarSurface: true);
+            return;
+        }
+
+        if (string.Equals(command, "focus-secondary", StringComparison.OrdinalIgnoreCase)) {
+            EnsureSecondaryWindow();
+            _secondaryForm?.FocusSecondaryWindow();
+            return;
+        }
+
+        if (command.StartsWith("hold-editor-foreground:", StringComparison.OrdinalIgnoreCase)) {
+            if (TryParseDuration(command, "hold-editor-foreground:", out int editorDurationMilliseconds)) {
+                StartForegroundHold(useCommandBarSurface: false, editorDurationMilliseconds);
+            }
+
+            return;
+        }
+
+        if (command.StartsWith("hold-commandbar-foreground:", StringComparison.OrdinalIgnoreCase)) {
+            if (TryParseDuration(command, "hold-commandbar-foreground:", out int commandBarDurationMilliseconds)) {
+                StartForegroundHold(useCommandBarSurface: true, commandBarDurationMilliseconds);
+            }
+
+            return;
+        }
+
+        if (string.Equals(command, "stop-foreground-hold", StringComparison.OrdinalIgnoreCase)) {
+            StopForegroundHold();
+        }
+    }
+
+    private void WriteStatusSnapshot() {
+        if (string.IsNullOrWhiteSpace(_statusFilePath)) {
+            return;
+        }
+
+        try {
+            UpdateForegroundDiagnostics();
+            string? directory = Path.GetDirectoryName(_statusFilePath);
+            if (!string.IsNullOrWhiteSpace(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+
+            var snapshot = new TestAppStatusSnapshot {
+                ProcessId = Environment.ProcessId,
+                WindowHandle = Handle.ToInt64(),
+                EditorHandle = _editorTextBox.IsHandleCreated ? _editorTextBox.Handle.ToInt64() : 0,
+                SecondaryWindowHandle = _secondaryForm != null && !_secondaryForm.IsDisposed && _secondaryForm.IsHandleCreated ? _secondaryForm.Handle.ToInt64() : 0,
+                WindowTitle = Text,
+                ActiveSurface = GetActiveSurface(),
+                ContainsFocus = ContainsFocus,
+                IsForegroundWindow = GetForegroundWindow() == Handle,
+                SecondaryIsForegroundWindow = _secondaryForm != null && !_secondaryForm.IsDisposed && _secondaryForm.IsHandleCreated && GetForegroundWindow() == _secondaryForm.Handle,
+                ForegroundHoldActive = IsForegroundHoldActive(),
+                ForegroundHoldSurface = _foregroundHoldUseCommandBar ? "commandbar" : "editor",
+                ForegroundHoldRequestCount = _foregroundHoldRequestCount,
+                ForegroundHoldRecoveryCount = _foregroundHoldRecoveryCount,
+                LastObservedForegroundHandle = _lastObservedForegroundHandle,
+                LastObservedForegroundTitle = _lastObservedForegroundTitle,
+                LastObservedForegroundClass = _lastObservedForegroundClass,
+                LastObservedForegroundChangedUtc = _lastObservedForegroundChangedUtc,
+                LastCommand = _lastCommand,
+                ForegroundHistory = new List<string>(_foregroundHistory),
+                EditorText = _editorTextBox.Text,
+                SecondaryText = _secondaryForm != null && !_secondaryForm.IsDisposed ? _secondaryForm.CurrentText : string.Empty,
+                CommandBarText = _commandBarTextBox.Text,
+                StatusText = _statusLabel.Text
+            };
+
+            string json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions {
+                WriteIndented = true
+            });
+            File.WriteAllText(_statusFilePath, json);
+        } catch {
+            // Best-effort diagnostics only.
+        }
+    }
+
+    private string GetActiveSurface() {
+        if (_secondaryForm != null && !_secondaryForm.IsDisposed && _secondaryForm.ContainsFocus) {
+            return "secondary";
+        }
+
+        if (_commandBarHost.Visible && _commandBarTextBox.IsKeyboardFocused) {
+            return "commandbar";
+        }
+
+        if (_editorTextBox.Focused) {
+            return "editor";
+        }
+
+        return _useCommandBarSurface ? "commandbar" : "editor";
+    }
+
+    private void EnsureSecondaryWindow() {
+        if (_secondaryForm != null && !_secondaryForm.IsDisposed) {
+            return;
+        }
+
+        _secondaryForm = new SecondaryFocusForm(_baseTitle, WriteStatusSnapshot);
+        _secondaryForm.Show(this);
+    }
+
+    private void MaintainForegroundHold() {
+        if (!IsForegroundHoldActive()) {
+            if (TopMost) {
+                StopForegroundHold();
+            }
+
+            return;
+        }
+
+        bool needsFocus = _foregroundHoldUseCommandBar
+            ? !_commandBarTextBox.IsKeyboardFocused || GetForegroundWindow() != Handle
+            : !_editorTextBox.Focused || GetForegroundWindow() != Handle;
+        if (!needsFocus) {
+            return;
+        }
+
+        _foregroundHoldRecoveryCount++;
+        AddForegroundHistoryEntry("hold-recover", _foregroundHoldUseCommandBar ? "commandbar" : "editor");
+        FocusSurface(_foregroundHoldUseCommandBar);
+    }
+
+    private void StartForegroundHold(bool useCommandBarSurface, int durationMilliseconds) {
+        if (durationMilliseconds <= 0) {
+            return;
+        }
+
+        _foregroundHoldUseCommandBar = useCommandBarSurface;
+        _foregroundHoldUntilUtc = DateTime.UtcNow.AddMilliseconds(durationMilliseconds);
+        _foregroundHoldRequestCount++;
+        AddForegroundHistoryEntry(
+            "hold-start",
+            (_foregroundHoldUseCommandBar ? "commandbar" : "editor") + " durationMs=" + durationMilliseconds);
+        TopMost = true;
+        FocusSurface(useCommandBarSurface);
+    }
+
+    private bool IsForegroundHoldActive() {
+        return _foregroundHoldUntilUtc > DateTime.UtcNow;
+    }
+
+    private void StopForegroundHold() {
+        if (_foregroundHoldUntilUtc != DateTime.MinValue) {
+            AddForegroundHistoryEntry("hold-stop", _foregroundHoldUseCommandBar ? "commandbar" : "editor");
+        }
+
+        _foregroundHoldUntilUtc = DateTime.MinValue;
+        TopMost = false;
+    }
+
+    private void UpdateForegroundDiagnostics() {
+        IntPtr foregroundHandle = GetForegroundWindow();
+        long handleValue = foregroundHandle.ToInt64();
+        if (_lastObservedForegroundHandle == handleValue) {
+            return;
+        }
+
+        _lastObservedForegroundHandle = handleValue;
+        _lastObservedForegroundTitle = ReadWindowText(foregroundHandle);
+        _lastObservedForegroundClass = ReadWindowClassName(foregroundHandle);
+        _lastObservedForegroundChangedUtc = DateTime.UtcNow.ToString("O");
+        AddForegroundHistoryEntry(
+            "foreground",
+            $"0x{_lastObservedForegroundHandle:X} '{_lastObservedForegroundTitle}' class='{_lastObservedForegroundClass}'");
+    }
+
+    private static string ReadWindowText(IntPtr handle) {
+        if (handle == IntPtr.Zero) {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(512);
+        return GetWindowText(handle, builder, builder.Capacity) > 0 ? builder.ToString() : string.Empty;
+    }
+
+    private static string ReadWindowClassName(IntPtr handle) {
+        if (handle == IntPtr.Zero) {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(256);
+        return GetClassName(handle, builder, builder.Capacity) > 0 ? builder.ToString() : string.Empty;
+    }
+
+    private static bool TryParseDuration(string command, string prefix, out int durationMilliseconds) {
+        durationMilliseconds = 0;
+        if (!command.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        string rawDuration = command.Substring(prefix.Length).Trim();
+        return int.TryParse(rawDuration, out durationMilliseconds) && durationMilliseconds > 0;
+    }
+
+    private void AddForegroundHistoryEntry(string category, string detail) {
+        string entry = DateTime.UtcNow.ToString("O") + " [" + category + "] " + detail;
+        _foregroundHistory.Add(entry);
+        if (_foregroundHistory.Count > ForegroundHistoryLimit) {
+            _foregroundHistory.RemoveAt(0);
+        }
     }
 }

--- a/Sources/DesktopManager.TestApp/SecondaryFocusForm.cs
+++ b/Sources/DesktopManager.TestApp/SecondaryFocusForm.cs
@@ -1,0 +1,66 @@
+using System.Runtime.InteropServices;
+using WinFormsTextBox = System.Windows.Forms.TextBox;
+
+namespace DesktopManager.TestApp;
+
+internal sealed class SecondaryFocusForm : Form {
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    private readonly Action _statusCallback;
+    private readonly WinFormsTextBox _textBox;
+
+    public SecondaryFocusForm(string title, Action statusCallback) {
+        _statusCallback = statusCallback ?? throw new ArgumentNullException(nameof(statusCallback));
+
+        Text = title + " - Secondary";
+        Name = "DesktopManagerSecondaryFocusWindow";
+        StartPosition = FormStartPosition.CenterScreen;
+        Width = 480;
+        Height = 200;
+
+        _textBox = new WinFormsTextBox {
+            Name = "SecondaryTextBox",
+            Multiline = true,
+            Dock = DockStyle.Fill
+        };
+        _textBox.TextChanged += (_, _) => _statusCallback();
+
+        var label = new Label {
+            Text = "Secondary focus helper",
+            Dock = DockStyle.Top,
+            AutoSize = true,
+            Padding = new Padding(8)
+        };
+
+        Controls.Add(_textBox);
+        Controls.Add(label);
+
+        Activated += (_, _) => _statusCallback();
+        Deactivate += (_, _) => _statusCallback();
+        Shown += (_, _) => {
+            FocusSecondaryWindow();
+            _statusCallback();
+        };
+        FormClosed += (_, _) => _statusCallback();
+    }
+
+    public string CurrentText => _textBox.Text;
+
+    public void FocusSecondaryWindow() {
+        TopMost = true;
+        Show();
+        BringToFront();
+        Activate();
+        BringWindowToTop(Handle);
+        SetForegroundWindow(Handle);
+        _textBox.Focus();
+        _textBox.SelectionStart = _textBox.TextLength;
+        _textBox.SelectionLength = 0;
+        TopMost = false;
+        _statusCallback();
+    }
+}

--- a/Sources/DesktopManager.TestApp/TestAppOptions.cs
+++ b/Sources/DesktopManager.TestApp/TestAppOptions.cs
@@ -5,10 +5,12 @@ internal sealed class TestAppOptions {
     private const string DefaultInitialText = "seed";
     private const string DefaultSurface = "editor";
 
-    private TestAppOptions(string title, string initialText, string surface) {
+    private TestAppOptions(string title, string initialText, string surface, string? statusFilePath, string? commandFilePath) {
         Title = title;
         InitialText = initialText;
         Surface = surface;
+        StatusFilePath = statusFilePath;
+        CommandFilePath = commandFilePath;
     }
 
     public string Title { get; }
@@ -17,10 +19,16 @@ internal sealed class TestAppOptions {
 
     public string Surface { get; }
 
+    public string? StatusFilePath { get; }
+
+    public string? CommandFilePath { get; }
+
     public static TestAppOptions Parse(string[] args) {
         string title = DefaultTitle;
         string initialText = DefaultInitialText;
         string surface = DefaultSurface;
+        string? statusFilePath = null;
+        string? commandFilePath = null;
 
         for (int index = 0; index < args.Length; index++) {
             string argument = args[index];
@@ -36,9 +44,19 @@ internal sealed class TestAppOptions {
 
             if (string.Equals(argument, "--surface", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
                 surface = args[++index];
+                continue;
+            }
+
+            if (string.Equals(argument, "--status-file", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
+                statusFilePath = args[++index];
+                continue;
+            }
+
+            if (string.Equals(argument, "--command-file", StringComparison.OrdinalIgnoreCase) && index + 1 < args.Length) {
+                commandFilePath = args[++index];
             }
         }
 
-        return new TestAppOptions(title, initialText, surface);
+        return new TestAppOptions(title, initialText, surface, statusFilePath, commandFilePath);
     }
 }

--- a/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
+++ b/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
@@ -1,0 +1,49 @@
+namespace DesktopManager.TestApp;
+
+internal sealed class TestAppStatusSnapshot {
+    public int ProcessId { get; set; }
+
+    public long WindowHandle { get; set; }
+
+    public long EditorHandle { get; set; }
+
+    public long SecondaryWindowHandle { get; set; }
+
+    public string WindowTitle { get; set; } = string.Empty;
+
+    public string ActiveSurface { get; set; } = string.Empty;
+
+    public bool ContainsFocus { get; set; }
+
+    public bool IsForegroundWindow { get; set; }
+
+    public bool SecondaryIsForegroundWindow { get; set; }
+
+    public bool ForegroundHoldActive { get; set; }
+
+    public string ForegroundHoldSurface { get; set; } = string.Empty;
+
+    public int ForegroundHoldRequestCount { get; set; }
+
+    public int ForegroundHoldRecoveryCount { get; set; }
+
+    public long LastObservedForegroundHandle { get; set; }
+
+    public string LastObservedForegroundTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundClass { get; set; } = string.Empty;
+
+    public string LastObservedForegroundChangedUtc { get; set; } = string.Empty;
+
+    public string LastCommand { get; set; } = string.Empty;
+
+    public List<string> ForegroundHistory { get; set; } = [];
+
+    public string EditorText { get; set; } = string.Empty;
+
+    public string SecondaryText { get; set; } = string.Empty;
+
+    public string CommandBarText { get; set; } = string.Empty;
+
+    public string StatusText { get; set; } = string.Empty;
+}

--- a/Sources/DesktopManager.Tests/BackgroundColorTests.cs
+++ b/Sources/DesktopManager.Tests/BackgroundColorTests.cs
@@ -15,7 +15,7 @@ public class BackgroundColorTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var monitors = new Monitors();
         uint original = monitors.GetBackgroundColor();

--- a/Sources/DesktopManager.Tests/CliApplicationTests.cs
+++ b/Sources/DesktopManager.Tests/CliApplicationTests.cs
@@ -147,6 +147,45 @@ public class CliApplicationTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures window typing rejects contradictory paste and strict foreground-input flags through the CLI entrypoint.
+    /// </summary>
+    public void Run_WindowTypeWithPasteAndForegroundInput_WritesCombinationError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("window", "type", "--text", "hello", "--paste", "--foreground-input");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Cannot combine '--paste' with '--foreground-input'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window typing rejects contradictory paste and physical-key flags through the CLI entrypoint.
+    /// </summary>
+    public void Run_WindowTypeWithPasteAndPhysicalKeys_WritesCombinationError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("window", "type", "--text", "hello", "--paste", "--physical-keys");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Cannot combine '--paste' with '--foreground-input'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window typing rejects contradictory paste and script flags through the CLI entrypoint.
+    /// </summary>
+    public void Run_WindowTypeWithPasteAndScript_WritesCombinationError() {
+        (int exitCode, string standardOutput, string standardError) = RunCli("window", "type", "--text", "hello", "--paste", "--script");
+
+        Assert.AreEqual(1, exitCode);
+        Assert.AreEqual(string.Empty, standardOutput);
+        StringAssert.Contains(standardError, "Error: Cannot combine '--paste' with '--script'.");
+        StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures malformed empty option names are reported through the CLI entrypoint.
     /// </summary>
     public void Run_WithMalformedEmptyOptionName_WritesParseError() {

--- a/Sources/DesktopManager.Tests/CliApplicationTests.cs
+++ b/Sources/DesktopManager.Tests/CliApplicationTests.cs
@@ -102,7 +102,7 @@ public class CliApplicationTests {
 
         Assert.AreEqual(1, exitCode);
         Assert.AreEqual(string.Empty, standardOutput);
-        StringAssert.Contains(standardError, $"Error: Unknown {group} command ''.");
+        StringAssert.Contains(standardError, $"Error: Missing required {group} command.");
         StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
     }
 

--- a/Sources/DesktopManager.Tests/DesktopAutomationAssertionTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationAssertionTests.cs
@@ -1,4 +1,6 @@
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -15,12 +17,20 @@ public class DesktopAutomationAssertionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
+        TestHelper.RequireForegroundWindowUiTests();
 
         var automation = new DesktopAutomationService();
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Assertion Harness Exists");
+        new WindowManager().ActivateWindow(harness.Window);
+        Application.DoEvents();
+        Thread.Sleep(100);
+
         WindowInfo? activeWindow = automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
         if (activeWindow == null) {
             Assert.Inconclusive("No active window could be resolved.");
         }
+
+        Assert.AreEqual(harness.Window.Handle, activeWindow.Handle, "Expected the owned harness window to be active for the assertion test.");
 
         bool result = automation.WindowExists(new WindowQueryOptions {
             Handle = activeWindow.Handle,
@@ -41,12 +51,20 @@ public class DesktopAutomationAssertionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
+        TestHelper.RequireForegroundWindowUiTests();
 
         var automation = new DesktopAutomationService();
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Assertion Harness Active");
+        new WindowManager().ActivateWindow(harness.Window);
+        Application.DoEvents();
+        Thread.Sleep(100);
+
         WindowInfo? activeWindow = automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
         if (activeWindow == null) {
             Assert.Inconclusive("No active window could be resolved.");
         }
+
+        Assert.AreEqual(harness.Window.Handle, activeWindow.Handle, "Expected the owned harness window to be active for the assertion test.");
 
         bool result = automation.ActiveWindowMatches(new WindowQueryOptions {
             Handle = activeWindow.Handle,

--- a/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
@@ -641,4 +641,134 @@ public class DesktopAutomationCoreTests {
     public void KeyboardInputService_SendTextToForeground_NegativeDelay_ThrowsArgumentOutOfRangeException() {
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => KeyboardInputService.SendTextToForeground("test", -1));
     }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window typing prefers real foreground input when the target already owns focus.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_WithForegroundTarget_UsesForegroundInput() {
+        WindowInputService.WindowTextDeliveryMode mode = WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true
+        }, targetOwnsForeground: true);
+
+        Assert.AreEqual(WindowInputService.WindowTextDeliveryMode.ForegroundInput, mode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window typing falls back to message delivery when foreground ownership is unavailable and strict typing is not required.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_WithoutForegroundTarget_UsesWindowMessageFallback() {
+        WindowInputService.WindowTextDeliveryMode mode = WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true
+        }, targetOwnsForeground: false);
+
+        Assert.AreEqual(WindowInputService.WindowTextDeliveryMode.WindowMessage, mode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures strict foreground typing fails when the target window does not own the foreground.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_RequireForegroundWithoutForeground_ThrowsInvalidOperationException() {
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() => WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true,
+            RequireForegroundWindowForTyping = true
+        }, targetOwnsForeground: false));
+
+        StringAssert.Contains(exception.Message, "Current:");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures strict foreground typing rejects message-only routing.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_RequireForegroundWithMessageOnly_ThrowsInvalidOperationException() {
+        Assert.ThrowsException<InvalidOperationException>(() => WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = false,
+            RequireForegroundWindowForTyping = true
+        }, targetOwnsForeground: true));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures physical-key typing requires the target window to own the foreground.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_PhysicalKeysWithoutForeground_ThrowsInvalidOperationException() {
+        Assert.ThrowsException<InvalidOperationException>(() => WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true,
+            UsePhysicalKeyboardLayout = true
+        }, targetOwnsForeground: false));
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures physical-key typing still routes through the foreground delivery path when focus ownership is available.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_PhysicalKeysWithForeground_UsesForegroundInput() {
+        WindowInputService.WindowTextDeliveryMode mode = WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true,
+            UsePhysicalKeyboardLayout = true
+        }, targetOwnsForeground: true);
+
+        Assert.AreEqual(WindowInputService.WindowTextDeliveryMode.ForegroundInput, mode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures hosted-session scan code typing requires the target window to own the foreground.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_HostedSessionWithoutForeground_ThrowsInvalidOperationException() {
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() => WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true,
+            UseHostedSessionScanCodes = true
+        }, targetOwnsForeground: false));
+
+        StringAssert.Contains(exception.Message, "Current:");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures hosted-session scan code typing routes through foreground delivery when the target owns focus.
+    /// </summary>
+    public void WindowInputService_ResolveTextDeliveryMode_HostedSessionWithForeground_UsesForegroundInput() {
+        WindowInputService.WindowTextDeliveryMode mode = WindowInputService.ResolveTextDeliveryMode(new WindowInputOptions {
+            UseSendInput = true,
+            UseHostedSessionScanCodes = true
+        }, targetOwnsForeground: true);
+
+        Assert.AreEqual(WindowInputService.WindowTextDeliveryMode.ForegroundInput, mode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures script chunking preserves blank lines and line breaks.
+    /// </summary>
+    public void WindowInputService_CreateScriptChunks_PreservesBlankLines() {
+        IReadOnlyList<WindowInputService.WindowScriptChunk> chunks = WindowInputService.CreateScriptChunks("line1\n\nline3", 120);
+
+        Assert.AreEqual(3, chunks.Count);
+        Assert.AreEqual("line1", chunks[0].Text);
+        Assert.IsTrue(chunks[0].SendLineBreak);
+        Assert.AreEqual(string.Empty, chunks[1].Text);
+        Assert.IsTrue(chunks[1].SendLineBreak);
+        Assert.AreEqual("line3", chunks[2].Text);
+        Assert.IsFalse(chunks[2].SendLineBreak);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures script chunking splits long lines into smaller segments and only marks the final chunk with a line break.
+    /// </summary>
+    public void WindowInputService_CreateScriptChunks_SplitsLongLinesSafely() {
+        IReadOnlyList<WindowInputService.WindowScriptChunk> chunks = WindowInputService.CreateScriptChunks("abcdef\ngh", 3);
+
+        Assert.AreEqual(3, chunks.Count);
+        Assert.AreEqual("abc", chunks[0].Text);
+        Assert.IsFalse(chunks[0].SendLineBreak);
+        Assert.AreEqual("def", chunks[1].Text);
+        Assert.IsTrue(chunks[1].SendLineBreak);
+        Assert.AreEqual("gh", chunks[2].Text);
+        Assert.IsFalse(chunks[2].SendLineBreak);
+    }
 }

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\WindowTextHelper32\WindowTextHelper32.csproj" OutputItemType="Content" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <ProjectReference Include="..\DesktopManager.Cli\DesktopManager.Cli.csproj" />
     <ProjectReference Include="..\DesktopManager.TestApp\DesktopManager.TestApp.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
+++ b/Sources/DesktopManager.Tests/DesktopManager.Tests.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <ProjectReference Include="..\DesktopManager.Cli\DesktopManager.Cli.csproj" />
+    <ProjectReference Include="..\DesktopManager.PowerShell\DesktopManager.PowerShell.csproj" />
     <ProjectReference Include="..\DesktopManager.TestApp\DesktopManager.TestApp.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/Sources/DesktopManager.Tests/DesktopManagerTestAppSession.cs
+++ b/Sources/DesktopManager.Tests/DesktopManagerTestAppSession.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+
+namespace DesktopManager.Tests;
+
+internal sealed class DesktopManagerTestAppSession : IDisposable {
+    private const int LaunchTimeoutMilliseconds = 20000;
+    private const int CommandWriteRetryCount = 5;
+    private const int MaxRetainedHostedSessionArtifacts = 12;
+    private readonly string _sessionDirectory;
+    private readonly string _statusFilePath;
+    private readonly string _commandFilePath;
+    private readonly int _launcherProcessId;
+    private readonly int _resolvedProcessId;
+    private readonly IntPtr _windowHandle;
+
+    private DesktopManagerTestAppSession(string sessionDirectory, string statusFilePath, string commandFilePath, string windowTitle, int launcherProcessId, int resolvedProcessId, IntPtr windowHandle) {
+        _sessionDirectory = sessionDirectory;
+        _statusFilePath = statusFilePath;
+        _commandFilePath = commandFilePath;
+        WindowTitle = windowTitle;
+        _launcherProcessId = launcherProcessId;
+        _resolvedProcessId = resolvedProcessId;
+        _windowHandle = windowHandle;
+    }
+
+    public string WindowTitle { get; }
+
+    public int ProcessId => _resolvedProcessId;
+
+    public IntPtr WindowHandle => _windowHandle;
+
+    public WindowQueryOptions CreateWindowQuery() {
+        return new WindowQueryOptions {
+            Handle = _windowHandle,
+            ProcessId = _resolvedProcessId,
+            TitlePattern = WindowTitle,
+            IncludeHidden = false,
+            IncludeCloaked = false,
+            IncludeOwned = true,
+            IncludeEmptyTitles = true
+        };
+    }
+
+    public WindowControlQueryOptions CreateEditorControlQuery() {
+        return new WindowControlQueryOptions {
+            ClassNamePattern = "*Edit*",
+            SupportsBackgroundText = true
+        };
+    }
+
+    public static DesktopManagerTestAppSession Start(string scenario, string initialText = "seed", string? surface = null) {
+        if (string.IsNullOrWhiteSpace(scenario)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(scenario));
+        }
+
+        string windowTitle = "DesktopManager-TestApp-" + scenario + "-" + Guid.NewGuid().ToString("N");
+        string sessionDirectory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "TestApp", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(sessionDirectory);
+        string statusFilePath = Path.Combine(sessionDirectory, "status.json");
+        string commandFilePath = Path.Combine(sessionDirectory, "command.txt");
+        var automation = new DesktopAutomationService();
+        DesktopProcessLaunchInfo launch = automation.LaunchProcess(new DesktopProcessStartOptions {
+            FilePath = RequireExecutablePath(),
+            Arguments = BuildArguments(windowTitle, initialText, surface, statusFilePath, commandFilePath),
+            WaitForInputIdleMilliseconds = 5000,
+            WaitForWindowMilliseconds = LaunchTimeoutMilliseconds,
+            WaitForWindowIntervalMilliseconds = 100,
+            RequireWindow = true
+        });
+
+        int launcherProcessId = launch.ProcessId;
+        int resolvedProcessId = launch.ResolvedProcessId ?? launch.ProcessId;
+        if (resolvedProcessId <= 0) {
+            throw new InvalidOperationException("Expected the test app launch to resolve a live process identifier.");
+        }
+        if (launch.MainWindow == null || launch.MainWindow.Handle == IntPtr.Zero) {
+            throw new InvalidOperationException("Expected the test app launch to resolve a concrete main window handle.");
+        }
+
+        TestHelper.TrackProcessId(launcherProcessId);
+        TestHelper.TrackProcessId(resolvedProcessId);
+        return new DesktopManagerTestAppSession(sessionDirectory, statusFilePath, commandFilePath, windowTitle, launcherProcessId, resolvedProcessId, launch.MainWindow.Handle);
+    }
+
+    public void Dispose() {
+        KillProcessById(_resolvedProcessId);
+        KillProcessById(_launcherProcessId);
+        TryDeleteDirectory(_sessionDirectory);
+    }
+
+    public void RequestFocusEditor() {
+        WriteCommandFile("focus-editor");
+    }
+
+    public void RequestFocusCommandBar() {
+        WriteCommandFile("focus-commandbar");
+    }
+
+    public void RequestFocusSecondary() {
+        WriteCommandFile("focus-secondary");
+    }
+
+    public void RequestHoldEditorForeground(int durationMilliseconds) {
+        WriteCommandFile("hold-editor-foreground:" + durationMilliseconds);
+    }
+
+    public void RequestHoldCommandBarForeground(int durationMilliseconds) {
+        WriteCommandFile("hold-commandbar-foreground:" + durationMilliseconds);
+    }
+
+    public void RequestStopForegroundHold() {
+        WriteCommandFile("stop-foreground-hold");
+    }
+
+    public DesktopManagerTestAppStatus ReadStatus() {
+        if (!File.Exists(_statusFilePath)) {
+            throw new AssertInconclusiveException("The desktop test app status file was not created.");
+        }
+
+        DesktopManagerTestAppStatus? status = JsonSerializer.Deserialize<DesktopManagerTestAppStatus>(File.ReadAllText(_statusFilePath));
+        if (status == null) {
+            throw new AssertInconclusiveException("The desktop test app status file could not be read.");
+        }
+
+        return status;
+    }
+
+    public DesktopManagerTestAppStatus WaitForStatus(Func<DesktopManagerTestAppStatus, bool> predicate, int timeoutMilliseconds, string failureMessage) {
+        DateTime deadlineUtc = DateTime.UtcNow.AddMilliseconds(timeoutMilliseconds);
+        while (DateTime.UtcNow <= deadlineUtc) {
+            if (TryReadStatus(out DesktopManagerTestAppStatus? status) && predicate(status!)) {
+                return status!;
+            }
+
+            Thread.Sleep(100);
+        }
+
+        throw new AssertInconclusiveException(failureMessage);
+    }
+
+    public string WriteStatusArtifact(string reason, string? summaryText = null, string? summaryCategoryHint = null) {
+        return WriteStatusArtifact(reason, null, null, summaryText, summaryCategoryHint);
+    }
+
+    public string WriteStatusArtifact(string reason, HostedSessionRetryHistoryReport? retryHistoryReport, string? policyReport = null, string? summaryText = null, string? summaryCategoryHint = null) {
+        DesktopManagerTestAppStatus status = ReadStatus();
+        string repositoryRoot = RequireRepositoryRoot();
+        string artifactDirectory = Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+        Directory.CreateDirectory(artifactDirectory);
+        PruneHostedSessionArtifacts(artifactDirectory, MaxRetainedHostedSessionArtifacts - 1);
+
+        string fileName =
+            DateTime.UtcNow.ToString("yyyyMMdd-HHmmssfff") + "-" +
+            SanitizeFileName(reason) + "-" +
+            SanitizeFileName(WindowTitle) + ".json";
+        string artifactPath = Path.Combine(artifactDirectory, fileName);
+
+        HostedSessionDiagnosticArtifact artifact = BuildStatusArtifact(reason, status, retryHistoryReport, policyReport, summaryText);
+        string json = JsonSerializer.Serialize(artifact, new JsonSerializerOptions {
+            WriteIndented = true
+        });
+        File.WriteAllText(artifactPath, json);
+        if (!string.IsNullOrWhiteSpace(summaryText)) {
+            File.WriteAllText(GetSummaryArtifactPath(artifactPath, summaryCategoryHint), summaryText);
+        }
+
+        return artifactPath;
+    }
+
+    public static string GetSummaryArtifactPath(string artifactPath, string? categoryHint = null) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(artifactPath));
+        }
+
+        string extension = string.IsNullOrWhiteSpace(categoryHint)
+            ? ".summary.txt"
+            : "." + SanitizeFileName(categoryHint ?? string.Empty) + ".summary.txt";
+        return Path.ChangeExtension(artifactPath, extension);
+    }
+
+    internal static void PruneHostedSessionArtifacts(string artifactDirectory, int maxJsonArtifacts) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory) || !Directory.Exists(artifactDirectory)) {
+            return;
+        }
+
+        if (maxJsonArtifacts < 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxJsonArtifacts));
+        }
+
+        string[] jsonArtifacts = Directory.GetFiles(artifactDirectory, "*.json", SearchOption.TopDirectoryOnly);
+        if (jsonArtifacts.Length <= maxJsonArtifacts) {
+            return;
+        }
+
+        Array.Sort(jsonArtifacts, CompareArtifactPathsByLastWriteDescending);
+        for (int index = maxJsonArtifacts; index < jsonArtifacts.Length; index++) {
+            foreach (string path in GetArtifactSetPaths(jsonArtifacts[index])) {
+                TryDeleteFile(path);
+            }
+        }
+    }
+
+    internal static string[] GetArtifactSetPaths(string jsonArtifactPath) {
+        if (string.IsNullOrWhiteSpace(jsonArtifactPath)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(jsonArtifactPath));
+        }
+
+        string directory = Path.GetDirectoryName(jsonArtifactPath) ?? string.Empty;
+        string stem = Path.GetFileNameWithoutExtension(jsonArtifactPath);
+        if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(stem) || !Directory.Exists(directory)) {
+            return new[] { jsonArtifactPath };
+        }
+
+        var paths = new List<string> { jsonArtifactPath };
+        string summaryPattern = stem + "*.summary.txt";
+        foreach (string summaryPath in Directory.GetFiles(directory, summaryPattern, SearchOption.TopDirectoryOnly)) {
+            if (!ContainsPath(paths, summaryPath)) {
+                paths.Add(summaryPath);
+            }
+        }
+
+        return paths.ToArray();
+    }
+
+    internal static HostedSessionDiagnosticArtifact BuildStatusArtifact(string reason, DesktopManagerTestAppStatus status, HostedSessionRetryHistoryReport? retryHistoryReport = null, string? policyReport = null, string? summaryText = null) {
+        if (string.IsNullOrWhiteSpace(reason)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(reason));
+        }
+
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        HostedSessionRetryHistoryReport resolvedRetryHistoryReport = retryHistoryReport ?? HostedSessionRetryHistoryReport.None;
+        string resolvedPolicyReport = string.IsNullOrWhiteSpace(policyReport)
+            ? HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status).ToPolicyReport()
+            : policyReport ?? string.Empty;
+        string resolvedSummaryText = string.IsNullOrWhiteSpace(summaryText)
+            ? HostedSessionDiagnosticFormatter.BuildArtifactSummary(reason, status, resolvedRetryHistoryReport, resolvedPolicyReport)
+            : summaryText ?? string.Empty;
+
+        return new HostedSessionDiagnosticArtifact {
+            Reason = reason,
+            CreatedUtc = DateTime.UtcNow.ToString("O"),
+            Summary = resolvedSummaryText,
+            PolicyReport = resolvedPolicyReport,
+            RetryHistoryReport = resolvedRetryHistoryReport,
+            Status = status
+        };
+    }
+
+    private bool TryReadStatus(out DesktopManagerTestAppStatus? status) {
+        status = null;
+        try {
+            if (!File.Exists(_statusFilePath)) {
+                return false;
+            }
+
+            status = JsonSerializer.Deserialize<DesktopManagerTestAppStatus>(File.ReadAllText(_statusFilePath));
+            return status != null;
+        } catch {
+            return false;
+        }
+    }
+
+    private void WriteCommandFile(string command) {
+        for (int attempt = 1; attempt <= CommandWriteRetryCount; attempt++) {
+            try {
+                File.WriteAllText(_commandFilePath, command);
+                return;
+            } catch (IOException) when (attempt < CommandWriteRetryCount) {
+                Thread.Sleep(50);
+            }
+        }
+
+        File.WriteAllText(_commandFilePath, command);
+    }
+
+    private static string BuildArguments(string windowTitle, string initialText, string? surface, string statusFilePath, string commandFilePath) {
+        string arguments = "--title " + QuoteArgument(windowTitle) + " --text " + QuoteArgument(initialText);
+        if (!string.IsNullOrWhiteSpace(surface)) {
+            arguments += " --surface " + QuoteArgument(surface!);
+        }
+
+        arguments += " --status-file " + QuoteArgument(statusFilePath);
+        arguments += " --command-file " + QuoteArgument(commandFilePath);
+
+        return arguments;
+    }
+
+    private static string QuoteArgument(string value) {
+        return "\"" + (value ?? string.Empty).Replace("\"", "\\\"") + "\"";
+    }
+
+    private static string RequireExecutablePath() {
+        DirectoryInfo? current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null) {
+            string preferred = Path.Combine(current.FullName, "Sources", "DesktopManager.TestApp", "bin", "Debug", GetPreferredTargetFramework(), "DesktopManager.TestApp.exe");
+            if (File.Exists(preferred)) {
+                return preferred;
+            }
+
+            string fallback = Path.Combine(current.FullName, "Sources", "DesktopManager.TestApp", "bin", "Debug", GetFallbackTargetFramework(), "DesktopManager.TestApp.exe");
+            if (File.Exists(fallback)) {
+                return fallback;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new AssertInconclusiveException("DesktopManager.TestApp.exe was not found. Build the DesktopManager.TestApp project before running live typing tests.");
+    }
+
+    private static string RequireRepositoryRoot() {
+        DirectoryInfo? current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null) {
+            if (Directory.Exists(Path.Combine(current.FullName, "Sources")) && Directory.Exists(Path.Combine(current.FullName, "Artifacts"))) {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new AssertInconclusiveException("Repository root could not be resolved for hosted-session diagnostics.");
+    }
+
+    private static string GetPreferredTargetFramework() {
+#if NET10_0
+        return "net10.0-windows";
+#else
+        return "net8.0-windows";
+#endif
+    }
+
+    private static string GetFallbackTargetFramework() {
+#if NET10_0
+        return "net8.0-windows";
+#else
+        return "net10.0-windows";
+#endif
+    }
+
+    private static void KillProcessById(int processId) {
+        if (processId <= 0) {
+            return;
+        }
+
+        try {
+            using Process process = Process.GetProcessById(processId);
+            TestHelper.SafeKillProcess(process);
+        } catch {
+            // Ignore cleanup failures for already exited processes.
+        }
+    }
+
+    private static int CompareArtifactPathsByLastWriteDescending(string left, string right) {
+        DateTime leftWriteTime = File.Exists(left) ? File.GetLastWriteTimeUtc(left) : DateTime.MinValue;
+        DateTime rightWriteTime = File.Exists(right) ? File.GetLastWriteTimeUtc(right) : DateTime.MinValue;
+        int comparison = rightWriteTime.CompareTo(leftWriteTime);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(right, left, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            if (Directory.Exists(path)) {
+                Directory.Delete(path, recursive: true);
+            }
+        } catch {
+            // Ignore cleanup failures for already removed temporary files.
+        }
+    }
+
+    private static void TryDeleteFile(string path) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            return;
+        }
+
+        try {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        } catch {
+            // Ignore cleanup failures for already removed temporary files.
+        }
+    }
+
+    private static string SanitizeFileName(string value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return "status";
+        }
+
+        char[] invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (char character in value) {
+            builder.Append(Array.IndexOf(invalid, character) >= 0 || char.IsWhiteSpace(character) ? '-' : character);
+        }
+
+        return builder.ToString().Trim('-');
+    }
+
+    private static bool ContainsPath(IReadOnlyList<string> paths, string candidate) {
+        foreach (string path in paths) {
+            if (string.Equals(path, candidate, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Sources/DesktopManager.Tests/DesktopManagerTestAppSessionTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopManagerTestAppSessionTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class DesktopManagerTestAppSessionTests {
+    [TestMethod]
+    public void BuildStatusArtifact_IncludesStructuredRetryHistoryReportAndStatus() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            LastObservedForegroundTitle = "Microsoft Edge",
+            LastObservedForegroundClass = "Chrome_WidgetWin_1",
+            StatusText = "waiting"
+        };
+        var retryHistoryReport = new HostedSessionRetryHistoryReport {
+            CategoryHint = "browser-electron",
+            Summary = "Repeated browser-electron foreground interruption observed 2 time(s): title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+            ExternalCount = 2,
+            DistinctFingerprintCount = 1
+        };
+
+        HostedSessionDiagnosticArtifact artifact = DesktopManagerTestAppSession.BuildStatusArtifact(
+            "Hosted-session typing inconclusive after foreground loss",
+            status,
+            retryHistoryReport,
+            "category='browser-electron', abortThreshold=2, fingerprint='title=''Microsoft Edge'' class=''Chrome_WidgetWin_1'''");
+
+        Assert.AreEqual(1, artifact.FormatVersion);
+        Assert.AreEqual("Hosted-session typing inconclusive after foreground loss", artifact.Reason);
+        Assert.AreEqual("browser-electron", artifact.RetryHistoryReport.CategoryHint);
+        Assert.AreEqual(2, artifact.RetryHistoryReport.ExternalCount);
+        Assert.AreEqual(1, artifact.RetryHistoryReport.DistinctFingerprintCount);
+        Assert.AreEqual("DesktopManager-TestApp-hosted-symbol-matrix-abc", artifact.Status.WindowTitle);
+        StringAssert.Contains(artifact.PolicyReport, "category='browser-electron'");
+        StringAssert.Contains(artifact.Summary, "RetryHistoryReport: category='browser-electron', externalCount=2, distinctFingerprintCount=1");
+    }
+
+    [TestMethod]
+    public void BuildStatusArtifact_SerializesRetryHistoryReportIntoJson() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            StatusText = "waiting"
+        };
+        var retryHistoryReport = new HostedSessionRetryHistoryReport {
+            CategoryHint = "mixed",
+            Summary = "Mixed foreground interruptions observed across retries: browser-electron x1, unknown x1.",
+            ExternalCount = 2,
+            DistinctFingerprintCount = 2
+        };
+
+        HostedSessionDiagnosticArtifact artifact = DesktopManagerTestAppSession.BuildStatusArtifact(
+            "Hosted-session typing inconclusive after foreground loss",
+            status,
+            retryHistoryReport,
+            "category='unknown', abortThreshold=3, fingerprint=''");
+        string json = JsonSerializer.Serialize(artifact);
+
+        StringAssert.Contains(json, "\"RetryHistoryReport\":");
+        StringAssert.Contains(json, "\"CategoryHint\":\"mixed\"");
+        StringAssert.Contains(json, "\"ExternalCount\":2");
+        StringAssert.Contains(json, "\"DistinctFingerprintCount\":2");
+        StringAssert.Contains(json, "\"Status\":");
+    }
+
+    [TestMethod]
+    public void GetArtifactSetPaths_ReturnsJsonAndCompanionSummaryFiles() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string jsonPath = Path.Combine(directory, "20260322-140000000-sample.json");
+            string summaryPath = Path.Combine(directory, "20260322-140000000-sample.browser-electron.summary.txt");
+            File.WriteAllText(jsonPath, "{}");
+            File.WriteAllText(summaryPath, "summary");
+
+            string[] paths = DesktopManagerTestAppSession.GetArtifactSetPaths(jsonPath);
+
+            CollectionAssert.AreEquivalent(new[] { jsonPath, summaryPath }, paths);
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void PruneHostedSessionArtifacts_RemovesOlderArtifactSetsAndKeepsNewest() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string oldestJsonPath = CreateArtifactSet(directory, "20260322-140000000-oldest", "oldest");
+            Thread.Sleep(20);
+            string middleJsonPath = CreateArtifactSet(directory, "20260322-140000001-middle", "middle");
+            Thread.Sleep(20);
+            string newestJsonPath = CreateArtifactSet(directory, "20260322-140000002-newest", "newest");
+
+            DesktopManagerTestAppSession.PruneHostedSessionArtifacts(directory, 2);
+
+            Assert.IsFalse(File.Exists(oldestJsonPath));
+            Assert.IsFalse(File.Exists(DesktopManagerTestAppSession.GetSummaryArtifactPath(oldestJsonPath, "oldest")));
+            Assert.IsTrue(File.Exists(middleJsonPath));
+            Assert.IsTrue(File.Exists(DesktopManagerTestAppSession.GetSummaryArtifactPath(middleJsonPath, "middle")));
+            Assert.IsTrue(File.Exists(newestJsonPath));
+            Assert.IsTrue(File.Exists(DesktopManagerTestAppSession.GetSummaryArtifactPath(newestJsonPath, "newest")));
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void PruneHostedSessionArtifacts_WithMixedSummaryNames_RemovesOnlyMatchingArtifactSet() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string oldestJsonPath = CreateArtifactSet(directory, "20260322-140000000-oldest", "browser-electron");
+            string oldestExtraSummaryPath = Path.Combine(directory, "20260322-140000000-oldest.mixed.summary.txt");
+            File.WriteAllText(oldestExtraSummaryPath, "alternate summary");
+            Thread.Sleep(20);
+            string newestJsonPath = CreateArtifactSet(directory, "20260322-140000001-newest", "unknown");
+            string unrelatedPath = Path.Combine(directory, "notes.txt");
+            File.WriteAllText(unrelatedPath, "keep me");
+
+            DesktopManagerTestAppSession.PruneHostedSessionArtifacts(directory, 1);
+
+            Assert.IsFalse(File.Exists(oldestJsonPath));
+            Assert.IsFalse(File.Exists(DesktopManagerTestAppSession.GetSummaryArtifactPath(oldestJsonPath, "browser-electron")));
+            Assert.IsFalse(File.Exists(oldestExtraSummaryPath));
+            Assert.IsTrue(File.Exists(newestJsonPath));
+            Assert.IsTrue(File.Exists(DesktopManagerTestAppSession.GetSummaryArtifactPath(newestJsonPath, "unknown")));
+            Assert.IsTrue(File.Exists(unrelatedPath));
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    private static string CreateArtifactSet(string directory, string stem, string categoryHint) {
+        string jsonPath = Path.Combine(directory, stem + ".json");
+        File.WriteAllText(jsonPath, "{}");
+        File.WriteAllText(DesktopManagerTestAppSession.GetSummaryArtifactPath(jsonPath, categoryHint), "summary");
+        return jsonPath;
+    }
+
+    private static string CreateTemporaryArtifactDirectory() {
+        string directory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "HostedSessionArtifacts", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void TryDeleteDirectory(string directory) {
+        try {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        } catch {
+            // Ignore cleanup failures for temporary test files.
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/DesktopManagerTestAppStatus.cs
+++ b/Sources/DesktopManager.Tests/DesktopManagerTestAppStatus.cs
@@ -1,0 +1,49 @@
+namespace DesktopManager.Tests;
+
+internal sealed class DesktopManagerTestAppStatus {
+    public int ProcessId { get; set; }
+
+    public long WindowHandle { get; set; }
+
+    public long EditorHandle { get; set; }
+
+    public long SecondaryWindowHandle { get; set; }
+
+    public string WindowTitle { get; set; } = string.Empty;
+
+    public string ActiveSurface { get; set; } = string.Empty;
+
+    public bool ContainsFocus { get; set; }
+
+    public bool IsForegroundWindow { get; set; }
+
+    public bool SecondaryIsForegroundWindow { get; set; }
+
+    public bool ForegroundHoldActive { get; set; }
+
+    public string ForegroundHoldSurface { get; set; } = string.Empty;
+
+    public int ForegroundHoldRequestCount { get; set; }
+
+    public int ForegroundHoldRecoveryCount { get; set; }
+
+    public long LastObservedForegroundHandle { get; set; }
+
+    public string LastObservedForegroundTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundClass { get; set; } = string.Empty;
+
+    public string LastObservedForegroundChangedUtc { get; set; } = string.Empty;
+
+    public string LastCommand { get; set; } = string.Empty;
+
+    public List<string> ForegroundHistory { get; set; } = [];
+
+    public string EditorText { get; set; } = string.Empty;
+
+    public string SecondaryText { get; set; } = string.Empty;
+
+    public string CommandBarText { get; set; } = string.Empty;
+
+    public string StatusText { get; set; } = string.Empty;
+}

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifact.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifact.cs
@@ -1,0 +1,17 @@
+namespace DesktopManager.Tests;
+
+internal sealed class HostedSessionDiagnosticArtifact {
+    public int FormatVersion { get; set; } = 1;
+
+    public string Reason { get; set; } = string.Empty;
+
+    public string CreatedUtc { get; set; } = string.Empty;
+
+    public string Summary { get; set; } = string.Empty;
+
+    public string PolicyReport { get; set; } = string.Empty;
+
+    public HostedSessionRetryHistoryReport RetryHistoryReport { get; set; } = HostedSessionRetryHistoryReport.None;
+
+    public DesktopManagerTestAppStatus Status { get; set; } = new();
+}

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifactReader.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifactReader.cs
@@ -1,0 +1,331 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+internal static class HostedSessionDiagnosticArtifactReader {
+    public static HostedSessionDiagnosticArtifact Load(string artifactPath) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(artifactPath));
+        }
+
+        if (!File.Exists(artifactPath)) {
+            throw new FileNotFoundException("Hosted-session diagnostic artifact was not found.", artifactPath);
+        }
+
+        string json = File.ReadAllText(artifactPath);
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+
+        if (root.TryGetProperty("Status", out _)) {
+            HostedSessionDiagnosticArtifact? artifact = JsonSerializer.Deserialize<HostedSessionDiagnosticArtifact>(json);
+            if (artifact == null) {
+                throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+            }
+
+            return Normalize(artifact);
+        }
+
+        if (root.TryGetProperty("WindowTitle", out _)) {
+            DesktopManagerTestAppStatus? status = JsonSerializer.Deserialize<DesktopManagerTestAppStatus>(json);
+            if (status == null) {
+                throw new InvalidOperationException("Hosted-session legacy diagnostic artifact could not be deserialized.");
+            }
+
+            return CreateLegacyArtifact(status);
+        }
+
+        throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+    }
+
+    public static bool TryLoad(string artifactPath, out HostedSessionDiagnosticArtifact artifact, out string error) {
+        artifact = new HostedSessionDiagnosticArtifact();
+        error = string.Empty;
+
+        try {
+            artifact = Load(artifactPath);
+            return true;
+        } catch (Exception exception) when (
+            exception is ArgumentException ||
+            exception is FileNotFoundException ||
+            exception is IOException ||
+            exception is InvalidOperationException ||
+            exception is JsonException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    public static string Summarize(HostedSessionDiagnosticArtifact artifact) {
+        if (artifact == null) {
+            throw new ArgumentNullException(nameof(artifact));
+        }
+
+        HostedSessionRetryHistoryReport retryHistoryReport = artifact.RetryHistoryReport ?? HostedSessionRetryHistoryReport.None;
+        DesktopManagerTestAppStatus status = artifact.Status ?? new DesktopManagerTestAppStatus();
+
+        return
+            "reason='" + artifact.Reason + "', " +
+            HostedSessionDiagnosticFormatter.DescribeRetryHistory(retryHistoryReport) + ", " +
+            "policy='" + artifact.PolicyReport + "', " +
+            "windowTitle='" + status.WindowTitle + "', " +
+            "statusText='" + status.StatusText + "'";
+    }
+
+    public static string ReadSummary(string artifactPath) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(artifactPath));
+        }
+
+        string? summaryArtifactPath = FindPreferredSummaryArtifactPath(artifactPath);
+        if (!string.IsNullOrWhiteSpace(summaryArtifactPath) && File.Exists(summaryArtifactPath)) {
+            return File.ReadAllText(summaryArtifactPath);
+        }
+
+        return Summarize(Load(artifactPath));
+    }
+
+    public static bool TryReadSummary(string artifactPath, out string summary, out string error) {
+        summary = string.Empty;
+        error = string.Empty;
+
+        try {
+            summary = ReadSummary(artifactPath);
+            return true;
+        } catch (Exception exception) when (
+            exception is ArgumentException ||
+            exception is FileNotFoundException ||
+            exception is IOException ||
+            exception is InvalidOperationException ||
+            exception is JsonException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    public static string FindLatestArtifactPath(string artifactDirectory) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(artifactDirectory));
+        }
+
+        if (!Directory.Exists(artifactDirectory)) {
+            throw new DirectoryNotFoundException("Hosted-session diagnostic artifact directory was not found.");
+        }
+
+        string latestArtifactPath = FindLatestArtifactPathOrDefault(artifactDirectory) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(latestArtifactPath)) {
+            throw new FileNotFoundException("No hosted-session diagnostic artifacts were found.", artifactDirectory);
+        }
+
+        return latestArtifactPath;
+    }
+
+    public static string GetHostedSessionArtifactDirectory(string repositoryRoot) {
+        if (string.IsNullOrWhiteSpace(repositoryRoot)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(repositoryRoot));
+        }
+
+        return Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+    }
+
+    public static string FindLatestArtifactPathFromRepositoryRoot(string repositoryRoot) {
+        return FindLatestArtifactPath(GetHostedSessionArtifactDirectory(repositoryRoot));
+    }
+
+    public static HostedSessionDiagnosticArtifact LoadLatest(string artifactDirectory) {
+        return Load(FindLatestArtifactPath(artifactDirectory));
+    }
+
+    public static HostedSessionDiagnosticArtifact LoadLatestFromRepositoryRoot(string repositoryRoot) {
+        return Load(FindLatestArtifactPathFromRepositoryRoot(repositoryRoot));
+    }
+
+    public static bool TryLoadLatest(string artifactDirectory, out HostedSessionDiagnosticArtifact artifact, out string artifactPath, out string error) {
+        artifact = new HostedSessionDiagnosticArtifact();
+        artifactPath = string.Empty;
+        error = string.Empty;
+
+        try {
+            artifactPath = FindLatestArtifactPath(artifactDirectory);
+            artifact = Load(artifactPath);
+            return true;
+        } catch (Exception exception) when (
+            exception is ArgumentException ||
+            exception is DirectoryNotFoundException ||
+            exception is FileNotFoundException ||
+            exception is IOException ||
+            exception is InvalidOperationException ||
+            exception is JsonException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    public static bool TryLoadLatestFromRepositoryRoot(string repositoryRoot, out HostedSessionDiagnosticArtifact artifact, out string artifactPath, out string error) {
+        artifact = new HostedSessionDiagnosticArtifact();
+        artifactPath = string.Empty;
+        error = string.Empty;
+
+        try {
+            return TryLoadLatest(GetHostedSessionArtifactDirectory(repositoryRoot), out artifact, out artifactPath, out error);
+        } catch (Exception exception) when (exception is ArgumentException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    public static bool TryReadLatestSummary(string artifactDirectory, out string artifactPath, out string summary, out string error) {
+        artifactPath = string.Empty;
+        summary = string.Empty;
+        error = string.Empty;
+
+        try {
+            artifactPath = FindLatestArtifactPath(artifactDirectory);
+            summary = ReadSummary(artifactPath);
+            return true;
+        } catch (Exception exception) when (
+            exception is ArgumentException ||
+            exception is DirectoryNotFoundException ||
+            exception is FileNotFoundException ||
+            exception is IOException ||
+            exception is InvalidOperationException ||
+            exception is JsonException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    public static bool TryReadLatestSummaryFromRepositoryRoot(string repositoryRoot, out string artifactPath, out string summary, out string error) {
+        string artifactDirectory = string.Empty;
+        artifactPath = string.Empty;
+        summary = string.Empty;
+        error = string.Empty;
+
+        try {
+            artifactDirectory = GetHostedSessionArtifactDirectory(repositoryRoot);
+            return TryReadLatestSummary(artifactDirectory, out artifactPath, out summary, out error);
+        } catch (Exception exception) when (exception is ArgumentException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    internal static string? FindPreferredSummaryArtifactPath(string artifactPath) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(artifactPath));
+        }
+
+        if (!File.Exists(artifactPath)) {
+            return null;
+        }
+
+        string[] artifactSetPaths = DesktopManagerTestAppSession.GetArtifactSetPaths(artifactPath);
+        string? preferred = null;
+        foreach (string candidatePath in artifactSetPaths) {
+            if (!candidatePath.EndsWith(".summary.txt", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (preferred == null) {
+                preferred = candidatePath;
+                continue;
+            }
+
+            preferred = CompareSummaryPaths(candidatePath, preferred) < 0 ? candidatePath : preferred;
+        }
+
+        return preferred;
+    }
+
+    internal static string? FindLatestArtifactPathOrDefault(string artifactDirectory) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory) || !Directory.Exists(artifactDirectory)) {
+            return null;
+        }
+
+        string[] artifactPaths = Directory.GetFiles(artifactDirectory, "*.json", SearchOption.TopDirectoryOnly);
+        if (artifactPaths.Length == 0) {
+            return null;
+        }
+
+        Array.Sort(artifactPaths, CompareArtifactPathsByLastWriteDescending);
+        return artifactPaths[0];
+    }
+
+    private static HostedSessionDiagnosticArtifact Normalize(HostedSessionDiagnosticArtifact artifact) {
+        artifact.Reason ??= string.Empty;
+        artifact.CreatedUtc ??= string.Empty;
+        artifact.Summary ??= string.Empty;
+        artifact.PolicyReport ??= string.Empty;
+        artifact.RetryHistoryReport ??= HostedSessionRetryHistoryReport.None;
+        artifact.RetryHistoryReport.CategoryHint ??= string.Empty;
+        artifact.RetryHistoryReport.Summary ??= string.Empty;
+        artifact.Status ??= new DesktopManagerTestAppStatus();
+        artifact.Status.WindowTitle ??= string.Empty;
+        artifact.Status.ActiveSurface ??= string.Empty;
+        artifact.Status.ForegroundHoldSurface ??= string.Empty;
+        artifact.Status.LastObservedForegroundTitle ??= string.Empty;
+        artifact.Status.LastObservedForegroundClass ??= string.Empty;
+        artifact.Status.LastObservedForegroundChangedUtc ??= string.Empty;
+        artifact.Status.LastCommand ??= string.Empty;
+        artifact.Status.ForegroundHistory ??= [];
+        artifact.Status.EditorText ??= string.Empty;
+        artifact.Status.SecondaryText ??= string.Empty;
+        artifact.Status.CommandBarText ??= string.Empty;
+        artifact.Status.StatusText ??= string.Empty;
+        return artifact;
+    }
+
+    private static HostedSessionDiagnosticArtifact CreateLegacyArtifact(DesktopManagerTestAppStatus status) {
+        HostedSessionExternalForegroundReport report = HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status);
+        HostedSessionRetryHistoryReport retryHistoryReport = HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(new[] { report });
+        return Normalize(new HostedSessionDiagnosticArtifact {
+            FormatVersion = 0,
+            Reason = "Legacy hosted-session diagnostic artifact",
+            CreatedUtc = string.Empty,
+            Summary = HostedSessionDiagnosticFormatter.Summarize(status),
+            PolicyReport = report.ToPolicyReport(),
+            RetryHistoryReport = retryHistoryReport,
+            Status = status
+        });
+    }
+
+    private static int CompareSummaryPaths(string left, string right) {
+        string leftFileName = Path.GetFileName(left);
+        string rightFileName = Path.GetFileName(right);
+        int leftSegmentCount = CountSummaryNameSegments(leftFileName);
+        int rightSegmentCount = CountSummaryNameSegments(rightFileName);
+        int comparison = leftSegmentCount.CompareTo(rightSegmentCount);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(leftFileName, rightFileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountSummaryNameSegments(string fileName) {
+        if (string.IsNullOrWhiteSpace(fileName)) {
+            return int.MaxValue;
+        }
+
+        int count = 0;
+        foreach (char character in fileName) {
+            if (character == '.') {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CompareArtifactPathsByLastWriteDescending(string left, string right) {
+        DateTime leftWriteTime = File.Exists(left) ? File.GetLastWriteTimeUtc(left) : DateTime.MinValue;
+        DateTime rightWriteTime = File.Exists(right) ? File.GetLastWriteTimeUtc(right) : DateTime.MinValue;
+        int comparison = rightWriteTime.CompareTo(leftWriteTime);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(right, left, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifactReaderTests.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticArtifactReaderTests.cs
@@ -1,0 +1,357 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class HostedSessionDiagnosticArtifactReaderTests {
+    [TestMethod]
+    public void Load_RoundTripsStructuredArtifact() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            var artifact = new HostedSessionDiagnosticArtifact {
+                Reason = "Hosted-session typing inconclusive after foreground loss",
+                CreatedUtc = "2026-03-22T17:20:00.0000000Z",
+                Summary = "summary",
+                PolicyReport = "category='browser-electron', abortThreshold=2, fingerprint='title=''Microsoft Edge'' class=''Chrome_WidgetWin_1'''",
+                RetryHistoryReport = new HostedSessionRetryHistoryReport {
+                    CategoryHint = "browser-electron",
+                    Summary = "Repeated browser-electron foreground interruption observed 2 time(s): title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                    ExternalCount = 2,
+                    DistinctFingerprintCount = 1
+                },
+                Status = new DesktopManagerTestAppStatus {
+                    WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+                    StatusText = "waiting"
+                }
+            };
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(artifact));
+
+            HostedSessionDiagnosticArtifact loaded = HostedSessionDiagnosticArtifactReader.Load(artifactPath);
+
+            Assert.AreEqual("Hosted-session typing inconclusive after foreground loss", loaded.Reason);
+            Assert.AreEqual("browser-electron", loaded.RetryHistoryReport.CategoryHint);
+            Assert.AreEqual(2, loaded.RetryHistoryReport.ExternalCount);
+            Assert.AreEqual("DesktopManager-TestApp-hosted-symbol-matrix-abc", loaded.Status.WindowTitle);
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void TryLoad_WithMalformedJson_ReturnsFalseAndError() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            File.WriteAllText(artifactPath, "{ not-json");
+
+            bool loaded = HostedSessionDiagnosticArtifactReader.TryLoad(artifactPath, out HostedSessionDiagnosticArtifact artifact, out string error);
+
+            Assert.IsFalse(loaded);
+            Assert.AreEqual(string.Empty, artifact.Reason);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(error));
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void Summarize_IncludesStructuredRetryHistoryAndStatusFields() {
+        var artifact = new HostedSessionDiagnosticArtifact {
+            Reason = "Hosted-session typing inconclusive after foreground loss",
+            PolicyReport = "category='mixed', abortThreshold=3, fingerprint=''",
+            RetryHistoryReport = new HostedSessionRetryHistoryReport {
+                CategoryHint = "mixed",
+                Summary = "Mixed foreground interruptions observed across retries: browser-electron x1, unknown x1.",
+                ExternalCount = 2,
+                DistinctFingerprintCount = 2
+            },
+            Status = new DesktopManagerTestAppStatus {
+                WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+                StatusText = "waiting"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticArtifactReader.Summarize(artifact);
+
+        StringAssert.Contains(summary, "reason='Hosted-session typing inconclusive after foreground loss'");
+        StringAssert.Contains(summary, "category='mixed', externalCount=2, distinctFingerprintCount=2");
+        StringAssert.Contains(summary, "windowTitle='DesktopManager-TestApp-hosted-symbol-matrix-abc'");
+        StringAssert.Contains(summary, "statusText='waiting'");
+    }
+
+    [TestMethod]
+    public void Load_WithLegacyRawStatusArtifact_ReturnsCompatibilityArtifact() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(new DesktopManagerTestAppStatus {
+                WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-legacy",
+                StatusText = "waiting",
+                LastObservedForegroundTitle = "Microsoft Edge",
+                LastObservedForegroundClass = "Chrome_WidgetWin_1",
+                ForegroundHistory = new List<string> {
+                    "2026-03-22T18:10:00.0000000Z [foreground] 0x999 'Microsoft Edge' class='Chrome_WidgetWin_1'"
+                }
+            }));
+
+            HostedSessionDiagnosticArtifact artifact = HostedSessionDiagnosticArtifactReader.Load(artifactPath);
+
+            Assert.AreEqual(0, artifact.FormatVersion);
+            Assert.AreEqual("Legacy hosted-session diagnostic artifact", artifact.Reason);
+            Assert.AreEqual("DesktopManager-TestApp-hosted-symbol-matrix-legacy", artifact.Status.WindowTitle);
+            Assert.AreEqual("browser-electron", artifact.RetryHistoryReport.CategoryHint);
+            StringAssert.Contains(artifact.PolicyReport, "category='browser-electron'");
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSummary_WithCompanionSummaryPrefersSummaryFile() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "reason",
+                Status = new DesktopManagerTestAppStatus {
+                    WindowTitle = "window"
+                }
+            }));
+            string summaryPath = DesktopManagerTestAppSession.GetSummaryArtifactPath(artifactPath, "browser-electron");
+            File.WriteAllText(summaryPath, "summary-file-text");
+
+            string summary = HostedSessionDiagnosticArtifactReader.ReadSummary(artifactPath);
+
+            Assert.AreEqual("summary-file-text", summary);
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSummary_WithoutCompanionSummaryFallsBackToArtifactSummary() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "Hosted-session typing inconclusive after foreground loss",
+                PolicyReport = "category='mixed', abortThreshold=3, fingerprint=''",
+                RetryHistoryReport = new HostedSessionRetryHistoryReport {
+                    CategoryHint = "mixed",
+                    Summary = "Mixed foreground interruptions observed across retries: browser-electron x1, unknown x1.",
+                    ExternalCount = 2,
+                    DistinctFingerprintCount = 2
+                },
+                Status = new DesktopManagerTestAppStatus {
+                    WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+                    StatusText = "waiting"
+                }
+            }));
+
+            string summary = HostedSessionDiagnosticArtifactReader.ReadSummary(artifactPath);
+
+            StringAssert.Contains(summary, "reason='Hosted-session typing inconclusive after foreground loss'");
+            StringAssert.Contains(summary, "category='mixed', externalCount=2, distinctFingerprintCount=2");
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void FindPreferredSummaryArtifactPath_WithMultipleCompanionFiles_PrefersSimplerName() {
+        string artifactPath = CreateTemporaryArtifactPath();
+        try {
+            File.WriteAllText(artifactPath, "{}");
+            string preferredSummaryPath = Path.ChangeExtension(artifactPath, ".summary.txt");
+            string alternateSummaryPath = DesktopManagerTestAppSession.GetSummaryArtifactPath(artifactPath, "browser-electron");
+            File.WriteAllText(preferredSummaryPath, "preferred");
+            File.WriteAllText(alternateSummaryPath, "alternate");
+
+            string? resolvedSummaryPath = HostedSessionDiagnosticArtifactReader.FindPreferredSummaryArtifactPath(artifactPath);
+
+            Assert.AreEqual(preferredSummaryPath, resolvedSummaryPath);
+        } finally {
+            TryDeleteFile(artifactPath);
+        }
+    }
+
+    [TestMethod]
+    public void FindLatestArtifactPathOrDefault_WithMultipleArtifacts_ReturnsNewestJson() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string oldestArtifactPath = Path.Combine(directory, "20260322-172000000-oldest.json");
+            File.WriteAllText(oldestArtifactPath, "{}");
+            Thread.Sleep(20);
+            string newestArtifactPath = Path.Combine(directory, "20260322-172000001-newest.json");
+            File.WriteAllText(newestArtifactPath, "{}");
+
+            string? latestArtifactPath = HostedSessionDiagnosticArtifactReader.FindLatestArtifactPathOrDefault(directory);
+
+            Assert.AreEqual(newestArtifactPath, latestArtifactPath);
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void TryReadLatestSummary_WithNewestSummaryArtifact_ReturnsArtifactAndSummary() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string oldestArtifactPath = Path.Combine(directory, "20260322-172000000-oldest.json");
+            File.WriteAllText(oldestArtifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "oldest"
+            }));
+            File.WriteAllText(DesktopManagerTestAppSession.GetSummaryArtifactPath(oldestArtifactPath, "unknown"), "oldest-summary");
+            Thread.Sleep(20);
+
+            string newestArtifactPath = Path.Combine(directory, "20260322-172000001-newest.json");
+            File.WriteAllText(newestArtifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "newest"
+            }));
+            File.WriteAllText(DesktopManagerTestAppSession.GetSummaryArtifactPath(newestArtifactPath, "browser-electron"), "newest-summary");
+
+            bool loaded = HostedSessionDiagnosticArtifactReader.TryReadLatestSummary(directory, out string artifactPath, out string summary, out string error);
+
+            Assert.IsTrue(loaded);
+            Assert.AreEqual(newestArtifactPath, artifactPath);
+            Assert.AreEqual("newest-summary", summary);
+            Assert.AreEqual(string.Empty, error);
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void TryReadLatestSummary_WithoutArtifacts_ReturnsFalseAndError() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            bool loaded = HostedSessionDiagnosticArtifactReader.TryReadLatestSummary(directory, out string artifactPath, out string summary, out string error);
+
+            Assert.IsFalse(loaded);
+            Assert.AreEqual(string.Empty, artifactPath);
+            Assert.AreEqual(string.Empty, summary);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(error));
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void GetHostedSessionArtifactDirectory_FromRepositoryRoot_ReturnsExpectedFolder() {
+        string directory = HostedSessionDiagnosticArtifactReader.GetHostedSessionArtifactDirectory(@"C:\Repo\DesktopManager");
+
+        Assert.AreEqual(@"C:\Repo\DesktopManager\Artifacts\HostedSessionTyping", directory);
+    }
+
+    [TestMethod]
+    public void TryReadLatestSummaryFromRepositoryRoot_UsesHostedSessionArtifactFolder() {
+        string repositoryRoot = CreateTemporaryArtifactDirectory();
+        string artifactDirectory = HostedSessionDiagnosticArtifactReader.GetHostedSessionArtifactDirectory(repositoryRoot);
+        Directory.CreateDirectory(artifactDirectory);
+
+        try {
+            string artifactPath = Path.Combine(artifactDirectory, "20260322-172000001-newest.json");
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "newest"
+            }));
+            File.WriteAllText(DesktopManagerTestAppSession.GetSummaryArtifactPath(artifactPath, "browser-electron"), "newest-summary");
+
+            bool loaded = HostedSessionDiagnosticArtifactReader.TryReadLatestSummaryFromRepositoryRoot(repositoryRoot, out string resolvedArtifactPath, out string summary, out string error);
+
+            Assert.IsTrue(loaded);
+            Assert.AreEqual(artifactPath, resolvedArtifactPath);
+            Assert.AreEqual("newest-summary", summary);
+            Assert.AreEqual(string.Empty, error);
+        } finally {
+            TryDeleteDirectory(repositoryRoot);
+        }
+    }
+
+    [TestMethod]
+    public void LoadLatest_WithMultipleArtifacts_ReturnsNewestArtifactObject() {
+        string directory = CreateTemporaryArtifactDirectory();
+        try {
+            string oldestArtifactPath = Path.Combine(directory, "20260322-172000000-oldest.json");
+            File.WriteAllText(oldestArtifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "oldest"
+            }));
+            Thread.Sleep(20);
+
+            string newestArtifactPath = Path.Combine(directory, "20260322-172000001-newest.json");
+            File.WriteAllText(newestArtifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "newest",
+                Status = new DesktopManagerTestAppStatus {
+                    WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-newest"
+                }
+            }));
+
+            HostedSessionDiagnosticArtifact artifact = HostedSessionDiagnosticArtifactReader.LoadLatest(directory);
+
+            Assert.AreEqual("newest", artifact.Reason);
+            Assert.AreEqual("DesktopManager-TestApp-hosted-symbol-matrix-newest", artifact.Status.WindowTitle);
+        } finally {
+            TryDeleteDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void TryLoadLatestFromRepositoryRoot_ReturnsArtifactAndPath() {
+        string repositoryRoot = CreateTemporaryArtifactDirectory();
+        string artifactDirectory = HostedSessionDiagnosticArtifactReader.GetHostedSessionArtifactDirectory(repositoryRoot);
+        Directory.CreateDirectory(artifactDirectory);
+
+        try {
+            string artifactPath = Path.Combine(artifactDirectory, "20260322-172000001-newest.json");
+            File.WriteAllText(artifactPath, JsonSerializer.Serialize(new HostedSessionDiagnosticArtifact {
+                Reason = "newest",
+                Status = new DesktopManagerTestAppStatus {
+                    WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-newest"
+                }
+            }));
+
+            bool loaded = HostedSessionDiagnosticArtifactReader.TryLoadLatestFromRepositoryRoot(repositoryRoot, out HostedSessionDiagnosticArtifact artifact, out string resolvedArtifactPath, out string error);
+
+            Assert.IsTrue(loaded);
+            Assert.AreEqual(artifactPath, resolvedArtifactPath);
+            Assert.AreEqual("newest", artifact.Reason);
+            Assert.AreEqual("DesktopManager-TestApp-hosted-symbol-matrix-newest", artifact.Status.WindowTitle);
+            Assert.AreEqual(string.Empty, error);
+        } finally {
+            TryDeleteDirectory(repositoryRoot);
+        }
+    }
+
+    private static string CreateTemporaryArtifactPath() {
+        return Path.Combine(CreateTemporaryArtifactDirectory(), "artifact.json");
+    }
+
+    private static string CreateTemporaryArtifactDirectory() {
+        string directory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "HostedSessionArtifacts", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void TryDeleteFile(string path) {
+        try {
+            string? directory = Path.GetDirectoryName(path);
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+
+            if (!string.IsNullOrWhiteSpace(directory) && Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        } catch {
+            // Ignore cleanup failures for temporary test files.
+        }
+    }
+
+    private static void TryDeleteDirectory(string directory) {
+        try {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        } catch {
+            // Ignore cleanup failures for temporary test files.
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticFormatter.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticFormatter.cs
@@ -1,0 +1,282 @@
+using System;
+
+namespace DesktopManager.Tests;
+
+internal static class HostedSessionDiagnosticFormatter {
+    private const int PersistentExternalForegroundAbortThreshold = 2;
+    private const int DefaultExternalForegroundAbortThreshold = 3;
+
+    public static string Summarize(DesktopManagerTestAppStatus status) {
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        HostedSessionExternalForegroundReport report = CreateExternalForegroundReport(status);
+        if (report.HasExternalForeground) {
+            return "External foreground interruption observed: " + report.Entry;
+        }
+
+        if (status.ForegroundHoldRecoveryCount > 0) {
+            return "Foreground hold recovered focus " + status.ForegroundHoldRecoveryCount + " time(s) without a retained external foreground entry.";
+        }
+
+        if (status.ForegroundHoldRequestCount > 0) {
+            return "No external foreground interruption recorded; hold requested " + status.ForegroundHoldRequestCount + " time(s).";
+        }
+
+        return "No hosted-session hold or external foreground interruption was recorded.";
+    }
+
+    internal static string BuildArtifactSummary(string reason, DesktopManagerTestAppStatus status, string retryHistorySummary, string policyReport) {
+        return BuildArtifactSummary(
+            reason,
+            status,
+            new HostedSessionRetryHistoryReport {
+                CategoryHint = "unknown",
+                Summary = retryHistorySummary,
+                ExternalCount = 0,
+                DistinctFingerprintCount = 0
+            },
+            policyReport);
+    }
+
+    internal static string BuildArtifactSummary(string reason, DesktopManagerTestAppStatus status, HostedSessionRetryHistoryReport retryHistoryReport, string policyReport) {
+        if (string.IsNullOrWhiteSpace(reason)) {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(reason));
+        }
+
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        if (retryHistoryReport == null) {
+            throw new ArgumentNullException(nameof(retryHistoryReport));
+        }
+
+        if (string.IsNullOrWhiteSpace(retryHistoryReport.Summary)) {
+            retryHistoryReport = new HostedSessionRetryHistoryReport {
+                CategoryHint = string.IsNullOrWhiteSpace(retryHistoryReport.CategoryHint) ? "none" : retryHistoryReport.CategoryHint,
+                Summary = "No retry history was captured for this diagnostic.",
+                ExternalCount = retryHistoryReport.ExternalCount,
+                DistinctFingerprintCount = retryHistoryReport.DistinctFingerprintCount
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(policyReport)) {
+            policyReport = CreateExternalForegroundReport(status).ToPolicyReport();
+        }
+
+        return string.Join(
+            Environment.NewLine,
+            new[] {
+                "Reason: " + reason,
+                "Summary: " + Summarize(status),
+                "RetryHistory: " + retryHistoryReport.Summary,
+                "RetryHistoryReport: " + DescribeRetryHistory(retryHistoryReport),
+                "Policy: " + policyReport,
+                "LastObservedForegroundTitle: " + status.LastObservedForegroundTitle,
+                "LastObservedForegroundClass: " + status.LastObservedForegroundClass,
+                "ForegroundHoldRecoveryCount: " + status.ForegroundHoldRecoveryCount,
+                "StatusText: " + status.StatusText
+            });
+    }
+
+    internal static string DescribeRetryHistory(HostedSessionRetryHistoryReport report) {
+        if (report == null) {
+            throw new ArgumentNullException(nameof(report));
+        }
+
+        return
+            "category='" + report.CategoryHint + "', " +
+            "externalCount=" + report.ExternalCount + ", " +
+            "distinctFingerprintCount=" + report.DistinctFingerprintCount;
+    }
+
+    internal static string GetRetryHistoryCategoryHint(IReadOnlyList<HostedSessionExternalForegroundReport> reports) {
+        return CreateRetryHistoryReport(reports).CategoryHint;
+    }
+
+    internal static string SummarizeRetryHistory(IReadOnlyList<HostedSessionExternalForegroundReport> reports) {
+        return CreateRetryHistoryReport(reports).Summary;
+    }
+
+    internal static HostedSessionRetryHistoryReport CreateRetryHistoryReport(IReadOnlyList<HostedSessionExternalForegroundReport> reports) {
+        if (reports == null) {
+            throw new ArgumentNullException(nameof(reports));
+        }
+
+        var externalReports = new List<HostedSessionExternalForegroundReport>();
+        foreach (HostedSessionExternalForegroundReport report in reports) {
+            if (report != null && report.HasExternalForeground) {
+                externalReports.Add(report);
+            }
+        }
+
+        if (externalReports.Count == 0) {
+            return HostedSessionRetryHistoryReport.None;
+        }
+
+        var categoryCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var fingerprintCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (HostedSessionExternalForegroundReport report in externalReports) {
+            if (!categoryCounts.ContainsKey(report.Category)) {
+                categoryCounts[report.Category] = 0;
+            }
+
+            categoryCounts[report.Category]++;
+
+            if (!fingerprintCounts.ContainsKey(report.Fingerprint)) {
+                fingerprintCounts[report.Fingerprint] = 0;
+            }
+
+            fingerprintCounts[report.Fingerprint]++;
+        }
+
+        if (fingerprintCounts.Count == 1) {
+            HostedSessionExternalForegroundReport firstReport = externalReports[0];
+            return new HostedSessionRetryHistoryReport {
+                CategoryHint = firstReport.Category,
+                ExternalCount = externalReports.Count,
+                DistinctFingerprintCount = 1,
+                Summary =
+                    "Repeated " +
+                    firstReport.Category +
+                    " foreground interruption observed " +
+                    externalReports.Count +
+                    " time(s): " +
+                    firstReport.Fingerprint
+            };
+        }
+
+        if (categoryCounts.Count == 1) {
+            HostedSessionExternalForegroundReport firstReport = externalReports[0];
+            return new HostedSessionRetryHistoryReport {
+                CategoryHint = firstReport.Category,
+                ExternalCount = externalReports.Count,
+                DistinctFingerprintCount = fingerprintCounts.Count,
+                Summary =
+                    "Multiple " +
+                    firstReport.Category +
+                    " foreground interruptions observed " +
+                    externalReports.Count +
+                    " time(s) across " +
+                    fingerprintCounts.Count +
+                    " distinct fingerprints."
+            };
+        }
+
+        var parts = new List<string>();
+        foreach (KeyValuePair<string, int> entry in categoryCounts) {
+            parts.Add(entry.Key + " x" + entry.Value);
+        }
+
+        return new HostedSessionRetryHistoryReport {
+            CategoryHint = "mixed",
+            ExternalCount = externalReports.Count,
+            DistinctFingerprintCount = fingerprintCounts.Count,
+            Summary = "Mixed foreground interruptions observed across retries: " + string.Join(", ", parts) + "."
+        };
+    }
+
+    internal static int GetRepeatedExternalForegroundAbortThreshold(DesktopManagerTestAppStatus status) {
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        return CreateExternalForegroundReport(status).AbortThreshold;
+    }
+
+    internal static string GetLatestExternalForegroundEntry(DesktopManagerTestAppStatus status) {
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        for (int index = status.ForegroundHistory.Count - 1; index >= 0; index--) {
+            string entry = status.ForegroundHistory[index];
+            if (!entry.Contains("[foreground]", StringComparison.Ordinal)) {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(status.WindowTitle) && entry.Contains(status.WindowTitle, StringComparison.Ordinal)) {
+                continue;
+            }
+
+            return entry;
+        }
+
+        return string.Empty;
+    }
+
+    internal static string GetLatestExternalForegroundFingerprint(DesktopManagerTestAppStatus status) {
+        return CreateExternalForegroundReport(status).Fingerprint;
+    }
+
+    internal static HostedSessionExternalForegroundReport CreateExternalForegroundReport(DesktopManagerTestAppStatus status) {
+        if (status == null) {
+            throw new ArgumentNullException(nameof(status));
+        }
+
+        string entry = GetLatestExternalForegroundEntry(status);
+        if (string.IsNullOrWhiteSpace(entry)) {
+            return HostedSessionExternalForegroundReport.None;
+        }
+
+        string title = ExtractQuotedValue(entry, 0);
+        string className = ExtractNamedValue(entry, "class='");
+        string fingerprint = string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(className)
+            ? entry
+            : "title='" + title + "' class='" + className + "'";
+        string category = GetExternalForegroundCategory(title, className);
+        int abortThreshold = string.Equals(category, "browser-electron", StringComparison.Ordinal)
+            ? PersistentExternalForegroundAbortThreshold
+            : DefaultExternalForegroundAbortThreshold;
+
+        return new HostedSessionExternalForegroundReport {
+            Category = category,
+            AbortThreshold = abortThreshold,
+            Summary = "External foreground interruption observed: " + entry,
+            Fingerprint = fingerprint,
+            Entry = entry
+        };
+    }
+
+    private static string ExtractQuotedValue(string entry, int startIndex) {
+        int openQuoteIndex = entry.IndexOf('\'', startIndex);
+        if (openQuoteIndex < 0) {
+            return string.Empty;
+        }
+
+        int closeQuoteIndex = entry.IndexOf('\'', openQuoteIndex + 1);
+        if (closeQuoteIndex < 0) {
+            return string.Empty;
+        }
+
+        return entry.Substring(openQuoteIndex + 1, closeQuoteIndex - openQuoteIndex - 1);
+    }
+
+    private static string ExtractNamedValue(string entry, string marker) {
+        int markerIndex = entry.IndexOf(marker, StringComparison.Ordinal);
+        if (markerIndex < 0) {
+            return string.Empty;
+        }
+
+        return ExtractQuotedValue(entry, markerIndex + marker.Length - 1);
+    }
+
+    private static string GetExternalForegroundCategory(string title, string className) {
+        if (className.Equals("Chrome_WidgetWin_1", StringComparison.OrdinalIgnoreCase) ||
+            className.Equals("Chrome_RenderWidgetHostHWND", StringComparison.OrdinalIgnoreCase) ||
+            className.Equals("MozillaWindowClass", StringComparison.OrdinalIgnoreCase) ||
+            className.Equals("ApplicationFrameWindow", StringComparison.OrdinalIgnoreCase)) {
+            return "browser-electron";
+        }
+
+        if (title.Contains("Microsoft Edge", StringComparison.OrdinalIgnoreCase) ||
+            title.Contains("Codex", StringComparison.OrdinalIgnoreCase) ||
+            title.Contains("ChatGPT", StringComparison.OrdinalIgnoreCase)) {
+            return "browser-electron";
+        }
+
+        return "unknown";
+    }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticFormatterTests.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticFormatterTests.cs
@@ -1,0 +1,364 @@
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class HostedSessionDiagnosticFormatterTests {
+    [TestMethod]
+    public void Summarize_WithExternalForegroundHistory_ReturnsExternalInterruptionSummary() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'",
+                "2026-03-22T13:55:01.0000000Z [foreground] 0x999 'Microsoft Edge' class='Chrome_WidgetWin_1'"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.Summarize(status);
+
+        StringAssert.Contains(summary, "External foreground interruption observed:");
+        StringAssert.Contains(summary, "Microsoft Edge");
+    }
+
+    [TestMethod]
+    public void Summarize_WithoutExternalForegroundButWithRecoveries_ReturnsRecoverySummary() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHoldRecoveryCount = 3,
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.Summarize(status);
+
+        StringAssert.Contains(summary, "recovered focus 3 time(s)");
+    }
+
+    [TestMethod]
+    public void Summarize_WithoutExternalForegroundOrRecoveries_ReturnsHoldSummary() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHoldRequestCount = 1,
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.Summarize(status);
+
+        StringAssert.Contains(summary, "No external foreground interruption recorded");
+    }
+
+    [TestMethod]
+    public void GetLatestExternalForegroundFingerprint_WithRepeatedExternalCulprit_IgnoresTimestampAndHandleNoise() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'",
+                "2026-03-22T13:55:01.0000000Z [foreground] 0x999 'Microsoft Edge' class='Chrome_WidgetWin_1'",
+                "2026-03-22T13:55:02.0000000Z [foreground] 0xABC 'Microsoft Edge' class='Chrome_WidgetWin_1'"
+            }
+        };
+
+        string fingerprint = HostedSessionDiagnosticFormatter.GetLatestExternalForegroundFingerprint(status);
+
+        Assert.AreEqual("title='Microsoft Edge' class='Chrome_WidgetWin_1'", fingerprint);
+    }
+
+    [TestMethod]
+    public void GetLatestExternalForegroundFingerprint_WithoutExternalForeground_ReturnsEmptyString() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'"
+            }
+        };
+
+        string fingerprint = HostedSessionDiagnosticFormatter.GetLatestExternalForegroundFingerprint(status);
+
+        Assert.AreEqual(string.Empty, fingerprint);
+    }
+
+    [TestMethod]
+    public void GetRepeatedExternalForegroundAbortThreshold_WithBrowserLikeExternalCulprit_ReturnsShortThreshold() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:01.0000000Z [foreground] 0x999 'Microsoft Edge' class='Chrome_WidgetWin_1'"
+            }
+        };
+
+        int threshold = HostedSessionDiagnosticFormatter.GetRepeatedExternalForegroundAbortThreshold(status);
+
+        Assert.AreEqual(2, threshold);
+    }
+
+    [TestMethod]
+    public void GetRepeatedExternalForegroundAbortThreshold_WithUnknownExternalCulprit_ReturnsDefaultThreshold() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:01.0000000Z [foreground] 0x999 'Untitled - Notepad' class='Notepad'"
+            }
+        };
+
+        int threshold = HostedSessionDiagnosticFormatter.GetRepeatedExternalForegroundAbortThreshold(status);
+
+        Assert.AreEqual(3, threshold);
+    }
+
+    [TestMethod]
+    public void CreateExternalForegroundReport_WithBrowserLikeCulprit_ReportsBrowserElectronCategory() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:01.0000000Z [foreground] 0x999 'Microsoft Edge' class='Chrome_WidgetWin_1'"
+            }
+        };
+
+        HostedSessionExternalForegroundReport report = HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status);
+
+        Assert.IsTrue(report.HasExternalForeground);
+        Assert.AreEqual("browser-electron", report.Category);
+        Assert.AreEqual(2, report.AbortThreshold);
+        StringAssert.Contains(report.ToPolicyReport(), "category='browser-electron'");
+    }
+
+    [TestMethod]
+    public void CreateExternalForegroundReport_WithoutExternalForeground_ReturnsNoneCategory() {
+        var status = new DesktopManagerTestAppStatus {
+            WindowTitle = "DesktopManager-TestApp-hosted-symbol-matrix-abc",
+            ForegroundHistory = new List<string> {
+                "2026-03-22T13:55:00.0000000Z [foreground] 0x123 'DesktopManager-TestApp-hosted-symbol-matrix-abc' class='WindowsForms10.Window.8.app.0.bb8560_r3_ad1'"
+            }
+        };
+
+        HostedSessionExternalForegroundReport report = HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status);
+
+        Assert.IsFalse(report.HasExternalForeground);
+        Assert.AreEqual("none", report.Category);
+        Assert.AreEqual(3, report.AbortThreshold);
+    }
+
+    [TestMethod]
+    public void SummarizeRetryHistory_WithRepeatedSameFingerprint_ReturnsRepeatedSummary() {
+        var reports = new List<HostedSessionExternalForegroundReport> {
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-2"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.SummarizeRetryHistory(reports);
+
+        StringAssert.Contains(summary, "Repeated browser-electron foreground interruption observed 2 time(s)");
+        StringAssert.Contains(summary, "Microsoft Edge");
+    }
+
+    [TestMethod]
+    public void SummarizeRetryHistory_WithMixedCategories_ReturnsMixedSummary() {
+        var reports = new List<HostedSessionExternalForegroundReport> {
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            new HostedSessionExternalForegroundReport {
+                Category = "unknown",
+                AbortThreshold = 3,
+                Summary = "External foreground interruption observed: Notepad",
+                Fingerprint = "title='Untitled - Notepad' class='Notepad'",
+                Entry = "entry-2"
+            }
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.SummarizeRetryHistory(reports);
+
+        StringAssert.Contains(summary, "Mixed foreground interruptions observed across retries");
+        StringAssert.Contains(summary, "browser-electron x1");
+        StringAssert.Contains(summary, "unknown x1");
+    }
+
+    [TestMethod]
+    public void BuildArtifactSummary_IncludesReasonRetryHistoryAndPolicy() {
+        var status = new DesktopManagerTestAppStatus {
+            LastObservedForegroundTitle = "Microsoft Edge",
+            LastObservedForegroundClass = "Chrome_WidgetWin_1",
+            ForegroundHoldRecoveryCount = 2,
+            StatusText = "waiting"
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.BuildArtifactSummary(
+            "Hosted-session typing inconclusive after foreground loss",
+            status,
+            "Repeated browser-electron foreground interruption observed 2 time(s): title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+            "category='browser-electron', abortThreshold=2, fingerprint='title=''Microsoft Edge'' class=''Chrome_WidgetWin_1'''");
+
+        StringAssert.Contains(summary, "Reason: Hosted-session typing inconclusive after foreground loss");
+        StringAssert.Contains(summary, "RetryHistory: Repeated browser-electron foreground interruption observed 2 time(s)");
+        StringAssert.Contains(summary, "Policy: category='browser-electron'");
+        StringAssert.Contains(summary, "LastObservedForegroundTitle: Microsoft Edge");
+    }
+
+    [TestMethod]
+    public void BuildArtifactSummary_WithRetryHistoryReport_IncludesRetryHistoryReportLine() {
+        var status = new DesktopManagerTestAppStatus {
+            LastObservedForegroundTitle = "Microsoft Edge",
+            LastObservedForegroundClass = "Chrome_WidgetWin_1",
+            ForegroundHoldRecoveryCount = 2,
+            StatusText = "waiting"
+        };
+        var retryHistoryReport = new HostedSessionRetryHistoryReport {
+            CategoryHint = "browser-electron",
+            Summary = "Repeated browser-electron foreground interruption observed 2 time(s): title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+            ExternalCount = 2,
+            DistinctFingerprintCount = 1
+        };
+
+        string summary = HostedSessionDiagnosticFormatter.BuildArtifactSummary(
+            "Hosted-session typing inconclusive after foreground loss",
+            status,
+            retryHistoryReport,
+            "category='browser-electron', abortThreshold=2, fingerprint='title=''Microsoft Edge'' class=''Chrome_WidgetWin_1'''");
+
+        StringAssert.Contains(summary, "RetryHistoryReport: category='browser-electron', externalCount=2, distinctFingerprintCount=1");
+    }
+
+    [TestMethod]
+    public void GetRetryHistoryCategoryHint_WithNoExternalReports_ReturnsNone() {
+        string hint = HostedSessionDiagnosticFormatter.GetRetryHistoryCategoryHint(new[] {
+            HostedSessionExternalForegroundReport.None
+        });
+
+        Assert.AreEqual("none", hint);
+    }
+
+    [TestMethod]
+    public void GetRetryHistoryCategoryHint_WithSameCategoryReports_ReturnsCategory() {
+        var reports = new[] {
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: ChatGPT",
+                Fingerprint = "title='ChatGPT' class='Chrome_WidgetWin_1'",
+                Entry = "entry-2"
+            }
+        };
+
+        string hint = HostedSessionDiagnosticFormatter.GetRetryHistoryCategoryHint(reports);
+
+        Assert.AreEqual("browser-electron", hint);
+    }
+
+    [TestMethod]
+    public void GetRetryHistoryCategoryHint_WithMixedCategories_ReturnsMixed() {
+        var reports = new[] {
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            new HostedSessionExternalForegroundReport {
+                Category = "unknown",
+                AbortThreshold = 3,
+                Summary = "External foreground interruption observed: Notepad",
+                Fingerprint = "title='Untitled - Notepad' class='Notepad'",
+                Entry = "entry-2"
+            }
+        };
+
+        string hint = HostedSessionDiagnosticFormatter.GetRetryHistoryCategoryHint(reports);
+
+        Assert.AreEqual("mixed", hint);
+    }
+
+    [TestMethod]
+    public void DescribeRetryHistory_WithReport_ReturnsStructuredCounts() {
+        var report = new HostedSessionRetryHistoryReport {
+            CategoryHint = "mixed",
+            Summary = "Mixed foreground interruptions observed across retries: browser-electron x1, unknown x1.",
+            ExternalCount = 2,
+            DistinctFingerprintCount = 2
+        };
+
+        string description = HostedSessionDiagnosticFormatter.DescribeRetryHistory(report);
+
+        Assert.AreEqual("category='mixed', externalCount=2, distinctFingerprintCount=2", description);
+    }
+
+    [TestMethod]
+    public void CreateRetryHistoryReport_WithNoisyInterleavedNoneEntries_IgnoresNonExternalReports() {
+        var reports = new[] {
+            HostedSessionExternalForegroundReport.None,
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            HostedSessionExternalForegroundReport.None,
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-2"
+            }
+        };
+
+        HostedSessionRetryHistoryReport report = HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(reports);
+
+        Assert.AreEqual("browser-electron", report.CategoryHint);
+        Assert.AreEqual(2, report.ExternalCount);
+        Assert.AreEqual(1, report.DistinctFingerprintCount);
+        StringAssert.Contains(report.Summary, "Repeated browser-electron foreground interruption observed 2 time(s)");
+    }
+
+    [TestMethod]
+    public void CreateRetryHistoryReport_WithSameCategoryDifferentFingerprints_ReturnsSameCategoryHint() {
+        var reports = new[] {
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Edge",
+                Fingerprint = "title='Microsoft Edge' class='Chrome_WidgetWin_1'",
+                Entry = "entry-1"
+            },
+            new HostedSessionExternalForegroundReport {
+                Category = "browser-electron",
+                AbortThreshold = 2,
+                Summary = "External foreground interruption observed: Codex",
+                Fingerprint = "title='Codex' class='Chrome_WidgetWin_1'",
+                Entry = "entry-2"
+            }
+        };
+
+        HostedSessionRetryHistoryReport report = HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(reports);
+
+        Assert.AreEqual("browser-electron", report.CategoryHint);
+        Assert.AreEqual(2, report.ExternalCount);
+        Assert.AreEqual(2, report.DistinctFingerprintCount);
+        StringAssert.Contains(report.Summary, "Multiple browser-electron foreground interruptions observed 2 time(s) across 2 distinct fingerprints.");
+    }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionExternalForegroundReport.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionExternalForegroundReport.cs
@@ -1,0 +1,30 @@
+namespace DesktopManager.Tests;
+
+internal sealed class HostedSessionExternalForegroundReport {
+    public static HostedSessionExternalForegroundReport None { get; } = new HostedSessionExternalForegroundReport {
+        Category = "none",
+        AbortThreshold = 3,
+        Summary = "No external foreground interruption recorded.",
+        Fingerprint = string.Empty,
+        Entry = string.Empty
+    };
+
+    public string Category { get; set; } = string.Empty;
+    public int AbortThreshold { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public string Fingerprint { get; set; } = string.Empty;
+    public string Entry { get; set; } = string.Empty;
+
+    public bool HasExternalForeground {
+        get {
+            return !string.IsNullOrWhiteSpace(Entry);
+        }
+    }
+
+    public string ToPolicyReport() {
+        return
+            "category='" + Category + "', " +
+            "abortThreshold=" + AbortThreshold + ", " +
+            "fingerprint='" + Fingerprint + "'";
+    }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionRetryHistoryReport.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionRetryHistoryReport.cs
@@ -1,0 +1,15 @@
+namespace DesktopManager.Tests;
+
+internal sealed class HostedSessionRetryHistoryReport {
+    public static HostedSessionRetryHistoryReport None { get; } = new HostedSessionRetryHistoryReport {
+        CategoryHint = "none",
+        Summary = "No external foreground interruptions were recorded across retries.",
+        ExternalCount = 0,
+        DistinctFingerprintCount = 0
+    };
+
+    public string CategoryHint { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public int ExternalCount { get; set; }
+    public int DistinctFingerprintCount { get; set; }
+}

--- a/Sources/DesktopManager.Tests/HostedSessionTypingTests.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionTypingTests.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Live typing tests for the hosted-session foreground path using the local desktop test app.
+/// </summary>
+public class HostedSessionTypingTests {
+    private const int TextReadTimeoutMilliseconds = 5000;
+    private const int FocusTimeoutMilliseconds = 5000;
+    private const int FocusRetryCount = 3;
+    private const int ForegroundHoldDurationMilliseconds = 4000;
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures hosted-session script typing round-trips a symbol-heavy ASCII payload into the local test app editor.
+    /// </summary>
+    public void HostedSessionTyping_TestAppEditor_RoundTripsAsciiScriptSymbols() {
+        RequireHostedTypingHarness();
+        TestHelper.RequireExternalDesktopApplicationTests();
+
+        using var session = DesktopManagerTestAppSession.Start("hosted-script");
+        var automation = new DesktopAutomationService();
+        string expectedText = BuildShortAsciiScriptText();
+
+        ClearEditor(automation, session);
+        FocusWindow(automation, session);
+
+        RunHostedTypingWithFocusRetry(
+            automation,
+            session,
+            () => ClearEditor(automation, session),
+            () => automation.TypeWindowText(
+                session.CreateWindowQuery(),
+                expectedText,
+                paste: false,
+                delayMilliseconds: 25,
+                foregroundInput: true,
+                physicalKeys: false,
+                hostedSession: true,
+                script: true,
+                scriptChunkLength: 24,
+                scriptLineDelayMilliseconds: 60));
+
+        string actualText = WaitForEditorText(session, expectedText);
+        Assert.AreEqual(expectedText, actualText);
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures hosted-session typing round-trips a broader ASCII symbol matrix that mirrors script punctuation and operator usage.
+    /// </summary>
+    public void HostedSessionTyping_TestAppEditor_RoundTripsAsciiSymbolMatrix() {
+        RequireHostedTypingHarness();
+        TestHelper.RequireExternalDesktopApplicationTests();
+
+        using var session = DesktopManagerTestAppSession.Start("hosted-symbol-matrix");
+        var automation = new DesktopAutomationService();
+        string expectedText = BuildAsciiSymbolMatrixText();
+
+        ClearEditor(automation, session);
+
+        RunHostedTypingWithFocusRetry(
+            automation,
+            session,
+            () => ClearEditor(automation, session),
+            () => automation.TypeWindowText(
+                session.CreateWindowQuery(),
+                expectedText,
+                paste: false,
+                delayMilliseconds: 20,
+                foregroundInput: true,
+                physicalKeys: false,
+                hostedSession: true,
+                script: true,
+                scriptChunkLength: 18,
+                scriptLineDelayMilliseconds: 45));
+
+        string actualText = WaitForEditorText(session, expectedText);
+        Assert.AreEqual(expectedText, actualText);
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures hosted-session typing aborts instead of continuing into another test-owned window after focus changes.
+    /// </summary>
+    public void HostedSessionTyping_TestAppEditor_StopsWhenForegroundChanges() {
+        RequireHostedTypingHarness();
+        TestHelper.RequireExternalDesktopApplicationTests();
+
+        using var session = DesktopManagerTestAppSession.Start("hosted-abort");
+        var automation = new DesktopAutomationService();
+        string longText = BuildLongProbeText();
+
+        ClearEditor(automation, session);
+        FocusWindow(automation, session);
+
+        var focusThread = new Thread(() => {
+            Thread.Sleep(400);
+            session.RequestFocusSecondary();
+        }) {
+            IsBackground = true
+        };
+
+        focusThread.Start();
+        InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() => automation.TypeWindowText(
+            session.CreateWindowQuery(),
+            longText,
+            paste: false,
+            delayMilliseconds: 35,
+            foregroundInput: true,
+            physicalKeys: false,
+            hostedSession: true,
+            script: false,
+            scriptChunkLength: 120,
+            scriptLineDelayMilliseconds: 0));
+        focusThread.Join();
+
+        StringAssert.Contains(exception.Message, "Foreground ownership changed while typing");
+
+        DesktopManagerTestAppStatus postStatus = WaitForStatusWithDiagnostics(
+            session,
+            candidate => candidate.SecondaryWindowHandle != 0 && candidate.SecondaryIsForegroundWindow && string.Equals(candidate.ActiveSurface, "secondary", StringComparison.OrdinalIgnoreCase),
+            FocusTimeoutMilliseconds,
+            "The interactive session did not report the secondary helper window as the new foreground target.");
+
+        string primaryText = postStatus.EditorText;
+        string secondaryText = postStatus.SecondaryText;
+        Assert.IsTrue(primaryText.Length > 0, "Expected the primary editor to receive an initial prefix before focus changed.");
+        Assert.IsTrue(primaryText.Length < longText.Length, "Expected hosted-session typing to stop before the full payload was delivered.");
+        int commonPrefixLength = CountCommonPrefix(longText, primaryText);
+        Assert.IsTrue(commonPrefixLength >= Math.Max(1, primaryText.Length - 1), "Expected the partial primary text to remain an exact prefix aside from at most one in-flight boundary character.");
+        Assert.AreNotEqual(longText, secondaryText, "Expected the full payload to stop instead of continuing into the secondary helper window.");
+        Assert.IsTrue(secondaryText.Length < 4, "Expected focus drift protection to prevent any meaningful suffix from reaching the secondary helper window.");
+    }
+
+    private static void RequireHostedTypingHarness() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows.");
+        }
+
+#if NET472
+        Assert.Inconclusive("Hosted-session live typing tests run only under net8.0-windows to avoid driving the same desktop twice.");
+#elif NET10_0
+        Assert.Inconclusive("Hosted-session live typing tests run only under net8.0-windows to avoid driving the same desktop twice.");
+#endif
+    }
+
+    private static void ClearEditor(DesktopAutomationService automation, DesktopManagerTestAppSession session) {
+        DesktopManagerTestAppStatus status = WaitForStatusWithDiagnostics(
+            session,
+            candidate => candidate.EditorHandle != 0,
+            TextReadTimeoutMilliseconds,
+            "The interactive session did not expose the test app editor handle in time.");
+
+        IReadOnlyList<WindowControlTargetInfo> controls = automation.GetControls(
+            session.CreateWindowQuery(),
+            new WindowControlQueryOptions {
+                Handle = new IntPtr(status.EditorHandle)
+            },
+            allWindows: false,
+            allControls: true);
+        WindowControlTargetInfo editor = controls.FirstOrDefault()
+            ?? throw new AssertInconclusiveException("The interactive session did not resolve the test app editor control by handle.");
+        WindowControlService.SetText(editor.Control, string.Empty);
+        WaitForStatusWithDiagnostics(
+            session,
+            candidate => string.Equals(candidate.EditorText, string.Empty, StringComparison.Ordinal),
+            TextReadTimeoutMilliseconds,
+            "The interactive session did not confirm the test app editor was cleared.");
+    }
+
+    private static void FocusWindow(DesktopAutomationService automation, DesktopManagerTestAppSession session) {
+        session.RequestFocusEditor();
+        try {
+            automation.FocusWindows(session.CreateWindowQuery());
+        } catch (InvalidOperationException) {
+            // The test app will keep retrying focus from inside its own UI thread.
+        }
+
+        WaitForStatusWithDiagnostics(
+            session,
+            candidate => candidate.IsForegroundWindow && string.Equals(candidate.ActiveSurface, "editor", StringComparison.OrdinalIgnoreCase),
+            FocusTimeoutMilliseconds,
+            "The interactive session did not allow the test app editor surface to become the foreground target.");
+    }
+
+    private static string WaitForEditorText(DesktopManagerTestAppSession session, string expectedText) {
+        DesktopManagerTestAppStatus status = WaitForStatusWithDiagnostics(
+            session,
+            candidate => string.Equals(expectedText, candidate.EditorText, StringComparison.Ordinal),
+            TextReadTimeoutMilliseconds,
+            "The interactive session did not report the expected test app editor text in time.");
+        return status.EditorText;
+    }
+
+    private static string BuildLongProbeText() {
+        return string.Concat(
+            "DesktopManager-hosted-session-",
+            "Aa1[]{}|\\\\/-_=+!?",
+            "Bb2[]{}|\\\\/-_=+!?",
+            "Cc3[]{}|\\\\/-_=+!?",
+            "Dd4[]{}|\\\\/-_=+!?",
+            "Ee5[]{}|\\\\/-_=+!?",
+            "Ff6[]{}|\\\\/-_=+!?",
+            "Gg7[]{}|\\\\/-_=+!?",
+            "Hh8[]{}|\\\\/-_=+!?",
+            "Ii9[]{}|\\\\/-_=+!?",
+            "Jj0[]{}|\\\\/-_=+!?");
+    }
+
+    private static string BuildShortAsciiScriptText() {
+        return
+            "function Test-HostedSession {" + Environment.NewLine +
+            "    $symbols = \"[]{}()<>|\\\\@#%&!?+-=*/;:,.\\\"~^_\"" + Environment.NewLine +
+            "}" + Environment.NewLine;
+    }
+
+    private static string BuildAsciiSymbolMatrixText() {
+        return string.Join(
+            Environment.NewLine,
+            new[] {
+                "[]{}()<>",
+                "\\\\ | @ # % &",
+                "! ? + - = * /",
+                "; : , . ' \"",
+                "~ ^ _ `",
+                "path\\\\to\\\\script.ps1",
+                "if ($value -eq \"x\") { $items[0] += 1 }"
+            }) + Environment.NewLine;
+    }
+
+    private static void RunHostedTypingWithFocusRetry(DesktopAutomationService automation, DesktopManagerTestAppSession session, Action prepareAttempt, Action action) {
+        string lastExternalForegroundFingerprint = string.Empty;
+        int repeatedExternalForegroundCount = 0;
+        int repeatedExternalForegroundAbortThreshold = FocusRetryCount;
+        string externalForegroundPolicyReport = "category='none', abortThreshold=" + FocusRetryCount + ", fingerprint=''";
+        var retryReports = new List<HostedSessionExternalForegroundReport>();
+
+        for (int attempt = 1; attempt <= FocusRetryCount; attempt++) {
+            try {
+                prepareAttempt();
+                FocusWindow(automation, session);
+                session.RequestHoldEditorForeground(ForegroundHoldDurationMilliseconds);
+                WaitForStatusWithDiagnostics(
+                    session,
+                    candidate => candidate.ForegroundHoldActive && string.Equals(candidate.ForegroundHoldSurface, "editor", StringComparison.OrdinalIgnoreCase),
+                    FocusTimeoutMilliseconds,
+                    "The interactive session did not enable the temporary editor foreground hold in time.");
+                action();
+                return;
+            } catch (InvalidOperationException exception) when (exception.Message.Contains("Foreground ownership changed while typing", StringComparison.Ordinal)) {
+                string externalForegroundFingerprint = string.Empty;
+                string externalForegroundSummary = string.Empty;
+                string currentPolicyReport = string.Empty;
+                HostedSessionExternalForegroundReport currentReport = HostedSessionExternalForegroundReport.None;
+                TryReadExternalForegroundDiagnostics(
+                    session,
+                    out externalForegroundFingerprint,
+                    out externalForegroundSummary,
+                    out repeatedExternalForegroundAbortThreshold,
+                    out currentPolicyReport,
+                    out currentReport);
+                externalForegroundPolicyReport = currentPolicyReport;
+                if (currentReport.HasExternalForeground) {
+                    retryReports.Add(currentReport);
+                }
+                if (!string.IsNullOrWhiteSpace(externalForegroundFingerprint)) {
+                    if (string.Equals(lastExternalForegroundFingerprint, externalForegroundFingerprint, StringComparison.Ordinal)) {
+                        repeatedExternalForegroundCount++;
+                    } else {
+                        lastExternalForegroundFingerprint = externalForegroundFingerprint;
+                        repeatedExternalForegroundCount = 1;
+                    }
+                } else {
+                    lastExternalForegroundFingerprint = string.Empty;
+                    repeatedExternalForegroundCount = 0;
+                }
+
+                if (repeatedExternalForegroundCount >= repeatedExternalForegroundAbortThreshold) {
+                    HostedSessionRetryHistoryReport retryHistoryReport = HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(retryReports);
+                    EmitStatusSnapshotToTestOutput(
+                        session,
+                        "Hosted-session typing stopped early after repeated external foreground interruptions",
+                        retryHistoryReport,
+                        externalForegroundPolicyReport);
+                    Assert.Inconclusive(
+                        "Repeated external foreground culprit observed across hosted-session retries (threshold " +
+                        repeatedExternalForegroundAbortThreshold +
+                        "): " +
+                        externalForegroundSummary +
+                        Environment.NewLine +
+                        "RetryHistory: " +
+                        retryHistoryReport.Summary +
+                        Environment.NewLine +
+                        "RetryHistoryReport: " +
+                        HostedSessionDiagnosticFormatter.DescribeRetryHistory(retryHistoryReport) +
+                        Environment.NewLine +
+                        "Policy: " +
+                        externalForegroundPolicyReport +
+                        Environment.NewLine +
+                        FormatStatusDiagnostics(session));
+                }
+
+                if (attempt == FocusRetryCount) {
+                    HostedSessionRetryHistoryReport retryHistoryReport = HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(retryReports);
+                    EmitStatusSnapshotToTestOutput(
+                        session,
+                        "Hosted-session typing inconclusive after foreground loss",
+                        retryHistoryReport,
+                        externalForegroundPolicyReport);
+                    Assert.Inconclusive(
+                        "The hosted-session typing harness could not retain foreground focus long enough to prove the round-trip in this desktop session." +
+                        Environment.NewLine +
+                        "RetryHistory: " +
+                        retryHistoryReport.Summary +
+                        Environment.NewLine +
+                        "RetryHistoryReport: " +
+                        HostedSessionDiagnosticFormatter.DescribeRetryHistory(retryHistoryReport) +
+                        Environment.NewLine +
+                        "Policy: " +
+                        externalForegroundPolicyReport +
+                        Environment.NewLine +
+                        FormatStatusDiagnostics(session));
+                }
+
+                Thread.Sleep(250);
+            } finally {
+                session.RequestStopForegroundHold();
+            }
+        }
+    }
+
+    private static void TryReadExternalForegroundDiagnostics(DesktopManagerTestAppSession session, out string fingerprint, out string summary, out int abortThreshold, out string policyReport, out HostedSessionExternalForegroundReport report) {
+        try {
+            DesktopManagerTestAppStatus status = session.ReadStatus();
+            report = HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status);
+            fingerprint = report.Fingerprint;
+            summary = HostedSessionDiagnosticFormatter.Summarize(status);
+            abortThreshold = report.AbortThreshold;
+            policyReport = report.ToPolicyReport();
+        } catch (AssertInconclusiveException) {
+            fingerprint = string.Empty;
+            summary = "Foreground diagnostics unavailable.";
+            abortThreshold = FocusRetryCount;
+            policyReport = "category='unknown', abortThreshold=" + FocusRetryCount + ", fingerprint=''";
+            report = HostedSessionExternalForegroundReport.None;
+        }
+    }
+
+    private static int CountCommonPrefix(string expected, string actual) {
+        int limit = Math.Min(expected.Length, actual.Length);
+        int index = 0;
+        while (index < limit && expected[index] == actual[index]) {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static DesktopManagerTestAppStatus WaitForStatusWithDiagnostics(DesktopManagerTestAppSession session, Func<DesktopManagerTestAppStatus, bool> predicate, int timeoutMilliseconds, string failureMessage) {
+        try {
+            return session.WaitForStatus(predicate, timeoutMilliseconds, failureMessage);
+        } catch (AssertInconclusiveException exception) {
+            EmitStatusSnapshotToTestOutput(session, failureMessage);
+            throw new AssertInconclusiveException(
+                exception.Message +
+                Environment.NewLine +
+                FormatStatusDiagnostics(session));
+        }
+    }
+
+    private static string FormatStatusDiagnostics(DesktopManagerTestAppSession session) {
+        try {
+            DesktopManagerTestAppStatus status = session.ReadStatus();
+            return
+                "Status: " +
+                $"Summary='{HostedSessionDiagnosticFormatter.Summarize(status)}', " +
+                $"PolicyReport='{HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status).ToPolicyReport()}', " +
+                $"ActiveSurface={status.ActiveSurface}, " +
+                $"IsForegroundWindow={status.IsForegroundWindow}, " +
+                $"SecondaryIsForegroundWindow={status.SecondaryIsForegroundWindow}, " +
+                $"ForegroundHoldActive={status.ForegroundHoldActive}, " +
+                $"ForegroundHoldSurface={status.ForegroundHoldSurface}, " +
+                $"ForegroundHoldRequestCount={status.ForegroundHoldRequestCount}, " +
+                $"ForegroundHoldRecoveryCount={status.ForegroundHoldRecoveryCount}, " +
+                $"LastObservedForegroundHandle=0x{status.LastObservedForegroundHandle:X}, " +
+                $"LastObservedForegroundTitle='{status.LastObservedForegroundTitle}', " +
+                $"LastObservedForegroundClass='{status.LastObservedForegroundClass}', " +
+                $"LastObservedForegroundChangedUtc='{status.LastObservedForegroundChangedUtc}', " +
+                $"LastCommand='{status.LastCommand}', " +
+                $"StatusText='{status.StatusText}', " +
+                $"ForegroundHistory=[{string.Join(" | ", status.ForegroundHistory)}].";
+        } catch (AssertInconclusiveException exception) {
+            return "Status diagnostics unavailable: " + exception.Message;
+        }
+    }
+
+    private static void EmitStatusSnapshotToTestOutput(DesktopManagerTestAppSession session, string reason, HostedSessionRetryHistoryReport? retryHistoryReport = null, string? policyReport = null) {
+        try {
+            DesktopManagerTestAppStatus status = session.ReadStatus();
+            HostedSessionExternalForegroundReport report = HostedSessionDiagnosticFormatter.CreateExternalForegroundReport(status);
+            HostedSessionRetryHistoryReport resolvedRetryHistoryReport = retryHistoryReport
+                ?? HostedSessionDiagnosticFormatter.CreateRetryHistoryReport(new[] { report });
+            string resolvedPolicyReport = string.IsNullOrWhiteSpace(policyReport)
+                ? report.ToPolicyReport()
+                : policyReport ?? string.Empty;
+            string summaryText = HostedSessionDiagnosticFormatter.BuildArtifactSummary(
+                reason,
+                status,
+                resolvedRetryHistoryReport,
+                resolvedPolicyReport);
+            string artifactPath = session.WriteStatusArtifact(reason, resolvedRetryHistoryReport, resolvedPolicyReport, summaryText, resolvedRetryHistoryReport.CategoryHint);
+            string summaryArtifactPath = DesktopManagerTestAppSession.GetSummaryArtifactPath(artifactPath, resolvedRetryHistoryReport.CategoryHint);
+            string json = JsonSerializer.Serialize(status, new JsonSerializerOptions {
+                WriteIndented = true
+            });
+            Console.WriteLine("Hosted-session diagnostics: " + reason);
+            Console.WriteLine("Hosted-session summary: " + HostedSessionDiagnosticFormatter.Summarize(status));
+            Console.WriteLine("Hosted-session retry history: " + resolvedRetryHistoryReport.Summary);
+            Console.WriteLine("Hosted-session retry history report: " + HostedSessionDiagnosticFormatter.DescribeRetryHistory(resolvedRetryHistoryReport));
+            Console.WriteLine("Hosted-session diagnostics artifact: " + artifactPath);
+            Console.WriteLine("Hosted-session diagnostics summary artifact: " + summaryArtifactPath);
+            Console.WriteLine(summaryText);
+            Console.WriteLine(json);
+        } catch (AssertInconclusiveException exception) {
+            Console.WriteLine("Hosted-session diagnostics unavailable: " + exception.Message);
+        }
+    }
+}

--- a/Sources/DesktopManager.Tests/KeyboardInputServiceTests.cs
+++ b/Sources/DesktopManager.Tests/KeyboardInputServiceTests.cs
@@ -1,76 +1,130 @@
-using System.Runtime.InteropServices;
-using System.Diagnostics;
-
+#if NET8_0_OR_GREATER
 namespace DesktopManager.Tests;
 
 [TestClass]
 /// <summary>
-/// Tests for <see cref="KeyboardInputService"/>.
+/// Tests for layout-aware keyboard input helpers.
 /// </summary>
 public class KeyboardInputServiceTests {
     [TestMethod]
     /// <summary>
-    /// Test for PressKey_DoesNotThrow.
+    /// Ensures keyboard-layout modifier state maps to Shift, Control, and Alt keys in order.
     /// </summary>
-    public void PressKey_DoesNotThrow() {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Inconclusive("Test requires Windows");
-        }
+    public void GetModifierKeysForKeyboardState_MapsShiftControlAndAlt() {
+        IReadOnlyList<VirtualKey> modifiers = KeyboardInputService.GetModifierKeysForKeyboardState(0b011);
 
-        KeyboardInputService.PressKey(VirtualKey.VK_F24);
+        CollectionAssert.AreEqual(new[] {
+            VirtualKey.VK_SHIFT,
+            VirtualKey.VK_CONTROL
+        }, modifiers.ToArray());
     }
 
     [TestMethod]
     /// <summary>
-    /// Test for PressShortcut_DoesNotThrow.
+    /// Ensures AltGr-style modifier state maps to Shift plus right Alt when required.
     /// </summary>
-    public void PressShortcut_DoesNotThrow() {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Inconclusive("Test requires Windows");
-        }
+    public void GetModifierKeysForKeyboardState_MapsShiftAndAltGr() {
+        IReadOnlyList<VirtualKey> modifiers = KeyboardInputService.GetModifierKeysForKeyboardState(0b111);
 
-        KeyboardInputService.PressShortcut(0, VirtualKey.VK_F23, VirtualKey.VK_F24);
+        CollectionAssert.AreEqual(new[] {
+            VirtualKey.VK_SHIFT,
+            VirtualKey.VK_RMENU
+        }, modifiers.ToArray());
     }
 
     [TestMethod]
     /// <summary>
-    /// Test that delay is honored when pressing shortcuts.
+    /// Ensures packed VkKeyScan results map to a key plus modifiers.
     /// </summary>
-    public void PressShortcut_HonorsDelay() {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Inconclusive("Test requires Windows");
-        }
+    public void TryCreateKeyboardLayoutStroke_MapsKeyAndModifiers() {
+        bool mapped = KeyboardInputService.TryCreateKeyboardLayoutStroke(unchecked((short)0x0141), out KeyboardInputService.KeyboardLayoutStroke stroke);
 
-        const int delay = 200;
-        Stopwatch sw = Stopwatch.StartNew();
-        KeyboardInputService.PressShortcut(delay, VirtualKey.VK_F23, VirtualKey.VK_F24);
-        sw.Stop();
-
-        long expected = delay * 4; // 2 keys => 4 events
-        Assert.IsTrue(sw.ElapsedMilliseconds >= expected, $"Delay not honored. Expected >= {expected}, got {sw.ElapsedMilliseconds}");
+        Assert.IsTrue(mapped);
+        Assert.AreEqual(VirtualKey.VK_A, stroke.Key);
+        CollectionAssert.AreEqual(new[] { VirtualKey.VK_SHIFT }, stroke.Modifiers.ToArray());
     }
 
     [TestMethod]
     /// <summary>
-    /// Test for KeyDown_DoesNotThrow.
+    /// Ensures packed AltGr-style VkKeyScan results map to Control plus Alt modifiers.
     /// </summary>
-    public void KeyDown_DoesNotThrow() {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Inconclusive("Test requires Windows");
-        }
+    public void TryCreateKeyboardLayoutStroke_MapsAltGrStyleModifierState() {
+        bool mapped = KeyboardInputService.TryCreateKeyboardLayoutStroke(unchecked((short)0x0645), out KeyboardInputService.KeyboardLayoutStroke stroke);
 
-        KeyboardInputService.KeyDown(VirtualKey.VK_F24);
+        Assert.IsTrue(mapped);
+        Assert.AreEqual(VirtualKey.VK_E, stroke.Key);
+        CollectionAssert.AreEqual(new[] { VirtualKey.VK_RMENU }, stroke.Modifiers.ToArray());
     }
 
     [TestMethod]
     /// <summary>
-    /// Test for KeyUp_DoesNotThrow.
+    /// Ensures unsupported VkKeyScan results are rejected cleanly.
     /// </summary>
-    public void KeyUp_DoesNotThrow() {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            Assert.Inconclusive("Test requires Windows");
-        }
+    public void TryCreateKeyboardLayoutStroke_UnsupportedCharacter_ReturnsFalse() {
+        bool mapped = KeyboardInputService.TryCreateKeyboardLayoutStroke(-1, out KeyboardInputService.KeyboardLayoutStroke stroke);
 
-        KeyboardInputService.KeyUp(VirtualKey.VK_F24);
+        Assert.IsFalse(mapped);
+        Assert.AreEqual(default, stroke);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures hosted-session US scancode mapping keeps braces on the bracket keys instead of the local-layout symbol path.
+    /// </summary>
+    public void TryCreateUsKeyboardScanCodeStroke_MapsBracesToBracketScanCodes() {
+        bool openMapped = KeyboardInputService.TryCreateUsKeyboardScanCodeStroke('{', out KeyboardInputService.ScanCodeStroke openStroke);
+        bool closeMapped = KeyboardInputService.TryCreateUsKeyboardScanCodeStroke('}', out KeyboardInputService.ScanCodeStroke closeStroke);
+
+        Assert.IsTrue(openMapped);
+        Assert.IsTrue(closeMapped);
+        Assert.AreEqual((ushort)0x1A, openStroke.ScanCode);
+        Assert.IsTrue(openStroke.ShiftRequired);
+        Assert.AreEqual((ushort)0x1B, closeStroke.ScanCode);
+        Assert.IsTrue(closeStroke.ShiftRequired);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures hosted-session US scancode mapping keeps letters on their physical key positions.
+    /// </summary>
+    public void TryCreateUsKeyboardScanCodeStroke_MapsLettersAndCase() {
+        bool lowerMapped = KeyboardInputService.TryCreateUsKeyboardScanCodeStroke('a', out KeyboardInputService.ScanCodeStroke lowerStroke);
+        bool upperMapped = KeyboardInputService.TryCreateUsKeyboardScanCodeStroke('A', out KeyboardInputService.ScanCodeStroke upperStroke);
+
+        Assert.IsTrue(lowerMapped);
+        Assert.IsTrue(upperMapped);
+        Assert.AreEqual(lowerStroke.ScanCode, upperStroke.ScanCode);
+        Assert.IsFalse(lowerStroke.ShiftRequired);
+        Assert.IsTrue(upperStroke.ShiftRequired);
+    }
+
+    [DataTestMethod]
+    [DataRow('[', (ushort)0x1A, false)]
+    [DataRow('{', (ushort)0x1A, true)]
+    [DataRow(']', (ushort)0x1B, false)]
+    [DataRow('}', (ushort)0x1B, true)]
+    [DataRow('\\', (ushort)0x2B, false)]
+    [DataRow('|', (ushort)0x2B, true)]
+    [DataRow('/', (ushort)0x35, false)]
+    [DataRow('?', (ushort)0x35, true)]
+    [DataRow('@', (ushort)0x03, true)]
+    [DataRow('_', (ushort)0x0C, true)]
+    [DataRow('+', (ushort)0x0D, true)]
+    [DataRow(':', (ushort)0x27, true)]
+    [DataRow('"', (ushort)0x28, true)]
+    [DataRow('<', (ushort)0x33, true)]
+    [DataRow('>', (ushort)0x34, true)]
+    [DataRow('~', (ushort)0x29, true)]
+    [DataRow('^', (ushort)0x07, true)]
+    /// <summary>
+    /// Ensures hosted-session US scancode mapping stays stable for script-heavy ASCII symbols.
+    /// </summary>
+    public void TryCreateUsKeyboardScanCodeStroke_MapsScriptHeavyAsciiSymbols(char character, ushort expectedScanCode, bool expectedShiftRequired) {
+        bool mapped = KeyboardInputService.TryCreateUsKeyboardScanCodeStroke(character, out KeyboardInputService.ScanCodeStroke stroke);
+
+        Assert.IsTrue(mapped, $"Expected a US scancode mapping for '{character}'.");
+        Assert.AreEqual(expectedScanCode, stroke.ScanCode);
+        Assert.AreEqual(expectedShiftRequired, stroke.ShiftRequired);
     }
 }
+#endif

--- a/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
+++ b/Sources/DesktopManager.Tests/LogonWallpaperTests.cs
@@ -20,7 +20,7 @@ public class LogonWallpaperTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         if (Type.GetType("Windows.System.UserProfile.LockScreen, Windows, ContentType=WindowsRuntime") == null ||
             Type.GetType("Windows.Storage.StorageFile, Windows, ContentType=WindowsRuntime") == null) {
@@ -46,7 +46,7 @@ public class LogonWallpaperTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         if (PrivilegeChecker.IsElevated) {
             Assert.Inconclusive("Test requires non-elevated context");

--- a/Sources/DesktopManager.Tests/McpServerTests.cs
+++ b/Sources/DesktopManager.Tests/McpServerTests.cs
@@ -507,6 +507,8 @@ public class McpServerTests {
         Assert.IsTrue(properties.TryGetProperty("captureBefore", out _));
         Assert.IsTrue(properties.TryGetProperty("captureAfter", out _));
         Assert.IsTrue(properties.TryGetProperty("artifactDirectory", out _));
+        Assert.IsTrue(properties.TryGetProperty("verifyAfter", out _));
+        Assert.IsTrue(properties.TryGetProperty("verificationTolerancePixels", out _));
     }
 
     private static void AssertToolHasProperty(JsonElement tool, string propertyName) {

--- a/Sources/DesktopManager.Tests/MonitorBrightnessTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorBrightnessTests.cs
@@ -16,7 +16,7 @@ public class MonitorBrightnessTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var monitors = new Monitors().GetMonitorsConnected();
         if (monitors.Count == 0) {

--- a/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorFallbackTests.cs
@@ -103,7 +103,7 @@ public class MonitorFallbackTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var service = new MonitorService(new FailingDesktopManager());
         var monitors = service.GetMonitorsConnected();
@@ -131,7 +131,7 @@ public class MonitorFallbackTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var service = new MonitorService(new FailingDesktopManager());
         var original = service.GetWallpaperPosition();
@@ -153,7 +153,7 @@ public class MonitorFallbackTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var service = new MonitorService(new FailingDesktopManager());
         uint original = service.GetBackgroundColor();

--- a/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorResolutionOrientationTests.cs
@@ -16,7 +16,7 @@ public class MonitorResolutionOrientationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireSystemDesktopChanges();
 
         var monitors = new Monitors().GetMonitorsConnected();
         if (monitors.Count == 0) {

--- a/Sources/DesktopManager.Tests/PowerShellWindowMutationTests.cs
+++ b/Sources/DesktopManager.Tests/PowerShellWindowMutationTests.cs
@@ -1,0 +1,115 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for PowerShell window mutation verification records and cmdlet defaults.
+/// </summary>
+public class PowerShellWindowMutationTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures PowerShell failure records distinguish verification failures from plain mutation failures.
+    /// </summary>
+    public void CreateFailureRecord_MapsVerificationState() {
+        var requestedWindow = new WindowInfo {
+            Title = "Editor",
+            Handle = new IntPtr(0x1234),
+            ProcessId = 42
+        };
+
+        global::DesktopManager.PowerShell.DesktopWindowMutationRecord verifiedFailure =
+            global::DesktopManager.PowerShell.DesktopWindowMutationVerifier.CreateFailureRecord(
+                "move",
+                requestedWindow,
+                "Verification mismatch.",
+                verificationPerformed: true,
+                tolerancePixels: 12);
+        global::DesktopManager.PowerShell.DesktopWindowMutationRecord plainFailure =
+            global::DesktopManager.PowerShell.DesktopWindowMutationVerifier.CreateFailureRecord(
+                "move",
+                requestedWindow,
+                "Mutation call failed.",
+                verificationPerformed: false,
+                tolerancePixels: 12);
+
+        Assert.IsFalse(verifiedFailure.Success);
+        Assert.IsTrue(verifiedFailure.VerificationPerformed);
+        Assert.AreEqual(false, verifiedFailure.Verified);
+        Assert.AreEqual("error", verifiedFailure.VerificationMode);
+        Assert.AreEqual(12, verifiedFailure.VerificationTolerancePixels);
+        Assert.AreEqual("Editor", verifiedFailure.RequestedWindow.Title);
+
+        Assert.IsFalse(plainFailure.Success);
+        Assert.IsFalse(plainFailure.VerificationPerformed);
+        Assert.IsNull(plainFailure.Verified);
+        Assert.AreEqual(string.Empty, plainFailure.VerificationMode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures PowerShell mutation records preserve observed and active window evidence for operator feedback.
+    /// </summary>
+    public void DesktopWindowMutationRecord_StoresObservedEvidence() {
+        var requestedWindow = new WindowInfo {
+            Title = "Editor",
+            Handle = new IntPtr(0x1234),
+            ProcessId = 42
+        };
+        var observedWindow = new WindowInfo {
+            Title = "Editor",
+            Handle = new IntPtr(0x1234),
+            ProcessId = 42
+        };
+        var activeWindow = new WindowInfo {
+            Title = "Editor",
+            Handle = new IntPtr(0x1234),
+            ProcessId = 42
+        };
+
+        var record = new global::DesktopManager.PowerShell.DesktopWindowMutationRecord {
+            Action = "move",
+            Success = true,
+            VerificationPerformed = true,
+            Verified = true,
+            VerificationMode = "geometry",
+            VerificationSummary = "Observed the requested postcondition after 'move'.",
+            VerificationTolerancePixels = 10,
+            RequestedWindow = requestedWindow,
+            ObservedWindow = observedWindow,
+            ActiveWindow = activeWindow,
+            VerificationNotes = new[] { "Window geometry matched." }
+        };
+
+        Assert.AreEqual("move", record.Action);
+        Assert.AreEqual(true, record.Verified);
+        Assert.AreEqual("geometry", record.VerificationMode);
+        Assert.AreEqual("Editor", record.RequestedWindow.Title);
+        Assert.AreEqual("Editor", record.ObservedWindow.Title);
+        Assert.AreEqual("Editor", record.ActiveWindow.Title);
+        Assert.AreEqual(1, record.VerificationNotes.Count);
+    }
+
+    [DataTestMethod]
+    [DataRow("CmdletInvokeDesktopWindowClick")]
+    [DataRow("CmdletInvokeDesktopWindowDrag")]
+    [DataRow("CmdletInvokeDesktopWindowScroll")]
+    /// <summary>
+    /// Ensures the pointer-style PowerShell cmdlets expose the shared verification and pass-through options.
+    /// </summary>
+    public void PointerWindowCmdlets_ExposeSharedVerificationParameters(string typeName) {
+        Type? cmdletType = Type.GetType($"DesktopManager.PowerShell.{typeName}, DesktopManager.PowerShell", throwOnError: true);
+        Assert.IsNotNull(cmdletType);
+
+        object? instance = Activator.CreateInstance(cmdletType);
+        System.Reflection.PropertyInfo? verifyProperty = cmdletType.GetProperty("Verify");
+        System.Reflection.PropertyInfo? toleranceProperty = cmdletType.GetProperty("VerificationTolerancePixels");
+        System.Reflection.PropertyInfo? passThruProperty = cmdletType.GetProperty("PassThru");
+
+        Assert.IsNotNull(instance);
+        Assert.IsNotNull(verifyProperty);
+        Assert.IsNotNull(toleranceProperty);
+        Assert.IsNotNull(passThruProperty);
+        Assert.AreEqual(10, toleranceProperty.GetValue(instance));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/TestHelper.cs
+++ b/Sources/DesktopManager.Tests/TestHelper.cs
@@ -131,6 +131,38 @@ internal static class TestHelper {
     }
 
     /// <summary>
+    /// Determines if system-wide desktop state tests should be skipped.
+    /// </summary>
+    public static bool ShouldSkipSystemDesktopChangeTests() {
+        if (ShouldSkipDesktopChangeTests()) {
+            return true;
+        }
+
+        if (Environment.GetEnvironmentVariable("RUN_SYSTEM_UI_TESTS") == "true" ||
+            Environment.GetEnvironmentVariable("DESKTOPMANAGER_RUN_SYSTEM_UI_TESTS") == "true") {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines if foreground-window UI tests should be skipped.
+    /// </summary>
+    public static bool ShouldSkipForegroundWindowUiTests() {
+        if (ShouldSkipDesktopChangeTests()) {
+            return true;
+        }
+
+        if (Environment.GetEnvironmentVariable("RUN_FOREGROUND_UI_TESTS") == "true" ||
+            Environment.GetEnvironmentVariable("DESKTOPMANAGER_RUN_FOREGROUND_UI_TESTS") == "true") {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Determines if tests that launch live external desktop applications should be skipped.
     /// </summary>
     public static bool ShouldSkipExternalApplicationUiTests() {
@@ -198,6 +230,26 @@ internal static class TestHelper {
         RequireInteractive();
         if (ShouldSkipDesktopChangeTests()) {
             Assert.Inconclusive("Desktop-changing UI tests skipped. Set RUN_DESTRUCTIVE_UI_TESTS=true (or DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true) to run.");
+        }
+    }
+
+    /// <summary>
+    /// Skips system-wide desktop-changing tests unless explicitly enabled.
+    /// </summary>
+    public static void RequireSystemDesktopChanges() {
+        RequireDesktopChanges();
+        if (ShouldSkipSystemDesktopChangeTests()) {
+            Assert.Inconclusive("System-wide desktop-changing tests skipped. Set RUN_SYSTEM_UI_TESTS=true (or DESKTOPMANAGER_RUN_SYSTEM_UI_TESTS=true) to run.");
+        }
+    }
+
+    /// <summary>
+    /// Skips tests that intentionally steal foreground focus unless explicitly enabled.
+    /// </summary>
+    public static void RequireForegroundWindowUiTests() {
+        RequireDesktopChanges();
+        if (ShouldSkipForegroundWindowUiTests()) {
+            Assert.Inconclusive("Foreground-window UI tests skipped. Set RUN_FOREGROUND_UI_TESTS=true (or DESKTOPMANAGER_RUN_FOREGROUND_UI_TESTS=true) to run.");
         }
     }
 

--- a/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
+++ b/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
@@ -18,7 +18,7 @@ public class WindowActivationPositioningTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position Harness");
 

--- a/Sources/DesktopManager.Tests/WindowAndTargetCriteriaTests.cs
+++ b/Sources/DesktopManager.Tests/WindowAndTargetCriteriaTests.cs
@@ -66,6 +66,26 @@ public class WindowAndTargetCriteriaTests {
 
     [TestMethod]
     /// <summary>
+    /// Ensures window mutation artifact options map verification flags and treat tolerance as an implicit verification request.
+    /// </summary>
+    public void WindowCreateArtifactOptions_MapsVerificationFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "move",
+            "--verify-tolerance-px", "14",
+            "--capture-after"
+        });
+
+        global::DesktopManager.Cli.MutationArtifactOptions? options = global::DesktopManager.Cli.WindowCommands.CreateArtifactOptions(arguments);
+
+        Assert.IsNotNull(options);
+        Assert.IsTrue(options.CaptureAfter);
+        Assert.IsTrue(options.VerifyAfter);
+        Assert.AreEqual(14, options.VerificationTolerancePixels);
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Ensures target command criteria use include-empty by default for resolve scenarios and honor selector flags.
     /// </summary>
     public void TargetCreateCriteria_MapsFlagsAndUsesResolveDefault() {

--- a/Sources/DesktopManager.Tests/WindowCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/WindowCommandOutputTests.cs
@@ -28,6 +28,21 @@ public class WindowCommandOutputTests {
                 new global::DesktopManager.Cli.ScreenshotResult(),
                 new global::DesktopManager.Cli.ScreenshotResult()
             },
+            Verification = new global::DesktopManager.Cli.WindowMutationVerificationResult {
+                Verified = true,
+                Mode = "geometry",
+                Summary = "Observed both windows at the requested post-mutation geometry.",
+                ExpectedCount = 2,
+                ObservedCount = 2,
+                MatchedCount = 2,
+                MismatchCount = 0,
+                TolerancePixels = 10,
+                ActiveWindow = new global::DesktopManager.Cli.WindowResult {
+                    Title = "Editor",
+                    ProcessId = 100
+                },
+                Notes = new[] { "Editor geometry matched within tolerance." }
+            },
             ArtifactWarnings = new[] { "Capture path normalized." },
             Windows = new[] {
                 new global::DesktopManager.Cli.WindowResult {
@@ -49,6 +64,10 @@ public class WindowCommandOutputTests {
         Assert.AreEqual(0, exitCode);
         StringAssert.Contains(output, "move-window: 2 window(s) success=True safety=background elapsed-ms=145");
         StringAssert.Contains(output, "target: window-target EditorCenter");
+        StringAssert.Contains(output, "verification: verified=True mode=geometry observed=2/2 matched=2 mismatches=0 tolerance-px=10");
+        StringAssert.Contains(output, "verification-summary: Observed both windows at the requested post-mutation geometry.");
+        StringAssert.Contains(output, "verification-active: Editor [PID 100]");
+        StringAssert.Contains(output, "verification-note: Editor geometry matched within tolerance.");
         StringAssert.Contains(output, "artifacts: before=1 after=2");
         StringAssert.Contains(output, "warning: Capture path normalized.");
         StringAssert.Contains(output, "- Editor [PID 100]");

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -19,7 +19,7 @@ public class WindowLayoutTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         string title = $"Layout Harness {System.Guid.NewGuid():N}";
         var fullLayoutPath = System.IO.Path.GetTempFileName();

--- a/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
@@ -26,59 +26,25 @@ public class WindowManagerFilterTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
+        TestHelper.RequireOwnedWindowUiTests();
+
+        string title = $"ProcessName Filter Harness {Guid.NewGuid():N}";
+        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create(title);
+        using var process = Process.GetCurrentProcess();
 
         var manager = new WindowManager();
-        var windows = manager.GetWindows(includeHidden: true);
-        if (windows.Count == 0) {
-            Assert.Inconclusive("No windows found to test");
-        }
+        var filtered = manager.GetWindows(processName: process.ProcessName, includeHidden: true);
 
-        // Find a window from a standard process like explorer or Windows system processes
-        var window = windows.FirstOrDefault(w => {
+        Assert.IsTrue(filtered.Any(w => w.Handle == harness.Window.Handle),
+            $"Expected to find harness window {harness.Window.Handle:X8} for process '{process.ProcessName}'.");
+
+        foreach (var window in filtered.Take(5)) {
             try {
-                var proc = Process.GetProcessById((int)w.ProcessId);
-                return proc.ProcessName.ToLower().Contains("explorer") || 
-                       proc.ProcessName.ToLower().Contains("dwm") ||
-                       proc.ProcessName.ToLower().Contains("winlogon");
+                using Process matchingProcess = Process.GetProcessById((int)window.ProcessId);
+                Assert.AreEqual(process.ProcessName, matchingProcess.ProcessName,
+                    $"Window {window.Handle:X8} has process '{matchingProcess.ProcessName}' but filter was for '{process.ProcessName}'.");
             } catch {
-                return false;
-            }
-        });
-        
-        if (window == null) {
-            // Fall back to any window we can get process info for
-            window = windows.FirstOrDefault(w => {
-                try {
-                    Process.GetProcessById((int)w.ProcessId);
-                    return true;
-                } catch {
-                    return false;
-                }
-            });
-        }
-        
-        if (window == null) {
-            Assert.Inconclusive("No windows with accessible process information found");
-        }
-        
-        var proc = Process.GetProcessById((int)window.ProcessId);
-        var processName = proc.ProcessName;
-        
-        var filtered = manager.GetWindows(processName: processName, includeHidden: true);
-        
-        // Instead of checking for the exact same window (which might disappear due to timing),
-        // verify that at least one window with the expected process name is found
-        Assert.IsTrue(filtered.Count > 0, 
-            $"Expected to find at least one window with process name '{processName}', but found {filtered.Count}");
-            
-        // Verify that all returned windows actually have the correct process name
-        foreach (var w in filtered.Take(3)) { // Check first few to avoid performance issues
-            try {
-                var p = Process.GetProcessById((int)w.ProcessId);
-                Assert.AreEqual(processName, p.ProcessName, 
-                    $"Window {w.Handle:X8} has process '{p.ProcessName}' but filter was for '{processName}'");
-            } catch {
-                // Process might have exited, skip verification for this window
+                // Process might have exited, skip verification for this window.
             }
         }
     }
@@ -218,19 +184,31 @@ public class WindowManagerFilterTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
+        TestHelper.RequireForegroundWindowUiTests();
+
+        using WinFormsWindowHarness firstHarness = WinFormsWindowHarness.Create($"Foreground Harness 1 {Guid.NewGuid():N}");
+        using WinFormsWindowHarness secondHarness = WinFormsWindowHarness.Create($"Foreground Harness 2 {Guid.NewGuid():N}");
+
+        var manager = new WindowManager();
+        manager.ActivateWindow(secondHarness.Window);
+        Application.DoEvents();
+        System.Threading.Thread.Sleep(100);
+        manager.ActivateWindow(firstHarness.Window);
+        Application.DoEvents();
+        System.Threading.Thread.Sleep(100);
 
         IntPtr foreground = MonitorNativeMethods.GetForegroundWindow();
         if (foreground == IntPtr.Zero) {
             Assert.Inconclusive("No foreground window found to test");
         }
 
-        var manager = new WindowManager();
         WindowInfo? window = manager.GetActiveWindow();
         if (window == null) {
             Assert.Inconclusive("The active window could not be resolved from enumeration");
         }
 
-        Assert.AreEqual(foreground, window.Handle, "Expected GetActiveWindow to resolve the current foreground window.");
+        Assert.AreEqual(firstHarness.Window.Handle, foreground, "Expected the owned harness window to be foreground.");
+        Assert.AreEqual(foreground, window.Handle, "Expected GetActiveWindow to resolve the owned foreground harness window.");
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/WindowMutationVerificationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowMutationVerificationTests.cs
@@ -1,0 +1,174 @@
+#if NET8_0_OR_GREATER
+using System;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for window mutation verification helpers.
+/// </summary>
+public class WindowMutationVerificationTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures move verification reports a successful geometry match within the requested tolerance.
+    /// </summary>
+    public void BuildWindowPostconditionVerificationResult_VerifiesRequestedGeometry() {
+        var expected = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 0,
+                Top = 0,
+                Right = 800,
+                Bottom = 600,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+        var observed = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 6,
+                Top = 4,
+                Right = 806,
+                Bottom = 604,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+
+        global::DesktopManager.Cli.WindowMutationVerificationResult verification = global::DesktopManager.Cli.DesktopOperations.BuildWindowPostconditionVerificationResult(
+            "move",
+            expected,
+            observed,
+            activeWindow: null,
+            tolerancePixels: 10,
+            monitorIndex: 1,
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 600);
+
+        Assert.IsTrue(verification.Verified);
+        Assert.AreEqual("geometry", verification.Mode);
+        Assert.AreEqual(1, verification.ExpectedCount);
+        Assert.AreEqual(1, verification.ObservedCount);
+        Assert.AreEqual(1, verification.MatchedCount);
+        Assert.AreEqual(0, verification.MismatchCount);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures focus verification fails when a different window owns the foreground after the action.
+    /// </summary>
+    public void BuildWindowPostconditionVerificationResult_FailsWhenForegroundDoesNotMatch() {
+        var expected = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 0,
+                Top = 0,
+                Right = 800,
+                Bottom = 600,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+        var observed = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 0,
+                Top = 0,
+                Right = 800,
+                Bottom = 600,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+        var activeWindow = new WindowInfo {
+            Title = "Browser",
+            Handle = new IntPtr(0x2002),
+            ProcessId = 11,
+            ThreadId = 2,
+            Left = 0,
+            Top = 0,
+            Right = 900,
+            Bottom = 700,
+            MonitorIndex = 1,
+            State = WindowState.Normal
+        };
+
+        global::DesktopManager.Cli.WindowMutationVerificationResult verification = global::DesktopManager.Cli.DesktopOperations.BuildWindowPostconditionVerificationResult(
+            "focus",
+            expected,
+            observed,
+            activeWindow,
+            tolerancePixels: 10,
+            requireForegroundMatch: true);
+
+        Assert.IsFalse(verification.Verified);
+        Assert.AreEqual("foreground", verification.Mode);
+        Assert.AreEqual(0, verification.MatchedCount);
+        Assert.AreEqual(1, verification.MismatchCount);
+        Assert.IsTrue(verification.Notes.Count > 0);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures minimize verification checks the reported window state instead of only the presence of the window.
+    /// </summary>
+    public void BuildWindowPostconditionVerificationResult_FailsWhenMinimizeStateDidNotStick() {
+        var expected = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 0,
+                Top = 0,
+                Right = 800,
+                Bottom = 600,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+        var observed = new[] {
+            new WindowInfo {
+                Title = "Editor",
+                Handle = new IntPtr(0x1001),
+                ProcessId = 10,
+                ThreadId = 1,
+                Left = 0,
+                Top = 0,
+                Right = 800,
+                Bottom = 600,
+                MonitorIndex = 1,
+                State = WindowState.Normal
+            }
+        };
+
+        global::DesktopManager.Cli.WindowMutationVerificationResult verification = global::DesktopManager.Cli.DesktopOperations.BuildWindowPostconditionVerificationResult(
+            "minimize",
+            expected,
+            observed,
+            activeWindow: null,
+            tolerancePixels: 10);
+
+        Assert.IsFalse(verification.Verified);
+        Assert.AreEqual("window-state", verification.Mode);
+        Assert.AreEqual(0, verification.MatchedCount);
+        Assert.AreEqual(1, verification.MismatchCount);
+        StringAssert.Contains(verification.Summary, "Minimize");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -18,7 +18,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position RoundTrip Harness");
 
@@ -41,7 +41,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager ZOrder Harness");
 
@@ -81,7 +81,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Same Monitor Harness");
 
@@ -105,7 +105,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         var monitors = new Monitors().GetMonitors();
         if (monitors.Count < 2) {

--- a/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
@@ -16,7 +16,7 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager State Harness");
 
@@ -40,7 +40,7 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager OnScreen Harness");
 

--- a/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
@@ -39,7 +39,7 @@ public class WindowStyleModificationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Style Harness");
 

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -19,7 +19,7 @@ public class WindowTopMostActivationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireForegroundWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager TopMost Harness");
 
@@ -57,40 +57,30 @@ public class WindowTopMostActivationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         var manager = new WindowManager();
-        var originalForeground = MonitorNativeMethods.GetForegroundWindow();
-        if (originalForeground == IntPtr.Zero) {
-            Assert.Inconclusive("No foreground window found for activation testing");
-            return;
-        }
+        using WinFormsWindowHarness firstHarness = WinFormsWindowHarness.Create("DesktopManager Activation Harness 1");
+        using WinFormsWindowHarness secondHarness = WinFormsWindowHarness.Create("DesktopManager Activation Harness 2");
 
-        var windows = manager.GetWindows(includeHidden: true);
-        var window = windows.FirstOrDefault(w => w.Handle == originalForeground);
-        if (window == null) {
-            Assert.Inconclusive("Foreground window was not found in enumeration");
-            return;
-        }
-        
         try {
-            // Attempt activation on the current foreground window to avoid focus changes
-            manager.ActivateWindow(window);
-
-            // Give Windows time to process the activation
+            manager.ActivateWindow(secondHarness.Window);
+            Application.DoEvents();
             Thread.Sleep(100);
 
-            var newForeground = MonitorNativeMethods.GetForegroundWindow();
+            manager.ActivateWindow(firstHarness.Window);
+            Application.DoEvents();
+            Thread.Sleep(100);
+
+            IntPtr newForeground = MonitorNativeMethods.GetForegroundWindow();
             if (newForeground == IntPtr.Zero) {
-                Assert.Inconclusive($"GetForegroundWindow returned 0 after activation attempt. Original: {originalForeground:X8}");
+                Assert.Inconclusive("GetForegroundWindow returned 0 after activation attempt.");
             }
 
-            if (newForeground != originalForeground) {
-                Assert.Inconclusive($"Foreground window changed unexpectedly. Original: {originalForeground:X8}, Current: {newForeground:X8}");
-            }
+            Assert.AreEqual(firstHarness.Window.Handle, newForeground,
+                $"Expected the owned harness window to become foreground. Expected: {firstHarness.Window.Handle:X8}, Actual: {newForeground:X8}");
         } catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to activate window")) {
-            // SetForegroundWindow failed - this is common due to Windows security restrictions
-            Assert.Inconclusive($"Window activation failed due to Windows security policies. Target window: Handle={window.Handle:X8}. This is expected behavior in many Windows configurations due to User Interface Privilege Isolation (UIPI) or other focus management policies.");
+            Assert.Inconclusive($"Window activation failed due to Windows security policies. Target window: Handle={firstHarness.Window.Handle:X8}. This is expected behavior in many Windows configurations due to User Interface Privilege Isolation (UIPI) or other focus management policies.");
         }
     }
 }

--- a/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
@@ -17,7 +17,7 @@ public class WindowTransparencyTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Transparency Harness");
 

--- a/Sources/DesktopManager.Tests/WindowTypeCommandOptionsTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTypeCommandOptionsTests.cs
@@ -1,0 +1,125 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI window typing option mapping.
+/// </summary>
+public class WindowTypeCommandOptionsTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures window type options map explicit foreground-input and delay flags.
+    /// </summary>
+    public void CreateTypeOptions_MapsForegroundTypingFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "type",
+            "--text", "safe probe",
+            "--foreground-input",
+            "--delay-ms", "25"
+        });
+
+        global::DesktopManager.Cli.WindowTextCommandOptions options = global::DesktopManager.Cli.WindowCommands.CreateTypeOptions(arguments);
+
+        Assert.AreEqual("safe probe", options.Text);
+        Assert.IsFalse(options.Paste);
+        Assert.IsTrue(options.ForegroundInput);
+        Assert.IsFalse(options.PhysicalKeys);
+        Assert.AreEqual(25, options.DelayMilliseconds);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures physical-key typing implies the strict foreground-input path.
+    /// </summary>
+    public void CreateTypeOptions_PhysicalKeys_EnablesForegroundInputToo() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "type",
+            "--text", "safe probe",
+            "--physical-keys"
+        });
+
+        global::DesktopManager.Cli.WindowTextCommandOptions options = global::DesktopManager.Cli.WindowCommands.CreateTypeOptions(arguments);
+
+        Assert.AreEqual("safe probe", options.Text);
+        Assert.IsFalse(options.Paste);
+        Assert.IsTrue(options.ForegroundInput);
+        Assert.IsTrue(options.PhysicalKeys);
+        Assert.AreEqual(0, options.DelayMilliseconds);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures script typing maps chunking and line pacing options without forcing a different delivery mode.
+    /// </summary>
+    public void CreateTypeOptions_MapsScriptFlags() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "type",
+            "--text", "line1\nline2",
+            "--script",
+            "--chunk-size", "32",
+            "--line-delay-ms", "15"
+        });
+
+        global::DesktopManager.Cli.WindowTextCommandOptions options = global::DesktopManager.Cli.WindowCommands.CreateTypeOptions(arguments);
+
+        Assert.AreEqual("line1\nline2", options.Text);
+        Assert.IsFalse(options.Paste);
+        Assert.IsFalse(options.ForegroundInput);
+        Assert.IsFalse(options.PhysicalKeys);
+        Assert.IsTrue(options.ScriptMode);
+        Assert.AreEqual(32, options.ScriptChunkLength);
+        Assert.AreEqual(15, options.ScriptLineDelayMilliseconds);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures hosted-session typing enables the physical foreground path and uses safer pacing defaults.
+    /// </summary>
+    public void CreateTypeOptions_HostedSession_UsesSaferForegroundDefaults() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "type",
+            "--text", "safe probe",
+            "--hosted-session",
+            "--script"
+        });
+
+        global::DesktopManager.Cli.WindowTextCommandOptions options = global::DesktopManager.Cli.WindowCommands.CreateTypeOptions(arguments);
+
+        Assert.AreEqual("safe probe", options.Text);
+        Assert.IsTrue(options.ForegroundInput);
+        Assert.IsFalse(options.PhysicalKeys);
+        Assert.IsTrue(options.HostedSession);
+        Assert.IsTrue(options.ScriptMode);
+        Assert.AreEqual(35, options.DelayMilliseconds);
+        Assert.AreEqual(120, options.ScriptLineDelayMilliseconds);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures window type options default to simulated typing without strict foreground requirements.
+    /// </summary>
+    public void CreateTypeOptions_UsesDefaultsWhenUnset() {
+        global::DesktopManager.Cli.CommandLineArguments arguments = global::DesktopManager.Cli.CommandLineArguments.Parse(new[] {
+            "window",
+            "type",
+            "--text", "hello"
+        });
+
+        global::DesktopManager.Cli.WindowTextCommandOptions options = global::DesktopManager.Cli.WindowCommands.CreateTypeOptions(arguments);
+
+        Assert.AreEqual("hello", options.Text);
+        Assert.IsFalse(options.Paste);
+        Assert.IsFalse(options.ForegroundInput);
+        Assert.IsFalse(options.PhysicalKeys);
+        Assert.IsFalse(options.HostedSession);
+        Assert.IsFalse(options.ScriptMode);
+        Assert.AreEqual(120, options.ScriptChunkLength);
+        Assert.AreEqual(0, options.ScriptLineDelayMilliseconds);
+        Assert.AreEqual(0, options.DelayMilliseconds);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
+++ b/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
@@ -18,7 +18,7 @@ public class WindowVisibilityTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireDesktopChanges();
+        TestHelper.RequireOwnedWindowUiTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Visibility Harness");
 

--- a/Sources/DesktopManager/DesktopAutomationModels.cs
+++ b/Sources/DesktopManager/DesktopAutomationModels.cs
@@ -655,6 +655,16 @@ public sealed class DesktopCapture : IDisposable {
     public Bitmap Bitmap { get; set; } = null!;
 
     /// <summary>
+    /// Gets the captured bitmap width.
+    /// </summary>
+    public int Width => Bitmap.Width;
+
+    /// <summary>
+    /// Gets the captured bitmap height.
+    /// </summary>
+    public int Height => Bitmap.Height;
+
+    /// <summary>
     /// Gets or sets the captured window when applicable.
     /// </summary>
     public WindowInfo? Window { get; set; }
@@ -673,6 +683,14 @@ public sealed class DesktopCapture : IDisposable {
     /// Gets or sets the captured monitor device name when applicable.
     /// </summary>
     public string? MonitorDeviceName { get; set; }
+
+    /// <summary>
+    /// Saves the captured bitmap using the output path extension.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    public void Save(string path) {
+        Bitmap.Save(path);
+    }
 
     /// <summary>
     /// Disposes the underlying bitmap.

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -174,7 +174,7 @@ public sealed class DesktopAutomationService {
     /// <summary>
     /// Sends text to matching windows.
     /// </summary>
-    public IReadOnlyList<WindowInfo> TypeWindowText(WindowQueryOptions options, string text, bool paste, int delayMilliseconds, bool all = false) {
+    public IReadOnlyList<WindowInfo> TypeWindowText(WindowQueryOptions options, string text, bool paste, int delayMilliseconds, bool foregroundInput, bool physicalKeys, bool hostedSession, bool script, int scriptChunkLength, int scriptLineDelayMilliseconds, bool all = false) {
         if (text == null) {
             throw new ArgumentNullException(nameof(text));
         }
@@ -184,7 +184,15 @@ public sealed class DesktopAutomationService {
             if (paste) {
                 _windowManager.PasteText(window, text);
             } else {
-                _windowManager.TypeText(window, text, delayMilliseconds);
+                _windowManager.TypeText(window, text, new WindowInputOptions {
+                    KeyDelayMilliseconds = delayMilliseconds,
+                    RequireForegroundWindowForTyping = foregroundInput,
+                    UsePhysicalKeyboardLayout = physicalKeys,
+                    UseHostedSessionScanCodes = hostedSession,
+                    TypeTextAsScript = script,
+                    ScriptChunkLength = scriptChunkLength,
+                    ScriptLineDelayMilliseconds = scriptLineDelayMilliseconds
+                });
             }
         }
 

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>DesktopManager</AssemblyName>
         <AssemblyTitle>DesktopManager</AssemblyTitle>
 
-        <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net472;netstandard2.0;net8.0-windows;net10.0-windows</TargetFrameworks>
         <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
@@ -12,7 +12,7 @@
         <IsPublishable>True</IsPublishable>
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <RepositoryUrl>https://github.com/evotecit/DesktopManager</RepositoryUrl>
-        <VersionPrefix>3.6.0</VersionPrefix>
+        <VersionPrefix>3.6.1</VersionPrefix>
         <DebugType>portable</DebugType>
         <!--
       Turns off reference assembly generation
@@ -34,7 +34,7 @@
         <PackageId>DesktopManager</PackageId>
         <PackageIcon>DesktopManager.png</PackageIcon>
         <PackageTags>
-            desktop;net472;net48;net80
+            desktop;net472;net48;netstandard20;net80;net100
         </PackageTags>
         <PackageProjectUrl>https://github.com/EvotecIT/DesktopManager</PackageProjectUrl>
         <PackageReadmeFile>README.MD</PackageReadmeFile>
@@ -45,10 +45,17 @@
     </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />   
-      <PackageReference Include="System.Drawing.Common" Version="8.0.17" />     
+      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+      <PackageReference Include="System.Drawing.Common" Version="8.0.17" />
   </ItemGroup>
 
 
@@ -75,7 +82,7 @@
         <Using Include="System.Collections.Generic" />
     </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
       <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
   </ItemGroup>
 

--- a/Sources/DesktopManager/KeyboardInputService.cs
+++ b/Sources/DesktopManager/KeyboardInputService.cs
@@ -10,6 +10,28 @@ namespace DesktopManager;
 /// </summary>
 [SupportedOSPlatform("windows")]
 public static class KeyboardInputService {
+    private const ushort LeftShiftScanCode = 0x2A;
+
+    internal readonly struct KeyboardLayoutStroke {
+        public KeyboardLayoutStroke(VirtualKey key, IReadOnlyList<VirtualKey> modifiers) {
+            Key = key;
+            Modifiers = modifiers;
+        }
+
+        public VirtualKey Key { get; }
+        public IReadOnlyList<VirtualKey> Modifiers { get; }
+    }
+
+    internal readonly struct ScanCodeStroke {
+        public ScanCodeStroke(ushort scanCode, bool shiftRequired) {
+            ScanCode = scanCode;
+            ShiftRequired = shiftRequired;
+        }
+
+        public ushort ScanCode { get; }
+        public bool ShiftRequired { get; }
+    }
+
     /// <summary>
     /// Presses a single key by sending a down and up event.
     /// </summary>
@@ -119,30 +141,47 @@ public static class KeyboardInputService {
         }
 
         foreach (char character in text) {
-            MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
+            SendCharacterToForeground(character, delayMilliseconds);
+        }
+    }
 
-            inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-            inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
-                Vk = 0,
-                Scan = character,
-                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+    /// <summary>
+    /// Sends text to the current foreground target using layout-aware physical key presses when available.
+    /// </summary>
+    /// <param name="text">Text to send.</param>
+    /// <param name="threadId">Target thread identifier used to resolve keyboard layout.</param>
+    /// <param name="delayMilliseconds">Optional delay between characters.</param>
+    public static void SendTextToForegroundUsingKeyboardLayout(string text, uint threadId, int delayMilliseconds = 0) {
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
 
-            inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-            inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
-                Vk = 0,
-                Scan = character,
-                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE | MonitorNativeMethods.KEYEVENTF_KEYUP,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+        if (delayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(delayMilliseconds), "delayMilliseconds must be zero or greater.");
+        }
 
-            MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
-            if (delayMilliseconds > 0) {
-                Thread.Sleep(delayMilliseconds);
-            }
+        IntPtr keyboardLayout = MonitorNativeMethods.GetKeyboardLayout(threadId);
+        foreach (char character in text) {
+            SendCharacterToForegroundUsingKeyboardLayout(character, keyboardLayout, delayMilliseconds);
+        }
+    }
+
+    /// <summary>
+    /// Sends text to the current foreground target using a fixed US-style scancode map.
+    /// </summary>
+    /// <param name="text">Text to send.</param>
+    /// <param name="delayMilliseconds">Optional delay between characters.</param>
+    public static void SendTextToForegroundUsingUsScanCodes(string text, int delayMilliseconds = 0) {
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        if (delayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(delayMilliseconds), "delayMilliseconds must be zero or greater.");
+        }
+
+        foreach (char character in text) {
+            SendCharacterToForegroundUsingUsScanCodes(character, delayMilliseconds);
         }
     }
 
@@ -167,6 +206,249 @@ public static class KeyboardInputService {
             key == VirtualKey.VK_RMENU ||
             key == VirtualKey.VK_LWIN ||
             key == VirtualKey.VK_RWIN;
+    }
+
+    internal static bool TryCreateKeyboardLayoutStroke(short layoutResult, out KeyboardLayoutStroke stroke) {
+        stroke = default;
+        if (layoutResult == -1) {
+            return false;
+        }
+
+        byte virtualKeyCode = unchecked((byte)(layoutResult & 0xFF));
+        if (virtualKeyCode == 0) {
+            return false;
+        }
+
+        byte modifierState = unchecked((byte)((layoutResult >> 8) & 0xFF));
+        stroke = new KeyboardLayoutStroke((VirtualKey)virtualKeyCode, GetModifierKeysForKeyboardState(modifierState));
+        return true;
+    }
+
+    internal static IReadOnlyList<VirtualKey> GetModifierKeysForKeyboardState(byte modifierState) {
+        List<VirtualKey> modifiers = new();
+        bool usesAltGr = (modifierState & 0b110) == 0b110;
+        if ((modifierState & 1) != 0) {
+            modifiers.Add(VirtualKey.VK_SHIFT);
+        }
+
+        if (usesAltGr) {
+            modifiers.Add(VirtualKey.VK_RMENU);
+            return modifiers;
+        }
+
+        if ((modifierState & 2) != 0) {
+            modifiers.Add(VirtualKey.VK_CONTROL);
+        }
+
+        if ((modifierState & 4) != 0) {
+            modifiers.Add(VirtualKey.VK_MENU);
+        }
+
+        return modifiers;
+    }
+
+    internal static bool TryCreateUsKeyboardScanCodeStroke(char character, out ScanCodeStroke stroke) {
+        stroke = default;
+
+        if (TryCreateUsLetterStroke(character, out stroke)) {
+            return true;
+        }
+
+        if (TryCreateUsDigitOrShiftedDigitStroke(character, out stroke)) {
+            return true;
+        }
+
+        return character switch {
+            ' ' => TrySetUsStroke(0x39, shiftRequired: false, out stroke),
+            '\t' => TrySetUsStroke(0x0F, shiftRequired: false, out stroke),
+            '`' => TrySetUsStroke(0x29, shiftRequired: false, out stroke),
+            '~' => TrySetUsStroke(0x29, shiftRequired: true, out stroke),
+            '-' => TrySetUsStroke(0x0C, shiftRequired: false, out stroke),
+            '_' => TrySetUsStroke(0x0C, shiftRequired: true, out stroke),
+            '=' => TrySetUsStroke(0x0D, shiftRequired: false, out stroke),
+            '+' => TrySetUsStroke(0x0D, shiftRequired: true, out stroke),
+            '[' => TrySetUsStroke(0x1A, shiftRequired: false, out stroke),
+            '{' => TrySetUsStroke(0x1A, shiftRequired: true, out stroke),
+            ']' => TrySetUsStroke(0x1B, shiftRequired: false, out stroke),
+            '}' => TrySetUsStroke(0x1B, shiftRequired: true, out stroke),
+            '\\' => TrySetUsStroke(0x2B, shiftRequired: false, out stroke),
+            '|' => TrySetUsStroke(0x2B, shiftRequired: true, out stroke),
+            ';' => TrySetUsStroke(0x27, shiftRequired: false, out stroke),
+            ':' => TrySetUsStroke(0x27, shiftRequired: true, out stroke),
+            '\'' => TrySetUsStroke(0x28, shiftRequired: false, out stroke),
+            '"' => TrySetUsStroke(0x28, shiftRequired: true, out stroke),
+            ',' => TrySetUsStroke(0x33, shiftRequired: false, out stroke),
+            '<' => TrySetUsStroke(0x33, shiftRequired: true, out stroke),
+            '.' => TrySetUsStroke(0x34, shiftRequired: false, out stroke),
+            '>' => TrySetUsStroke(0x34, shiftRequired: true, out stroke),
+            '/' => TrySetUsStroke(0x35, shiftRequired: false, out stroke),
+            '?' => TrySetUsStroke(0x35, shiftRequired: true, out stroke),
+            _ => false
+        };
+    }
+
+    internal static void SendCharacterToForeground(char character, int delayMilliseconds = 0) {
+        if (delayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(delayMilliseconds), "delayMilliseconds must be zero or greater.");
+        }
+
+        MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
+
+        inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+            Vk = 0,
+            Scan = character,
+            Flags = MonitorNativeMethods.KEYEVENTF_UNICODE,
+            Time = 0,
+            ExtraInfo = IntPtr.Zero
+        };
+
+        inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+            Vk = 0,
+            Scan = character,
+            Flags = MonitorNativeMethods.KEYEVENTF_UNICODE | MonitorNativeMethods.KEYEVENTF_KEYUP,
+            Time = 0,
+            ExtraInfo = IntPtr.Zero
+        };
+
+        MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
+        if (delayMilliseconds > 0) {
+            Thread.Sleep(delayMilliseconds);
+        }
+    }
+
+    internal static void SendCharacterToForegroundUsingKeyboardLayout(char character, uint threadId, int delayMilliseconds = 0) {
+        if (delayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(delayMilliseconds), "delayMilliseconds must be zero or greater.");
+        }
+
+        IntPtr keyboardLayout = MonitorNativeMethods.GetKeyboardLayout(threadId);
+        SendCharacterToForegroundUsingKeyboardLayout(character, keyboardLayout, delayMilliseconds);
+    }
+
+    internal static void SendCharacterToForegroundUsingUsScanCodes(char character, int delayMilliseconds = 0) {
+        if (delayMilliseconds < 0) {
+            throw new ArgumentOutOfRangeException(nameof(delayMilliseconds), "delayMilliseconds must be zero or greater.");
+        }
+
+        if (TryCreateUsKeyboardScanCodeStroke(character, out ScanCodeStroke stroke)) {
+            SendScanCodeStroke(stroke, delayMilliseconds);
+            return;
+        }
+
+        SendCharacterToForeground(character, delayMilliseconds);
+    }
+
+    private static bool TryCreateUsLetterStroke(char character, out ScanCodeStroke stroke) {
+        stroke = default;
+        char upper = char.ToUpperInvariant(character);
+        if (upper < 'A' || upper > 'Z') {
+            return false;
+        }
+
+        VirtualKey key = (VirtualKey)Enum.Parse(typeof(VirtualKey), $"VK_{upper}", ignoreCase: false);
+        ushort scanCode = GetScanCodeForVirtualKey(key);
+        bool shiftRequired = char.IsUpper(character);
+        return TrySetUsStroke(scanCode, shiftRequired, out stroke);
+    }
+
+    private static bool TryCreateUsDigitOrShiftedDigitStroke(char character, out ScanCodeStroke stroke) {
+        stroke = default;
+        return character switch {
+            '1' => TrySetUsStroke(0x02, shiftRequired: false, out stroke),
+            '!' => TrySetUsStroke(0x02, shiftRequired: true, out stroke),
+            '2' => TrySetUsStroke(0x03, shiftRequired: false, out stroke),
+            '@' => TrySetUsStroke(0x03, shiftRequired: true, out stroke),
+            '3' => TrySetUsStroke(0x04, shiftRequired: false, out stroke),
+            '#' => TrySetUsStroke(0x04, shiftRequired: true, out stroke),
+            '4' => TrySetUsStroke(0x05, shiftRequired: false, out stroke),
+            '$' => TrySetUsStroke(0x05, shiftRequired: true, out stroke),
+            '5' => TrySetUsStroke(0x06, shiftRequired: false, out stroke),
+            '%' => TrySetUsStroke(0x06, shiftRequired: true, out stroke),
+            '6' => TrySetUsStroke(0x07, shiftRequired: false, out stroke),
+            '^' => TrySetUsStroke(0x07, shiftRequired: true, out stroke),
+            '7' => TrySetUsStroke(0x08, shiftRequired: false, out stroke),
+            '&' => TrySetUsStroke(0x08, shiftRequired: true, out stroke),
+            '8' => TrySetUsStroke(0x09, shiftRequired: false, out stroke),
+            '*' => TrySetUsStroke(0x09, shiftRequired: true, out stroke),
+            '9' => TrySetUsStroke(0x0A, shiftRequired: false, out stroke),
+            '(' => TrySetUsStroke(0x0A, shiftRequired: true, out stroke),
+            '0' => TrySetUsStroke(0x0B, shiftRequired: false, out stroke),
+            ')' => TrySetUsStroke(0x0B, shiftRequired: true, out stroke),
+            _ => false
+        };
+    }
+
+    private static bool TrySetUsStroke(ushort scanCode, bool shiftRequired, out ScanCodeStroke stroke) {
+        stroke = default;
+        if (scanCode == 0) {
+            return false;
+        }
+
+        stroke = new ScanCodeStroke(scanCode, shiftRequired);
+        return true;
+    }
+
+    private static void SendKeyboardLayoutStroke(KeyboardLayoutStroke stroke, int delayMilliseconds) {
+        foreach (VirtualKey modifier in stroke.Modifiers) {
+            KeyDown(modifier);
+        }
+
+        PressKey(stroke.Key);
+
+        for (int index = stroke.Modifiers.Count - 1; index >= 0; index--) {
+            KeyUp(stroke.Modifiers[index]);
+        }
+
+        if (delayMilliseconds > 0) {
+            Thread.Sleep(delayMilliseconds);
+        }
+    }
+
+    private static void SendCharacterToForegroundUsingKeyboardLayout(char character, IntPtr keyboardLayout, int delayMilliseconds) {
+        short layoutResult = MonitorNativeMethods.VkKeyScanEx(character, keyboardLayout);
+        if (TryCreateKeyboardLayoutStroke(layoutResult, out KeyboardLayoutStroke stroke)) {
+            SendKeyboardLayoutStroke(stroke, delayMilliseconds);
+            return;
+        }
+
+        SendCharacterToForeground(character, delayMilliseconds);
+    }
+
+    private static ushort GetScanCodeForVirtualKey(VirtualKey key) {
+        return unchecked((ushort)MonitorNativeMethods.MapVirtualKey((uint)key, 0));
+    }
+
+    private static void SendScanCodeStroke(ScanCodeStroke stroke, int delayMilliseconds) {
+        if (stroke.ShiftRequired) {
+            SendScanCodeKey(LeftShiftScanCode, keyUp: false);
+        }
+
+        SendScanCodeKey(stroke.ScanCode, keyUp: false);
+        SendScanCodeKey(stroke.ScanCode, keyUp: true);
+
+        if (stroke.ShiftRequired) {
+            SendScanCodeKey(LeftShiftScanCode, keyUp: true);
+        }
+
+        if (delayMilliseconds > 0) {
+            Thread.Sleep(delayMilliseconds);
+        }
+    }
+
+    private static void SendScanCodeKey(ushort scanCode, bool keyUp) {
+        MonitorNativeMethods.INPUT input = new();
+        input.Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        input.Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+            Vk = 0,
+            Scan = scanCode,
+            Flags = MonitorNativeMethods.KEYEVENTF_SCANCODE | (keyUp ? MonitorNativeMethods.KEYEVENTF_KEYUP : 0),
+            Time = 0,
+            ExtraInfo = IntPtr.Zero
+        };
+
+        MonitorNativeMethods.SendInput(1, [input], Marshal.SizeOf<MonitorNativeMethods.INPUT>());
     }
 
     private static void ReleaseHeldModifiers(List<VirtualKey> heldModifiers) {

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -61,6 +61,32 @@ public static partial class MonitorNativeMethods
     public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
     /// <summary>
+    /// Gets the active keyboard layout for a thread.
+    /// </summary>
+    /// <param name="idThread">The thread identifier.</param>
+    /// <returns>The keyboard layout handle.</returns>
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetKeyboardLayout(uint idThread);
+
+    /// <summary>
+    /// Translates a character to the virtual key and modifier state for a keyboard layout.
+    /// </summary>
+    /// <param name="ch">The character to translate.</param>
+    /// <param name="dwhkl">The keyboard layout handle.</param>
+    /// <returns>A packed virtual-key and modifier-state result, or -1 when no mapping exists.</returns>
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern short VkKeyScanEx(char ch, IntPtr dwhkl);
+
+    /// <summary>
+    /// Maps a virtual key to a scan code.
+    /// </summary>
+    /// <param name="uCode">The value to translate.</param>
+    /// <param name="uMapType">Translation mode.</param>
+    /// <returns>The translated scan code.</returns>
+    [DllImport("user32.dll")]
+    public static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+    /// <summary>
     /// Checks if a window is visible.
     /// </summary>
     /// <param name="hWnd">The window handle.</param>
@@ -200,6 +226,14 @@ public static partial class MonitorNativeMethods
     public static extern bool SetForegroundWindow(IntPtr hWnd);
 
     /// <summary>
+    /// Activates the specified window.
+    /// </summary>
+    /// <param name="hWnd">The window handle.</param>
+    /// <returns>The previously active window.</returns>
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetActiveWindow(IntPtr hWnd);
+
+    /// <summary>
     /// Brings the specified window to the top of the Z order.
     /// </summary>
     /// <param name="hWnd">The window handle.</param>
@@ -213,6 +247,23 @@ public static partial class MonitorNativeMethods
     /// <returns>The foreground window handle.</returns>
     [DllImport("user32.dll")]
     public static extern IntPtr GetForegroundWindow();
+
+    /// <summary>
+    /// Retrieves the identifier of the calling thread.
+    /// </summary>
+    /// <returns>The current thread identifier.</returns>
+    [DllImport("kernel32.dll")]
+    public static extern uint GetCurrentThreadId();
+
+    /// <summary>
+    /// Attaches or detaches the input processing mechanism of one thread to that of another thread.
+    /// </summary>
+    /// <param name="idAttach">Thread identifier to attach or detach.</param>
+    /// <param name="idAttachTo">Thread identifier to attach to or detach from.</param>
+    /// <param name="fAttach">True to attach; false to detach.</param>
+    /// <returns>True if successful.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
 
     /// <summary>
     /// Determines whether a window is minimized.
@@ -696,6 +747,11 @@ public static partial class MonitorNativeMethods
     /// Key event flag indicating key release.
     /// </summary>
     public const uint KEYEVENTF_KEYUP = 0x0002;
+
+    /// <summary>
+    /// Key event flag indicating a hardware scan code.
+    /// </summary>
+    public const uint KEYEVENTF_SCANCODE = 0x0008;
 
     /// <summary>
     /// Key event flag indicating Unicode scan code.

--- a/Sources/DesktopManager/MonitorService.Display.cs
+++ b/Sources/DesktopManager/MonitorService.Display.cs
@@ -571,7 +571,11 @@ public partial class MonitorService {
             }
 
             IntPtr unk = Marshal.GetIUnknownForObject(collection);
+#if NET10_0_OR_GREATER
+            Marshal.QueryInterface(unk, in iidShellItemArray, out IntPtr arrayPtr);
+#else
             Marshal.QueryInterface(unk, ref iidShellItemArray, out IntPtr arrayPtr);
+#endif
             Marshal.Release(unk);
             return arrayPtr;
         } finally {

--- a/Sources/DesktopManager/WindowActivationService.cs
+++ b/Sources/DesktopManager/WindowActivationService.cs
@@ -59,7 +59,7 @@ internal static class WindowActivationService {
 
         for (int attempt = 0; attempt < retryCount; attempt++) {
             TryPrepareWindowForAutomation(handle, retryCount: 1, retryDelayMilliseconds: 0);
-            MonitorNativeMethods.SetForegroundWindow(handle);
+            TryForceForegroundActivation(handle);
 
             if (MonitorNativeMethods.GetForegroundWindow() == handle) {
                 return true;
@@ -71,5 +71,41 @@ internal static class WindowActivationService {
         }
 
         return MonitorNativeMethods.GetForegroundWindow() == handle;
+    }
+
+    private static void TryForceForegroundActivation(IntPtr handle) {
+        if (handle == IntPtr.Zero) {
+            return;
+        }
+
+        IntPtr foregroundHandle = MonitorNativeMethods.GetForegroundWindow();
+        uint currentThreadId = MonitorNativeMethods.GetCurrentThreadId();
+        uint targetThreadId = MonitorNativeMethods.GetWindowThreadProcessId(handle, out _);
+        uint foregroundThreadId = foregroundHandle == IntPtr.Zero ? 0 : MonitorNativeMethods.GetWindowThreadProcessId(foregroundHandle, out _);
+        bool attachedToTarget = false;
+        bool attachedToForeground = false;
+
+        try {
+            if (targetThreadId != 0 && targetThreadId != currentThreadId) {
+                attachedToTarget = MonitorNativeMethods.AttachThreadInput(currentThreadId, targetThreadId, true);
+            }
+
+            if (foregroundThreadId != 0 && foregroundThreadId != currentThreadId && foregroundThreadId != targetThreadId) {
+                attachedToForeground = MonitorNativeMethods.AttachThreadInput(currentThreadId, foregroundThreadId, true);
+            }
+
+            MonitorNativeMethods.BringWindowToTop(handle);
+            MonitorNativeMethods.SetActiveWindow(handle);
+            MonitorNativeMethods.SetForegroundWindow(handle);
+            MonitorNativeMethods.SetFocus(handle);
+        } finally {
+            if (attachedToForeground) {
+                MonitorNativeMethods.AttachThreadInput(currentThreadId, foregroundThreadId, false);
+            }
+
+            if (attachedToTarget) {
+                MonitorNativeMethods.AttachThreadInput(currentThreadId, targetThreadId, false);
+            }
+        }
     }
 }

--- a/Sources/DesktopManager/WindowInputOptions.cs
+++ b/Sources/DesktopManager/WindowInputOptions.cs
@@ -53,4 +53,34 @@ public sealed class WindowInputOptions {
     /// Gets or sets whether to use SendInput for typing (true) or WM_CHAR (false).
     /// </summary>
     public bool UseSendInput { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether typing must use real foreground keyboard input and fail instead of falling back to background messaging.
+    /// </summary>
+    public bool RequireForegroundWindowForTyping { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether foreground typing should prefer layout-aware physical key presses over Unicode packet input.
+    /// </summary>
+    public bool UsePhysicalKeyboardLayout { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether foreground typing should prefer a fixed US-style scancode map for hosted remote sessions.
+    /// </summary>
+    public bool UseHostedSessionScanCodes { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether text should be delivered in script mode, preserving line boundaries and chunking long lines safely.
+    /// </summary>
+    public bool TypeTextAsScript { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters to send in each script chunk.
+    /// </summary>
+    public int ScriptChunkLength { get; set; } = 120;
+
+    /// <summary>
+    /// Gets or sets the delay in milliseconds to apply after each script line break.
+    /// </summary>
+    public int ScriptLineDelayMilliseconds { get; set; }
 }

--- a/Sources/DesktopManager/WindowInputService.cs
+++ b/Sources/DesktopManager/WindowInputService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Threading;
 
 namespace DesktopManager;
@@ -12,6 +13,22 @@ namespace DesktopManager;
 /// </summary>
 [SupportedOSPlatform("windows")]
 public static class WindowInputService {
+    internal enum WindowTextDeliveryMode {
+        ForegroundInput,
+        WindowMessage
+    }
+
+    internal readonly struct WindowScriptChunk {
+        public WindowScriptChunk(string text, bool sendLineBreak) {
+            Text = text ?? string.Empty;
+            SendLineBreak = sendLineBreak;
+        }
+
+        public string Text { get; }
+
+        public bool SendLineBreak { get; }
+    }
+
     /// <summary>
     /// Pastes the specified text into the window using the clipboard.
     /// </summary>
@@ -104,18 +121,18 @@ public static class WindowInputService {
         }
 
         bool targetOwnsForeground = MonitorNativeMethods.GetForegroundWindow() == window.Handle;
-        IntPtr targetHandle = ResolvePreferredTextHandle(window.Handle);
-        if (settings.UseSendInput) {
-            if (targetOwnsForeground) {
-                SendInputText(text, settings);
-            } else {
-                SendMessageText(targetHandle, text, settings.KeyDelayMilliseconds);
-            }
+        WindowTextDeliveryMode deliveryMode = ResolveTextDeliveryMode(settings, targetOwnsForeground);
+        if (settings.TypeTextAsScript) {
+            SendScriptText(window, text, settings, deliveryMode);
         } else {
-            SendMessageText(targetHandle, text, settings.KeyDelayMilliseconds);
+            if (deliveryMode == WindowTextDeliveryMode.ForegroundInput) {
+                SendForegroundText(window, text, settings);
+            } else {
+                IntPtr targetHandle = ResolvePreferredTextHandle(window.Handle);
+                SendMessageText(targetHandle, text, settings.KeyDelayMilliseconds);
+                EnsureTextApplied(window, text);
+            }
         }
-
-        EnsureTextApplied(window, text);
 
         if (settings.RestoreFocus && previousForeground != IntPtr.Zero && previousForeground != window.Handle) {
             MonitorNativeMethods.SetForegroundWindow(previousForeground);
@@ -179,6 +196,10 @@ public static class WindowInputService {
     }
 
     private static void NormalizeOptions(WindowInputOptions options) {
+        if (options.UseHostedSessionScanCodes) {
+            options.ActivateWindow = false;
+        }
+
         if (options.ClipboardRetryCount < 1) {
             options.ClipboardRetryCount = 1;
         }
@@ -196,6 +217,184 @@ public static class WindowInputService {
         }
         if (options.KeyDelayMilliseconds < 0) {
             options.KeyDelayMilliseconds = 0;
+        }
+        if (options.ScriptChunkLength < 1) {
+            options.ScriptChunkLength = 1;
+        }
+        if (options.ScriptLineDelayMilliseconds < 0) {
+            options.ScriptLineDelayMilliseconds = 0;
+        }
+    }
+
+    internal static WindowTextDeliveryMode ResolveTextDeliveryMode(WindowInputOptions options, bool targetOwnsForeground) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if ((options.RequireForegroundWindowForTyping || options.UsePhysicalKeyboardLayout || options.UseHostedSessionScanCodes) && !options.UseSendInput) {
+            throw new InvalidOperationException("Foreground-only window typing requires SendInput.");
+        }
+
+        if (options.UseHostedSessionScanCodes) {
+            if (!targetOwnsForeground) {
+                throw new InvalidOperationException(BuildForegroundOwnershipMessage(
+                    "Window must own the foreground before typing with hosted-session scan code input.",
+                    IntPtr.Zero));
+            }
+
+            return WindowTextDeliveryMode.ForegroundInput;
+        }
+
+        if (options.UsePhysicalKeyboardLayout) {
+            if (!targetOwnsForeground) {
+                throw new InvalidOperationException(BuildForegroundOwnershipMessage(
+                    "Window must own the foreground before typing with physical key input.",
+                    IntPtr.Zero));
+            }
+
+            return WindowTextDeliveryMode.ForegroundInput;
+        }
+
+        if (options.UseSendInput && targetOwnsForeground) {
+            return WindowTextDeliveryMode.ForegroundInput;
+        }
+
+        if (options.RequireForegroundWindowForTyping) {
+            throw new InvalidOperationException(BuildForegroundOwnershipMessage(
+                "Window must own the foreground before typing with foreground input.",
+                IntPtr.Zero));
+        }
+
+        return WindowTextDeliveryMode.WindowMessage;
+    }
+
+    private static uint ResolveWindowThreadId(WindowInfo window) {
+        if (window.ThreadId != 0) {
+            return window.ThreadId;
+        }
+
+        return MonitorNativeMethods.GetWindowThreadProcessId(window.Handle, out _);
+    }
+
+    internal static IReadOnlyList<WindowScriptChunk> CreateScriptChunks(string text, int chunkLength) {
+        if (text == null) {
+            throw new ArgumentNullException(nameof(text));
+        }
+        if (chunkLength < 1) {
+            throw new ArgumentOutOfRangeException(nameof(chunkLength));
+        }
+
+        var chunks = new List<WindowScriptChunk>();
+        string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+        if (normalized.Length == 0) {
+            return chunks;
+        }
+
+        int index = 0;
+        while (index < normalized.Length) {
+            int newlineIndex = normalized.IndexOf('\n', index);
+            bool hasLineBreak = newlineIndex >= 0;
+            int lineEnd = hasLineBreak ? newlineIndex : normalized.Length;
+            string line = normalized.Substring(index, lineEnd - index);
+            AppendLineChunks(chunks, line, chunkLength, hasLineBreak);
+            index = hasLineBreak ? lineEnd + 1 : normalized.Length;
+        }
+
+        return chunks;
+    }
+
+    private static void AppendLineChunks(List<WindowScriptChunk> chunks, string line, int chunkLength, bool hasLineBreak) {
+        if (line.Length == 0) {
+            if (hasLineBreak) {
+                chunks.Add(new WindowScriptChunk(string.Empty, sendLineBreak: true));
+            }
+
+            return;
+        }
+
+        for (int offset = 0; offset < line.Length; offset += chunkLength) {
+            int length = Math.Min(chunkLength, line.Length - offset);
+            bool sendLineBreak = hasLineBreak && offset + length >= line.Length;
+            chunks.Add(new WindowScriptChunk(line.Substring(offset, length), sendLineBreak));
+        }
+    }
+
+    private static void SendScriptText(WindowInfo window, string text, WindowInputOptions options, WindowTextDeliveryMode deliveryMode) {
+        IReadOnlyList<WindowScriptChunk> chunks = CreateScriptChunks(text, options.ScriptChunkLength);
+        if (chunks.Count == 0) {
+            return;
+        }
+
+        if (deliveryMode == WindowTextDeliveryMode.ForegroundInput) {
+            foreach (WindowScriptChunk chunk in chunks) {
+                EnsureForegroundOwnership(window, options);
+                if (!string.IsNullOrEmpty(chunk.Text)) {
+                    SendForegroundText(window, chunk.Text, options);
+                }
+
+                if (chunk.SendLineBreak) {
+                    EnsureForegroundOwnership(window, options);
+                    KeyboardInputService.SendToForeground(VirtualKey.VK_RETURN);
+                    if (options.ScriptLineDelayMilliseconds > 0) {
+                        Thread.Sleep(options.ScriptLineDelayMilliseconds);
+                    }
+                }
+            }
+
+            return;
+        }
+
+        IntPtr targetHandle = ResolvePreferredTextHandle(window.Handle);
+        foreach (WindowScriptChunk chunk in chunks) {
+            if (!string.IsNullOrEmpty(chunk.Text)) {
+                SendMessageText(targetHandle, chunk.Text, options.KeyDelayMilliseconds);
+            }
+
+            if (chunk.SendLineBreak) {
+                SendMessageText(targetHandle, Environment.NewLine, options.KeyDelayMilliseconds);
+                if (options.ScriptLineDelayMilliseconds > 0) {
+                    Thread.Sleep(options.ScriptLineDelayMilliseconds);
+                }
+            }
+        }
+    }
+
+    private static void SendForegroundText(WindowInfo window, string text, WindowInputOptions options) {
+        if (string.IsNullOrEmpty(text)) {
+            return;
+        }
+
+        uint windowThreadId = 0;
+        if (options.UsePhysicalKeyboardLayout) {
+            windowThreadId = ResolveWindowThreadId(window);
+        }
+
+        foreach (char character in text) {
+            EnsureForegroundOwnership(window, options);
+
+            if (options.UseHostedSessionScanCodes) {
+                KeyboardInputService.SendCharacterToForegroundUsingUsScanCodes(character, options.KeyDelayMilliseconds);
+                continue;
+            }
+
+            if (options.UsePhysicalKeyboardLayout) {
+                KeyboardInputService.SendCharacterToForegroundUsingKeyboardLayout(character, windowThreadId, options.KeyDelayMilliseconds);
+                continue;
+            }
+
+            SendInputCharacter(character, options);
+        }
+    }
+
+    private static void EnsureForegroundOwnership(WindowInfo window, WindowInputOptions options) {
+        if (!options.RequireForegroundWindowForTyping && !options.UsePhysicalKeyboardLayout && !options.UseHostedSessionScanCodes) {
+            return;
+        }
+
+        if (MonitorNativeMethods.GetForegroundWindow() != window.Handle) {
+            throw new InvalidOperationException(BuildForegroundOwnershipMessage(
+                "Foreground ownership changed while typing. Hosted-session and foreground typing stop immediately when focus drifts.",
+                window.Handle));
         }
     }
 
@@ -221,42 +420,83 @@ public static class WindowInputService {
         }
     }
 
-    private static void SendInputText(string text, WindowInputOptions options) {
-        foreach (char c in text) {
-            MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
+    private static void SendInputCharacter(char character, WindowInputOptions options) {
+        MonitorNativeMethods.INPUT[] inputs = new MonitorNativeMethods.INPUT[2];
 
-            inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-            inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
-                Vk = 0,
-                Scan = c,
-                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+        inputs[0].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        inputs[0].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+            Vk = 0,
+            Scan = character,
+            Flags = MonitorNativeMethods.KEYEVENTF_UNICODE,
+            Time = 0,
+            ExtraInfo = IntPtr.Zero
+        };
 
-            inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
-            inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
-                Vk = 0,
-                Scan = c,
-                Flags = MonitorNativeMethods.KEYEVENTF_UNICODE | MonitorNativeMethods.KEYEVENTF_KEYUP,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+        inputs[1].Type = MonitorNativeMethods.INPUT_KEYBOARD;
+        inputs[1].Data.Keyboard = new MonitorNativeMethods.KEYBDINPUT {
+            Vk = 0,
+            Scan = character,
+            Flags = MonitorNativeMethods.KEYEVENTF_UNICODE | MonitorNativeMethods.KEYEVENTF_KEYUP,
+            Time = 0,
+            ExtraInfo = IntPtr.Zero
+        };
 
-            for (int attempt = 0; attempt < options.InputRetryCount; attempt++) {
-                uint sent = MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
-                if (sent == inputs.Length) {
-                    break;
-                }
-                if (attempt < options.InputRetryCount - 1 && options.ActivationRetryDelayMilliseconds > 0) {
-                    Thread.Sleep(options.ActivationRetryDelayMilliseconds);
-                }
+        for (int attempt = 0; attempt < options.InputRetryCount; attempt++) {
+            uint sent = MonitorNativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<MonitorNativeMethods.INPUT>());
+            if (sent == inputs.Length) {
+                break;
             }
-
-            if (options.KeyDelayMilliseconds > 0) {
-                Thread.Sleep(options.KeyDelayMilliseconds);
+            if (attempt < options.InputRetryCount - 1 && options.ActivationRetryDelayMilliseconds > 0) {
+                Thread.Sleep(options.ActivationRetryDelayMilliseconds);
             }
         }
+
+        if (options.KeyDelayMilliseconds > 0) {
+            Thread.Sleep(options.KeyDelayMilliseconds);
+        }
+    }
+
+    private static string BuildForegroundOwnershipMessage(string message, IntPtr expectedForegroundHandle) {
+        IntPtr currentForegroundHandle = MonitorNativeMethods.GetForegroundWindow();
+        if (expectedForegroundHandle != IntPtr.Zero) {
+            return message +
+                " Expected: " + DescribeWindowHandle(expectedForegroundHandle) +
+                ". Current: " + DescribeWindowHandle(currentForegroundHandle) + ".";
+        }
+
+        return message + " Current: " + DescribeWindowHandle(currentForegroundHandle) + ".";
+    }
+
+    private static string DescribeWindowHandle(IntPtr handle) {
+        if (handle == IntPtr.Zero) {
+            return "no foreground window";
+        }
+
+        string title;
+        try {
+            title = WindowTextHelper.GetWindowText(handle);
+        } catch {
+            title = string.Empty;
+        }
+
+        var classNameBuilder = new StringBuilder(256);
+        string className = MonitorNativeMethods.GetClassName(handle, classNameBuilder, classNameBuilder.Capacity) > 0
+            ? classNameBuilder.ToString()
+            : string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(title) && !string.IsNullOrWhiteSpace(className)) {
+            return "'" + title + "' [" + "0x" + handle.ToInt64().ToString("X") + "] class=" + className;
+        }
+
+        if (!string.IsNullOrWhiteSpace(title)) {
+            return "'" + title + "' [" + "0x" + handle.ToInt64().ToString("X") + "]";
+        }
+
+        if (!string.IsNullOrWhiteSpace(className)) {
+            return "[" + "0x" + handle.ToInt64().ToString("X") + "] class=" + className;
+        }
+
+        return "[" + "0x" + handle.ToInt64().ToString("X") + "]";
     }
 
     private static void EnsureTextApplied(WindowInfo window, string text) {

--- a/Sources/WindowTextHelper32/WindowTextHelper32.csproj
+++ b/Sources/WindowTextHelper32/WindowTextHelper32.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows;net10.0-windows</TargetFrameworks>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>latest</LangVersion>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net8.0-windows'">win-x86</RuntimeIdentifier>
-    <SelfContained Condition="'$(TargetFramework)' == 'net8.0-windows'">true</SelfContained>
-    <PublishSingleFile Condition="'$(TargetFramework)' == 'net8.0-windows'">true</PublishSingleFile>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'net472'">win-x86</RuntimeIdentifier>
+    <SelfContained Condition="'$(TargetFramework)' != 'net472'">true</SelfContained>
+    <PublishSingleFile Condition="'$(TargetFramework)' != 'net472'">true</PublishSingleFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopManager\DesktopManager.csproj" />

--- a/powerforge.dotnetpublish.json
+++ b/powerforge.dotnetpublish.json
@@ -22,12 +22,31 @@
   },
   "Targets": [
     {
-      "Name": "DesktopManager.Cli",
+      "Name": "DesktopManager.Cli.net8",
       "Kind": "Cli",
       "ProjectPath": "Sources/DesktopManager.Cli/DesktopManager.Cli.csproj",
       "Publish": {
         "Style": "PortableCompat",
         "Framework": "net8.0-windows",
+        "OutputPath": "Artefacts/PowerForge/DesktopManager/{rid}/{framework}/{style}",
+        "UseStaging": true,
+        "ClearOutput": true,
+        "Slim": true,
+        "KeepSymbols": false,
+        "KeepDocs": false,
+        "PruneReferences": true,
+        "RenameTo": "desktopmanager.exe",
+        "Zip": true,
+        "ZipNameTemplate": "desktopmanager-{rid}-{framework}-{style}.zip"
+      }
+    },
+    {
+      "Name": "DesktopManager.Cli.net10",
+      "Kind": "Cli",
+      "ProjectPath": "Sources/DesktopManager.Cli/DesktopManager.Cli.csproj",
+      "Publish": {
+        "Style": "PortableCompat",
+        "Framework": "net10.0-windows",
         "OutputPath": "Artefacts/PowerForge/DesktopManager/{rid}/{framework}/{style}",
         "UseStaging": true,
         "ClearOutput": true,


### PR DESCRIPTION
## Summary
- add `net10.0-windows` targeting across the DesktopManager solution and related publish/build docs
- add opt-in post-action verification for window mutations across CLI, MCP, and PowerShell
- add hosted-session typing diagnostics, repo-owned DesktopManager.TestApp coverage, and artifact readers/helpers
- split UI tests into owned-window, foreground, system-wide, external, and experimental gates so local runs stop touching unrelated live windows
- promote verification/pass-through support to PowerShell window mutation cmdlets, including click/drag/scroll

## Verification
- `dotnet test Sources/DesktopManager.sln --nologo -m:1`
- focused net8 slices for PowerShell mutation coverage, hosted-session diagnostics, and UI test gate cleanup were also run during development

## Notes
- default test runs no longer rely on the current foreground window and should not move or resize unrelated live windows
- system-wide desktop mutations now require an extra explicit opt-in through `RUN_SYSTEM_UI_TESTS=true`
- foreground-stealing tests now require `RUN_FOREGROUND_UI_TESTS=true`