### PR TITLE
feat(automation): ✨ add hosted-session diagnostics and safer ui test gates

### DIFF
--- a/Docs/Build.Runbook.md
+++ b/Docs/Build.Runbook.md
@@ -95,7 +95,8 @@ desktopmanager mcp serve --allow-mutations --allow-process notepad
 
 | Gate | Purpose | Notes |
 | ---- | ------- | ----- |
-| `RUN_UI_TESTS` | Owned-window UI tests | Uses repo-created harness windows only |
+| `RUN_UI_TESTS` | Top-level UI pack enablement | Required before any UI slice can run |
+| `RUN_OWNED_WINDOW_UI_TESTS` | Owned-window UI tests | Uses repo-created harness windows only |
 | `RUN_DESTRUCTIVE_UI_TESTS` | Owned-window mutation tests | Move/resize/hide/snap/transparency on harness windows |
 | `RUN_FOREGROUND_UI_TESTS` | Foreground-focus tests | Intentionally steals focus to prove active-window behavior |
 | `RUN_SYSTEM_UI_TESTS` | System-wide desktop mutations | Wallpaper, brightness, resolution, and other monitor/session changes |
@@ -106,6 +107,7 @@ desktopmanager mcp serve --allow-mutations --allow-process notepad
 
 ```powershell
 $env:RUN_UI_TESTS = "true"
+$env:RUN_OWNED_WINDOW_UI_TESTS = "true"
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
 $env:RUN_EXTERNAL_UI_TESTS = "true"
 $env:RUN_EXPERIMENTAL_UI_TESTS = "true"
@@ -120,6 +122,7 @@ Owned-window mutation slice without system-wide or foreground changes:
 
 ```powershell
 $env:RUN_UI_TESTS = "true"
+$env:RUN_OWNED_WINDOW_UI_TESTS = "true"
 dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "WindowPositionTests|WindowStateHelpersTests|WindowVisibilityTests|WindowTransparencyTests|WindowStyleModificationTests|WindowLayoutTests|WindowActivationPositioningTests"
 ```
 
@@ -127,6 +130,7 @@ Foreground-window slice:
 
 ```powershell
 $env:RUN_UI_TESTS = "true"
+$env:RUN_OWNED_WINDOW_UI_TESTS = "true"
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
 $env:RUN_FOREGROUND_UI_TESTS = "true"
 dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "DesktopAutomationAssertionTests|WindowManagerFilterTests|WindowTopMostActivationTests"
@@ -136,6 +140,7 @@ System-wide desktop mutation slice:
 
 ```powershell
 $env:RUN_UI_TESTS = "true"
+$env:RUN_OWNED_WINDOW_UI_TESTS = "true"
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"
 $env:RUN_SYSTEM_UI_TESTS = "true"
 dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --no-build --filter "BackgroundColorTests|MonitorBrightnessTests|MonitorFallbackTests|MonitorResolutionOrientationTests|LogonWallpaperTests"
@@ -167,12 +172,16 @@ Artifact behavior:
 Quick PowerShell inspection flow:
 
 ```powershell
+Get-DesktopHostedSessionDiagnostic -RepositoryRoot C:\Support\GitHub\DesktopManager -SummaryOnly
 .\Build\Get-HostedSessionDiagnostic.ps1 -SummaryOnly
+desktopmanager diagnostic hosted-session --repository-root C:\Support\GitHub\DesktopManager --summary-only
 ```
 
 JSON fallback for the newest hosted-session artifact:
 
 ```powershell
+Get-DesktopHostedSessionDiagnostic -RepositoryRoot C:\Support\GitHub\DesktopManager
 .\Build\Get-HostedSessionDiagnostic.ps1
 .\Build\Get-HostedSessionDiagnostic.ps1 -AsJson
+desktopmanager diagnostic hosted-session --repository-root C:\Support\GitHub\DesktopManager --json
 ```

--- a/Docs/DesktopManager.Cli.md
+++ b/Docs/DesktopManager.Cli.md
@@ -62,6 +62,8 @@ desktopmanager snapshot save
 desktopmanager snapshot restore
 desktopmanager snapshot list
 
+desktopmanager diagnostic hosted-session
+
 desktopmanager workflow prepare-coding
 desktopmanager workflow prepare-screen-sharing
 desktopmanager workflow clean-up-distractions
@@ -112,6 +114,7 @@ desktopmanager mcp serve --dry-run
 - `--verify-tolerance-px` tunes geometry verification for commands like `window move`; specifying it also implies `--verify`.
 - the verification block is action-aware for `window move`, `window focus`, and `window minimize`, and falls back to honest presence-only observation for other window mutations such as typing and pointer input.
 - hosted-session live diagnostics now write repo-local artifacts under `Artifacts\HostedSessionTyping`, including a raw JSON snapshot and a companion `*.summary.txt` file with the likely focus-culprit category and retry summary.
+- `diagnostic hosted-session` reads the newest hosted-session artifact (or a specific one) and can return either the compact summary text or a structured record.
 - hosted-session diagnostic artifacts now trim older entries automatically, keeping the newest artifact sets so the folder stays readable during repeated harness runs.
 - `window keys` sends key chords or single keys to the target window after activating it, which is the safer shared follow-up path for Enter, Escape, and similar actions when modern controls stop being structurally reusable after text entry.
 - mutating `window` and `control` commands can now return shared verification metadata: `success`, `elapsedMilliseconds`, `safetyMode`, optional target name/kind, best-effort before/after screenshots, artifact warnings, and for verified window mutations an explicit `verification` block with observed counts, summary text, and notes.
@@ -202,4 +205,12 @@ When you want mutation evidence too, add artifact flags to the action step:
 ```text
 desktopmanager control set-text --window-process msedge --target edge-address --text "https://evotec.xyz" --allow-foreground-input --capture-before --capture-after --json
 desktopmanager window click --process msedge --target edge-editor-center --capture-before --capture-after --artifact-directory .\artifacts --json
+```
+
+For hosted-session diagnostics, prefer the summary first and then fall back to the full record only when needed:
+
+```text
+desktopmanager diagnostic hosted-session --summary-only
+desktopmanager diagnostic hosted-session --repository-root C:\Support\GitHub\DesktopManager
+desktopmanager diagnostic hosted-session --artifact C:\Support\GitHub\DesktopManager\Artifacts\HostedSessionTyping\sample.json --json
 ```

--- a/README.MD
+++ b/README.MD
@@ -161,6 +161,7 @@ The important part is that CLI, MCP, and PowerShell are meant to stay aligned by
 | Get-DesktopWindowProcessInfo | Return process details for matched windows |
 | Get-DesktopWindowTarget | List saved window-relative targets or resolve one against live windows |
 | Get-DesktopControlTarget | List saved control targets or resolve one against live windows |
+| Get-DesktopHostedSessionDiagnostic | Read the latest hosted-session typing diagnostic artifact or a specific one |
 | Invoke-DesktopControlClick | Click a matched control using shared control action routing |
 | Invoke-DesktopWindowClick | Click a window-relative point or saved window target |
 | Invoke-DesktopWindowDrag | Drag between window-relative points or saved targets |
@@ -253,11 +254,40 @@ For using in PowerShell you can install it from PowerShell Gallery
 Install-Module DesktopManager -Force -Verbose
 ```
 
+### Verified mutation examples
+
+When you want more than "the call did not throw", prefer `-Verify` together with `-PassThru` so the cmdlet returns the observed postcondition.
+
+```powershell
+# Verify a window move against the observed geometry
+Set-DesktopWindow -Name "*Visual Studio Code*" -Left 0 -Top 0 -Width 1600 -Height 1200 -Verify -PassThru
+
+# Verify exact text after a control text update
+Set-DesktopControlText -Control $ctrl -Text "Hello world" -Verify -PassThru
+
+# Verify the observed check state
+Set-DesktopControlCheck -Control $checkbox -Check $true -Verify -PassThru
+
+# Return a structured record after a control click
+Invoke-DesktopControlClick -Control $button -PassThru
+
+# Return a structured record after sending keys
+Send-DesktopControlKey -Control $editor -Keys @([DesktopManager.VirtualKey]::VK_RETURN) -PassThru
+```
+
+Verification behavior is action-aware:
+
+- window mutations verify geometry, state, topmost, close, or foreground conditions when those postconditions are meaningful
+- `Set-DesktopControlText -Verify` verifies the observed text/value when the control can be re-queried
+- `Set-DesktopControlCheck -Verify` verifies the observed check state
+- control click/key actions return honest presence and foreground evidence when exact semantic verification would be misleading
+
 ### Testing notes
 
 UI-impacting tests are opt-in to avoid opening windows or changing the desktop during local development. Use the environment variables below to control behavior:
 
-- `RUN_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_UI_TESTS=true`) enables owned-window UI tests that use repo-created harness windows.
+- `RUN_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_UI_TESTS=true`) enables the top-level UI test pack.
+- `RUN_OWNED_WINDOW_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_OWNED_WINDOW_UI_TESTS=true`) enables owned-window UI tests that use repo-created harness windows.
 - `RUN_DESTRUCTIVE_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_DESTRUCTIVE_UI_TESTS=true`) enables owned-window mutation tests such as move, resize, hide, snap, and transparency changes against repo-created harness windows.
 - `RUN_FOREGROUND_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_FOREGROUND_UI_TESTS=true`) enables tests that intentionally steal foreground focus, even when they only target repo-created harness windows.
 - `RUN_SYSTEM_UI_TESTS=true` (or `DESKTOPMANAGER_RUN_SYSTEM_UI_TESTS=true`) enables system-wide desktop changes such as wallpapers, brightness, resolution, and other monitor-level mutations that can affect your current session.
@@ -269,8 +299,9 @@ The gates compose intentionally:
 
 | Gate | What it permits | Typical impact |
 | ---- | --------------- | -------------- |
-| `RUN_UI_TESTS` | Repo-owned WinForms/WPF harness windows | Low |
-| `RUN_DESTRUCTIVE_UI_TESTS` | Mutations against owned harness windows | Medium |
+| `RUN_UI_TESTS` | Top-level UI pack enablement only | Low |
+| `RUN_OWNED_WINDOW_UI_TESTS` | Repo-owned WinForms/WPF harness windows | Low to medium |
+| `RUN_DESTRUCTIVE_UI_TESTS` | Mutations against owned harness windows | Medium to high |
 | `RUN_FOREGROUND_UI_TESTS` | Tests that intentionally take foreground focus | Medium to high |
 | `RUN_SYSTEM_UI_TESTS` | System-wide desktop changes | High |
 | `RUN_EXTERNAL_UI_TESTS` | Launching real desktop apps | Medium to high |
@@ -279,6 +310,7 @@ The gates compose intentionally:
 ```powershell
 # Run owned-window UI tests
 $env:RUN_UI_TESTS = "true"
+$env:RUN_OWNED_WINDOW_UI_TESTS = "true"
 
 # Run repo-owned window mutation tests
 $env:RUN_DESTRUCTIVE_UI_TESTS = "true"

--- a/Sources/DesktopManager.Cli/CliApplication.cs
+++ b/Sources/DesktopManager.Cli/CliApplication.cs
@@ -9,7 +9,16 @@ internal static class CliApplication {
     }
 
     internal static int Run(string[] args, TextWriter output, TextWriter error) {
+        TextWriter originalOutput = Console.Out;
+        TextWriter originalError = Console.Error;
         try {
+            if (!ReferenceEquals(output, originalOutput)) {
+                Console.SetOut(output);
+            }
+            if (!ReferenceEquals(error, originalError)) {
+                Console.SetError(error);
+            }
+
             var parsed = CommandLineArguments.Parse(args);
             if (parsed.IsEmpty || parsed.HasFlag("help")) {
                 output.WriteLine(HelpText.GetGeneralHelp());
@@ -32,6 +41,7 @@ internal static class CliApplication {
                 "control-target" => ControlTargetCommands.Run(action, parsed),
                 "layout" => LayoutCommands.Run(action, parsed),
                 "snapshot" => SnapshotCommands.Run(action, parsed),
+                "diagnostic" => DiagnosticCommands.Run(action, parsed),
                 "workflow" => WorkflowCommands.Run(action, parsed),
                 "mcp" => McpCommands.Run(action, parsed),
                 "help" => ShowGroupHelp(parsed, output),
@@ -45,6 +55,13 @@ internal static class CliApplication {
         } catch (Exception ex) {
             error.WriteLine($"Unhandled error: {ex.Message}");
             return 1;
+        } finally {
+            if (!ReferenceEquals(Console.Out, originalOutput)) {
+                Console.SetOut(originalOutput);
+            }
+            if (!ReferenceEquals(Console.Error, originalError)) {
+                Console.SetError(originalError);
+            }
         }
     }
 
@@ -59,6 +76,7 @@ internal static class CliApplication {
             "control-target" => true,
             "layout" => true,
             "snapshot" => true,
+            "diagnostic" => true,
             "workflow" => true,
             "mcp" => true,
             _ => false
@@ -76,6 +94,7 @@ internal static class CliApplication {
             "control-target" => HelpText.GetControlTargetHelp(),
             "layout" => HelpText.GetLayoutHelp(),
             "snapshot" => HelpText.GetSnapshotHelp(),
+            "diagnostic" => HelpText.GetDiagnosticHelp(),
             "workflow" => HelpText.GetWorkflowHelp(),
             "mcp" => HelpText.GetMcpHelp(),
             _ => HelpText.GetGeneralHelp()

--- a/Sources/DesktopManager.Cli/DiagnosticCommands.cs
+++ b/Sources/DesktopManager.Cli/DiagnosticCommands.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+
+namespace DesktopManager.Cli;
+
+internal static class DiagnosticCommands {
+    public static int Run(string action, CommandLineArguments arguments) {
+        return action switch {
+            "hosted-session" => HostedSession(arguments),
+            _ => throw new CommandLineException($"Unknown diagnostic command '{action}'.")
+        };
+    }
+
+    private static int HostedSession(CommandLineArguments arguments) {
+        string resolvedArtifactPath = ResolveArtifactPath(arguments);
+        HostedSessionDiagnosticResult result = HostedSessionDiagnosticReader.Load(resolvedArtifactPath);
+
+        if (arguments.GetBoolFlag("json")) {
+            OutputFormatter.WriteJson(result);
+            return 0;
+        }
+
+        if (arguments.GetBoolFlag("summary-only")) {
+            return WriteSummary(result, Console.Out);
+        }
+
+        return WriteDiagnosticResult(result, Console.Out);
+    }
+
+    private static string ResolveArtifactPath(CommandLineArguments arguments) {
+        string artifactPath = arguments.GetOption("artifact") ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(artifactPath)) {
+            return artifactPath;
+        }
+
+        string artifactDirectory = arguments.GetOption("artifact-directory") ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(artifactDirectory)) {
+            return HostedSessionDiagnosticReader.FindLatestArtifactPath(artifactDirectory);
+        }
+
+        string repositoryRoot = arguments.GetOption("repository-root") ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(repositoryRoot)) {
+            return HostedSessionDiagnosticReader.FindLatestArtifactPath(
+                HostedSessionDiagnosticReader.GetHostedSessionArtifactDirectory(repositoryRoot));
+        }
+
+        if (HostedSessionDiagnosticReader.TryFindRepositoryRoot(Environment.CurrentDirectory, out string currentRepositoryRoot)) {
+            return HostedSessionDiagnosticReader.FindLatestArtifactPath(
+                HostedSessionDiagnosticReader.GetHostedSessionArtifactDirectory(currentRepositoryRoot));
+        }
+
+        throw new CommandLineException(
+            "Could not resolve the DesktopManager repository root from the current location. Specify --repository-root, --artifact-directory, or --artifact.");
+    }
+
+    internal static int WriteSummary(HostedSessionDiagnosticResult result, TextWriter writer) {
+        writer.WriteLine(result.SummaryText);
+        return 0;
+    }
+
+    internal static int WriteDiagnosticResult(HostedSessionDiagnosticResult result, TextWriter writer) {
+        writer.WriteLine(result.ArtifactPath);
+        if (!string.IsNullOrWhiteSpace(result.SummaryPath)) {
+            writer.WriteLine($"- SummaryPath: {result.SummaryPath}");
+        }
+        writer.WriteLine($"- Summary: {result.SummaryText}");
+        if (!string.IsNullOrWhiteSpace(result.Reason)) {
+            writer.WriteLine($"- Reason: {result.Reason}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.CreatedUtc)) {
+            writer.WriteLine($"- CreatedUtc: {result.CreatedUtc}");
+        }
+        writer.WriteLine($"- RetryHistoryCategory: {result.RetryHistoryCategory}");
+        writer.WriteLine($"- RetryHistorySummary: {result.RetryHistorySummary}");
+        writer.WriteLine($"- RetryHistoryExternalCount: {result.RetryHistoryExternalCount}");
+        writer.WriteLine($"- RetryHistoryDistinctFingerprintCount: {result.RetryHistoryDistinctFingerprintCount}");
+        if (!string.IsNullOrWhiteSpace(result.PolicyReport)) {
+            writer.WriteLine($"- PolicyReport: {result.PolicyReport}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.WindowTitle)) {
+            writer.WriteLine($"- WindowTitle: {result.WindowTitle}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.StatusText)) {
+            writer.WriteLine($"- StatusText: {result.StatusText}");
+        }
+        return 0;
+    }
+}

--- a/Sources/DesktopManager.Cli/HelpText.cs
+++ b/Sources/DesktopManager.Cli/HelpText.cs
@@ -18,6 +18,7 @@ Groups:
   control-target Save and resolve reusable control selector targets
   layout     Save, apply, and list named layouts
   snapshot   Save, restore, and list named snapshots
+  diagnostic Read DesktopManager diagnostic artifacts
   workflow   Run higher-level desktop workflows
   mcp        Host an MCP server over stdio
   help       Show help for a command group
@@ -38,6 +39,7 @@ Examples:
   desktopmanager layout assert coding --position-tolerance-px 50 --size-tolerance-px 50
   desktopmanager snapshot save workday
   desktopmanager snapshot restore workday
+  desktopmanager diagnostic hosted-session --summary-only
 
 Use:
   desktopmanager help window
@@ -49,6 +51,7 @@ Use:
   desktopmanager help control-target
   desktopmanager help layout
   desktopmanager help snapshot
+  desktopmanager help diagnostic
   desktopmanager help workflow
   desktopmanager help mcp
 """;
@@ -360,6 +363,22 @@ Snapshot commands:
 
 Snapshots currently store window layout state only. This command group is designed
 to grow into broader desktop state capture later.
+""";
+    }
+
+    public static string GetDiagnosticHelp() {
+        return """
+Diagnostic commands:
+  desktopmanager diagnostic hosted-session [--artifact <path> | --artifact-directory <path> | --repository-root <path>] [--summary-only] [--json]
+
+Examples:
+  desktopmanager diagnostic hosted-session --summary-only
+  desktopmanager diagnostic hosted-session --repository-root C:\Support\GitHub\DesktopManager
+  desktopmanager diagnostic hosted-session --artifact C:\Support\GitHub\DesktopManager\Artifacts\HostedSessionTyping\sample.json --json
+
+Notes:
+  This command reads hosted-session typing diagnostics written under Artifacts\HostedSessionTyping.
+  It prefers the companion .summary.txt artifact when one exists and falls back to the .json payload otherwise.
 """;
     }
 

--- a/Sources/DesktopManager.Cli/HostedSessionDiagnosticArtifact.cs
+++ b/Sources/DesktopManager.Cli/HostedSessionDiagnosticArtifact.cs
@@ -1,0 +1,17 @@
+namespace DesktopManager.Cli;
+
+internal sealed class HostedSessionDiagnosticArtifact {
+    public int FormatVersion { get; set; } = 1;
+
+    public string Reason { get; set; } = string.Empty;
+
+    public string CreatedUtc { get; set; } = string.Empty;
+
+    public string Summary { get; set; } = string.Empty;
+
+    public string PolicyReport { get; set; } = string.Empty;
+
+    public HostedSessionRetryHistoryReport RetryHistoryReport { get; set; } = HostedSessionRetryHistoryReport.None;
+
+    public HostedSessionStatus Status { get; set; } = new();
+}

--- a/Sources/DesktopManager.Cli/HostedSessionDiagnosticReader.cs
+++ b/Sources/DesktopManager.Cli/HostedSessionDiagnosticReader.cs
@@ -1,0 +1,236 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace DesktopManager.Cli;
+
+internal static class HostedSessionDiagnosticReader {
+    public static HostedSessionDiagnosticResult Load(string artifactPath) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("Artifact path cannot be null or empty.", nameof(artifactPath));
+        }
+
+        if (!File.Exists(artifactPath)) {
+            throw new FileNotFoundException("Hosted-session diagnostic artifact was not found.", artifactPath);
+        }
+
+        HostedSessionDiagnosticArtifact artifact = LoadArtifact(artifactPath);
+        string? summaryPath = FindPreferredSummaryArtifactPath(artifactPath);
+        string summaryText = !string.IsNullOrWhiteSpace(summaryPath) && File.Exists(summaryPath)
+            ? File.ReadAllText(summaryPath)
+            : BuildSummaryText(artifact);
+
+        return new HostedSessionDiagnosticResult {
+            ArtifactPath = artifactPath,
+            SummaryPath = summaryPath ?? string.Empty,
+            SummaryText = summaryText,
+            Reason = artifact.Reason,
+            CreatedUtc = artifact.CreatedUtc,
+            RetryHistoryCategory = artifact.RetryHistoryReport.CategoryHint,
+            RetryHistorySummary = artifact.RetryHistoryReport.Summary,
+            RetryHistoryExternalCount = artifact.RetryHistoryReport.ExternalCount,
+            RetryHistoryDistinctFingerprintCount = artifact.RetryHistoryReport.DistinctFingerprintCount,
+            PolicyReport = artifact.PolicyReport,
+            WindowTitle = artifact.Status.WindowTitle,
+            StatusText = artifact.Status.StatusText
+        };
+    }
+
+    public static string FindLatestArtifactPath(string artifactDirectory) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory)) {
+            throw new ArgumentException("Artifact directory cannot be null or empty.", nameof(artifactDirectory));
+        }
+
+        if (!Directory.Exists(artifactDirectory)) {
+            throw new DirectoryNotFoundException("Hosted-session diagnostic artifact directory was not found.");
+        }
+
+        string[] artifactPaths = Directory.GetFiles(artifactDirectory, "*.json", SearchOption.TopDirectoryOnly);
+        if (artifactPaths.Length == 0) {
+            throw new FileNotFoundException("No hosted-session diagnostic artifacts were found.", artifactDirectory);
+        }
+
+        Array.Sort(artifactPaths, CompareArtifactPathsByLastWriteDescending);
+        return artifactPaths[0];
+    }
+
+    public static string GetHostedSessionArtifactDirectory(string repositoryRoot) {
+        if (string.IsNullOrWhiteSpace(repositoryRoot)) {
+            throw new ArgumentException("Repository root cannot be null or empty.", nameof(repositoryRoot));
+        }
+
+        return Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+    }
+
+    public static bool TryFindRepositoryRoot(string startDirectory, out string repositoryRoot) {
+        repositoryRoot = string.Empty;
+        if (string.IsNullOrWhiteSpace(startDirectory)) {
+            return false;
+        }
+
+        DirectoryInfo? current = new(startDirectory);
+        while (current != null) {
+            if (File.Exists(Path.Combine(current.FullName, "DesktopManager.sln")) ||
+                Directory.Exists(Path.Combine(current.FullName, "Artifacts", "HostedSessionTyping"))) {
+                repositoryRoot = current.FullName;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static HostedSessionDiagnosticArtifact LoadArtifact(string artifactPath) {
+        string json = File.ReadAllText(artifactPath);
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+
+        if (root.TryGetProperty("Status", out _)) {
+            HostedSessionDiagnosticArtifact? artifact = JsonSerializer.Deserialize<HostedSessionDiagnosticArtifact>(json);
+            if (artifact == null) {
+                throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+            }
+
+            return Normalize(artifact);
+        }
+
+        if (root.TryGetProperty("WindowTitle", out _)) {
+            HostedSessionStatus? status = JsonSerializer.Deserialize<HostedSessionStatus>(json);
+            if (status == null) {
+                throw new InvalidOperationException("Hosted-session legacy diagnostic artifact could not be deserialized.");
+            }
+
+            return CreateLegacyArtifact(status);
+        }
+
+        throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+    }
+
+    private static HostedSessionDiagnosticArtifact Normalize(HostedSessionDiagnosticArtifact artifact) {
+        artifact.Reason ??= string.Empty;
+        artifact.CreatedUtc ??= string.Empty;
+        artifact.Summary ??= string.Empty;
+        artifact.PolicyReport ??= string.Empty;
+        artifact.RetryHistoryReport ??= HostedSessionRetryHistoryReport.None;
+        artifact.RetryHistoryReport.CategoryHint ??= string.Empty;
+        artifact.RetryHistoryReport.Summary ??= string.Empty;
+        artifact.Status ??= new HostedSessionStatus();
+        artifact.Status.WindowTitle ??= string.Empty;
+        artifact.Status.LastObservedForegroundTitle ??= string.Empty;
+        artifact.Status.LastObservedForegroundClass ??= string.Empty;
+        artifact.Status.StatusText ??= string.Empty;
+        artifact.Status.ForegroundHistory ??= [];
+        return artifact;
+    }
+
+    private static HostedSessionDiagnosticArtifact CreateLegacyArtifact(HostedSessionStatus status) {
+        string categoryHint;
+        if (!string.IsNullOrWhiteSpace(status.LastObservedForegroundClass) &&
+            (status.LastObservedForegroundClass.Contains("Chrome_WidgetWin_1", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("Chrome_RenderWidgetHostHWND", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("MozillaWindowClass", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("ApplicationFrameWindow", StringComparison.OrdinalIgnoreCase))) {
+            categoryHint = "browser-electron";
+        } else if (!string.IsNullOrWhiteSpace(status.LastObservedForegroundTitle)) {
+            categoryHint = "unknown";
+        } else {
+            categoryHint = "none";
+        }
+
+        return Normalize(new HostedSessionDiagnosticArtifact {
+            FormatVersion = 0,
+            Reason = "Legacy hosted-session diagnostic artifact",
+            CreatedUtc = string.Empty,
+            Summary = BuildSummaryText(status.WindowTitle, status.StatusText, categoryHint, 0, 0, $"category='{categoryHint}'"),
+            PolicyReport = $"category='{categoryHint}'",
+            RetryHistoryReport = new HostedSessionRetryHistoryReport {
+                CategoryHint = categoryHint,
+                Summary = categoryHint == "none" ? "no retained external foreground interruption" : $"external foreground interruption observed ({categoryHint})",
+                ExternalCount = categoryHint == "none" ? 0 : 1,
+                DistinctFingerprintCount = categoryHint == "none" ? 0 : 1
+            },
+            Status = status
+        });
+    }
+
+    private static string BuildSummaryText(HostedSessionDiagnosticArtifact artifact) {
+        if (!string.IsNullOrWhiteSpace(artifact.Summary)) {
+            return artifact.Summary;
+        }
+
+        return BuildSummaryText(
+            artifact.Status.WindowTitle,
+            artifact.Status.StatusText,
+            artifact.RetryHistoryReport.CategoryHint,
+            artifact.RetryHistoryReport.ExternalCount,
+            artifact.RetryHistoryReport.DistinctFingerprintCount,
+            artifact.PolicyReport);
+    }
+
+    private static string BuildSummaryText(string windowTitle, string statusText, string categoryHint, int externalCount, int distinctFingerprintCount, string policyReport) {
+        return
+            "category='" + categoryHint + "', " +
+            "externalCount=" + externalCount + ", " +
+            "distinctFingerprintCount=" + distinctFingerprintCount + ", " +
+            "policy='" + policyReport + "', " +
+            "windowTitle='" + windowTitle + "', " +
+            "statusText='" + statusText + "'";
+    }
+
+    private static string? FindPreferredSummaryArtifactPath(string artifactPath) {
+        string directory = Path.GetDirectoryName(artifactPath) ?? string.Empty;
+        string stem = Path.GetFileNameWithoutExtension(artifactPath);
+        if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(stem) || !Directory.Exists(directory)) {
+            return null;
+        }
+
+        string[] summaryPaths = Directory.GetFiles(directory, stem + "*.summary.txt", SearchOption.TopDirectoryOnly);
+        if (summaryPaths.Length == 0) {
+            return null;
+        }
+
+        Array.Sort(summaryPaths, CompareSummaryPaths);
+        return summaryPaths[0];
+    }
+
+    private static int CompareSummaryPaths(string left, string right) {
+        string leftFileName = Path.GetFileName(left);
+        string rightFileName = Path.GetFileName(right);
+        int leftSegmentCount = CountSegments(leftFileName);
+        int rightSegmentCount = CountSegments(rightFileName);
+        int comparison = leftSegmentCount.CompareTo(rightSegmentCount);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(leftFileName, rightFileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountSegments(string fileName) {
+        if (string.IsNullOrWhiteSpace(fileName)) {
+            return int.MaxValue;
+        }
+
+        int count = 0;
+        foreach (char character in fileName) {
+            if (character == '.') {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CompareArtifactPathsByLastWriteDescending(string left, string right) {
+        DateTime leftWriteTime = File.Exists(left) ? File.GetLastWriteTimeUtc(left) : DateTime.MinValue;
+        DateTime rightWriteTime = File.Exists(right) ? File.GetLastWriteTimeUtc(right) : DateTime.MinValue;
+        int comparison = rightWriteTime.CompareTo(leftWriteTime);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(right, left, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Sources/DesktopManager.Cli/HostedSessionDiagnosticResult.cs
+++ b/Sources/DesktopManager.Cli/HostedSessionDiagnosticResult.cs
@@ -1,0 +1,27 @@
+namespace DesktopManager.Cli;
+
+internal sealed class HostedSessionDiagnosticResult {
+    public string ArtifactPath { get; set; } = string.Empty;
+
+    public string SummaryPath { get; set; } = string.Empty;
+
+    public string SummaryText { get; set; } = string.Empty;
+
+    public string Reason { get; set; } = string.Empty;
+
+    public string CreatedUtc { get; set; } = string.Empty;
+
+    public string RetryHistoryCategory { get; set; } = string.Empty;
+
+    public string RetryHistorySummary { get; set; } = string.Empty;
+
+    public int RetryHistoryExternalCount { get; set; }
+
+    public int RetryHistoryDistinctFingerprintCount { get; set; }
+
+    public string PolicyReport { get; set; } = string.Empty;
+
+    public string WindowTitle { get; set; } = string.Empty;
+
+    public string StatusText { get; set; } = string.Empty;
+}

--- a/Sources/DesktopManager.Cli/HostedSessionRetryHistoryReport.cs
+++ b/Sources/DesktopManager.Cli/HostedSessionRetryHistoryReport.cs
@@ -1,0 +1,13 @@
+namespace DesktopManager.Cli;
+
+internal sealed class HostedSessionRetryHistoryReport {
+    public static HostedSessionRetryHistoryReport None { get; } = new();
+
+    public string CategoryHint { get; set; } = string.Empty;
+
+    public string Summary { get; set; } = string.Empty;
+
+    public int ExternalCount { get; set; }
+
+    public int DistinctFingerprintCount { get; set; }
+}

--- a/Sources/DesktopManager.Cli/HostedSessionStatus.cs
+++ b/Sources/DesktopManager.Cli/HostedSessionStatus.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace DesktopManager.Cli;
+
+internal sealed class HostedSessionStatus {
+    public string WindowTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundClass { get; set; } = string.Empty;
+
+    public string StatusText { get; set; } = string.Empty;
+
+    public List<string> ForegroundHistory { get; set; } = [];
+}

--- a/Sources/DesktopManager.PowerShell/CmdletGetDesktopHostedSessionDiagnostic.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletGetDesktopHostedSessionDiagnostic.cs
@@ -1,0 +1,83 @@
+using System.Management.Automation;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Gets the latest hosted-session diagnostic artifact or a specific hosted-session artifact.</summary>
+/// <para type="synopsis">Reads hosted-session typing diagnostics from the DesktopManager artifact folder.</para>
+/// <para>Prefers the companion summary file when one exists and falls back to the JSON diagnostic artifact otherwise.</para>
+/// <example>
+///   <code>Get-DesktopHostedSessionDiagnostic</code>
+/// </example>
+/// <example>
+///   <code>Get-DesktopHostedSessionDiagnostic -SummaryOnly</code>
+/// </example>
+/// <example>
+///   <code>Get-DesktopHostedSessionDiagnostic -RepositoryRoot C:\Support\GitHub\DesktopManager</code>
+/// </example>
+/// <example>
+///   <code>Get-DesktopHostedSessionDiagnostic -ArtifactPath C:\Support\GitHub\DesktopManager\Artifacts\HostedSessionTyping\sample.json</code>
+/// </example>
+[Cmdlet(VerbsCommon.Get, "DesktopHostedSessionDiagnostic")]
+public sealed class CmdletGetDesktopHostedSessionDiagnostic : PSCmdlet {
+    /// <summary>
+    /// <para type="description">Specific hosted-session JSON artifact to read.</para>
+    /// </summary>
+    [Parameter(Position = 0)]
+    public string ArtifactPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Directory containing hosted-session JSON artifacts and summary companion files.</para>
+    /// </summary>
+    [Parameter]
+    public string ArtifactDirectory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Repository root used to resolve Artifacts\HostedSessionTyping when ArtifactPath is not supplied.</para>
+    /// </summary>
+    [Parameter]
+    public string RepositoryRoot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Returns only the resolved summary text instead of the structured diagnostic record.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter SummaryOnly { get; set; }
+
+    /// <inheritdoc />
+    protected override void BeginProcessing() {
+        string resolvedArtifactPath;
+
+        if (!string.IsNullOrWhiteSpace(ArtifactPath)) {
+            resolvedArtifactPath = ArtifactPath;
+        } else {
+            string artifactDirectory = ResolveArtifactDirectory();
+            resolvedArtifactPath = DesktopHostedSessionDiagnosticReader.FindLatestArtifactPath(artifactDirectory);
+        }
+
+        DesktopHostedSessionDiagnosticRecord record = DesktopHostedSessionDiagnosticReader.Load(resolvedArtifactPath);
+        if (SummaryOnly) {
+            WriteObject(record.SummaryText);
+            return;
+        }
+
+        WriteObject(record);
+    }
+
+    private string ResolveArtifactDirectory() {
+        if (!string.IsNullOrWhiteSpace(ArtifactDirectory)) {
+            return ArtifactDirectory;
+        }
+
+        if (!string.IsNullOrWhiteSpace(RepositoryRoot)) {
+            return DesktopHostedSessionDiagnosticReader.GetHostedSessionArtifactDirectory(RepositoryRoot);
+        }
+
+        string currentDirectory = SessionState.Path.CurrentFileSystemLocation?.Path ?? string.Empty;
+        if (DesktopHostedSessionDiagnosticReader.TryFindRepositoryRoot(currentDirectory, out string repositoryRoot)) {
+            return DesktopHostedSessionDiagnosticReader.GetHostedSessionArtifactDirectory(repositoryRoot);
+        }
+
+        throw new PSInvalidOperationException(
+            "Could not resolve the DesktopManager repository root from the current location. Specify -RepositoryRoot, -ArtifactDirectory, or -ArtifactPath.");
+    }
+}

--- a/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopControlClick.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletInvokeDesktopControlClick.cs
@@ -23,11 +23,35 @@ public sealed class CmdletInvokeDesktopControlClick : PSCmdlet {
     [Parameter]
     public MouseButton Button { get; set; } = MouseButton.Left;
 
+    /// <summary>
+    /// <para type="description">Re-query the control after the click and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the clicked control.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         if (ShouldProcess(Control.Text ?? Control.ClassName, $"Click {Button}")) {
             var automation = new DesktopAutomationService();
-            automation.ClickControl(Control, Button);
+            try {
+                automation.ClickControl(Control, Button);
+                if (Verify.IsPresent || PassThru.IsPresent) {
+                    WriteObject(DesktopControlMutationVerifier.Verify(automation, "click", Control));
+                }
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to click control '{Control.Text ?? Control.ClassName}': {ex.Message}");
+                WriteObject(DesktopControlMutationVerifier.CreateFailureRecord("click", Control, ex.Message, Verify.IsPresent));
+            }
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletSendDesktopControlKey.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSendDesktopControlKey.cs
@@ -35,11 +35,39 @@ public sealed class CmdletSendDesktopControlKey : PSCmdlet {
     [Parameter]
     public SwitchParameter AllowForegroundInput { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the control after sending keys and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the targeted control.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         if (ShouldProcess(Control.Text ?? Control.ClassName, "Send keys")) {
             var automation = new DesktopAutomationService();
-            automation.SendControlKeys(Control, Keys, EnsureForeground, AllowForegroundInput);
+            try {
+                automation.SendControlKeys(Control, Keys, EnsureForeground, AllowForegroundInput);
+                if (Verify.IsPresent || PassThru.IsPresent) {
+                    WriteObject(DesktopControlMutationVerifier.Verify(
+                        automation,
+                        "send-keys",
+                        Control,
+                        requireForeground: EnsureForeground.IsPresent));
+                }
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to send keys to control '{Control.Text ?? Control.ClassName}': {ex.Message}");
+                WriteObject(DesktopControlMutationVerifier.CreateFailureRecord("send-keys", Control, ex.Message, Verify.IsPresent));
+            }
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopControlCheck.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopControlCheck.cs
@@ -23,11 +23,40 @@ public sealed class CmdletSetDesktopControlCheck : PSCmdlet {
     [Parameter(Mandatory = true, Position = 1)]
     public bool Check { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the control after changing the check state and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the targeted control.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         string action = Check ? "Check" : "Uncheck";
         if (ShouldProcess(Control.Text ?? Control.ClassName, action)) {
-            WindowControlService.SetCheckState(Control, Check);
+            var automation = new DesktopAutomationService();
+            try {
+                WindowControlService.SetCheckState(Control, Check);
+                if (Verify.IsPresent || PassThru.IsPresent) {
+                    WriteObject(DesktopControlMutationVerifier.Verify(
+                        automation,
+                        Check ? "check" : "uncheck",
+                        Control,
+                        expectedCheckState: Check));
+                }
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to set check state on control '{Control.Text ?? Control.ClassName}': {ex.Message}");
+                WriteObject(DesktopControlMutationVerifier.CreateFailureRecord(Check ? "check" : "uncheck", Control, ex.Message, Verify.IsPresent));
+            }
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/CmdletSetDesktopControlText.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletSetDesktopControlText.cs
@@ -35,11 +35,40 @@ public sealed class CmdletSetDesktopControlText : PSCmdlet {
     [Parameter]
     public SwitchParameter AllowForegroundInput { get; set; }
 
+    /// <summary>
+    /// <para type="description">Re-query the control after setting text and report the observed postcondition.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter Verify { get; set; }
+
+    /// <summary>
+    /// <para type="description">Return a structured mutation result object for the targeted control.</para>
+    /// </summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing() {
         if (ShouldProcess(Control.Text ?? Control.ClassName, "Set text")) {
             var automation = new DesktopAutomationService();
-            automation.SetControlText(Control, Text, EnsureForeground, AllowForegroundInput);
+            try {
+                automation.SetControlText(Control, Text, EnsureForeground, AllowForegroundInput);
+                if (Verify.IsPresent || PassThru.IsPresent) {
+                    WriteObject(DesktopControlMutationVerifier.Verify(
+                        automation,
+                        "set-text",
+                        Control,
+                        expectedText: Text,
+                        requireForeground: EnsureForeground.IsPresent));
+                }
+            } catch (Exception ex) {
+                if (!Verify.IsPresent && !PassThru.IsPresent) {
+                    throw;
+                }
+
+                WriteWarning($"Failed to set text on control '{Control.Text ?? Control.ClassName}': {ex.Message}");
+                WriteObject(DesktopControlMutationVerifier.CreateFailureRecord("set-text", Control, ex.Message, Verify.IsPresent));
+            }
         }
     }
 }

--- a/Sources/DesktopManager.PowerShell/DesktopControlMutationRecord.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopControlMutationRecord.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace DesktopManager.PowerShell;
+
+/// <summary>Represents the outcome of a PowerShell control mutation.</summary>
+public sealed class DesktopControlMutationRecord {
+    /// <summary>Gets or sets the action name.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether the mutation call completed without throwing.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Gets or sets whether post-mutation verification was requested.</summary>
+    public bool VerificationPerformed { get; set; }
+
+    /// <summary>Gets or sets whether the post-mutation verification succeeded.</summary>
+    public bool? Verified { get; set; }
+
+    /// <summary>Gets or sets the verification mode.</summary>
+    public string VerificationMode { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the verification summary.</summary>
+    public string VerificationSummary { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the originally targeted control.</summary>
+    public WindowControlInfo RequestedControl { get; set; } = new();
+
+    /// <summary>Gets or sets the observed control after the mutation, when available.</summary>
+    public WindowControlInfo ObservedControl { get; set; }
+
+    /// <summary>Gets or sets the observed parent window after the mutation, when available.</summary>
+    public WindowInfo ParentWindow { get; set; }
+
+    /// <summary>Gets or sets the active foreground window observed during verification, when available.</summary>
+    public WindowInfo ActiveWindow { get; set; }
+
+    /// <summary>Gets or sets verification notes.</summary>
+    public IReadOnlyList<string> VerificationNotes { get; set; } = new List<string>();
+}

--- a/Sources/DesktopManager.PowerShell/DesktopControlMutationVerifier.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopControlMutationVerifier.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DesktopManager.PowerShell;
+
+internal static class DesktopControlMutationVerifier {
+    internal static DesktopControlMutationRecord Verify(
+        DesktopAutomationService automation,
+        string action,
+        WindowControlInfo requestedControl,
+        string expectedText = null,
+        bool? expectedCheckState = null,
+        bool requireForeground = false) {
+        WindowInfo parentWindow = ObserveParentWindow(automation, requestedControl.ParentWindowHandle);
+        WindowControlInfo observedControl = ObserveControl(automation, requestedControl, parentWindow);
+        WindowInfo activeWindow = SafeGetActiveWindow(automation);
+        var notes = new List<string>();
+
+        if (observedControl == null) {
+            return new DesktopControlMutationRecord {
+                Action = action,
+                Success = true,
+                VerificationPerformed = true,
+                Verified = false,
+                VerificationMode = "presence",
+                VerificationSummary = $"DesktopManager requested '{action}', but the control was no longer observable afterward.",
+                RequestedControl = requestedControl,
+                ParentWindow = parentWindow,
+                ActiveWindow = activeWindow,
+                VerificationNotes = new[] { BuildMissingControlNote(requestedControl) }
+            };
+        }
+
+        bool hasSpecificExpectation = expectedText != null || expectedCheckState.HasValue || requireForeground;
+        if (!hasSpecificExpectation) {
+            return new DesktopControlMutationRecord {
+                Action = action,
+                Success = true,
+                VerificationPerformed = true,
+                Verified = true,
+                VerificationMode = "presence",
+                VerificationSummary = $"Observed the control after '{action}'.",
+                RequestedControl = requestedControl,
+                ObservedControl = observedControl,
+                ParentWindow = parentWindow,
+                ActiveWindow = activeWindow
+            };
+        }
+
+        bool verified = true;
+        string mode = "postcondition";
+        if (expectedText != null) {
+            string observedText = GetObservedControlText(observedControl);
+            if (!string.Equals(observedText, expectedText, StringComparison.Ordinal)) {
+                verified = false;
+                mode = "text";
+                notes.Add($"Observed text/value '{observedText}' instead of '{expectedText}'.");
+            } else {
+                mode = "text";
+            }
+        }
+
+        if (expectedCheckState.HasValue) {
+            bool? observedCheckState = TryGetObservedCheckState(observedControl);
+            if (!observedCheckState.HasValue) {
+                verified = false;
+                mode = "check";
+                notes.Add("The observed control did not expose a check state that could be re-queried.");
+            } else if (observedCheckState.Value != expectedCheckState.Value) {
+                verified = false;
+                mode = "check";
+                notes.Add($"Observed check state {observedCheckState.Value} instead of {expectedCheckState.Value}.");
+            } else {
+                mode = "check";
+            }
+        }
+
+        if (requireForeground) {
+            mode = mode == "postcondition" ? "foreground" : mode + "-foreground";
+            if (parentWindow == null || activeWindow == null || activeWindow.Handle != parentWindow.Handle) {
+                verified = false;
+                notes.Add(activeWindow == null
+                    ? "Windows did not report an active foreground window after the mutation."
+                    : $"Foreground window was '{activeWindow.Title}' [{activeWindow.Handle.ToInt64():X}] instead of the control's parent window.");
+            }
+        }
+
+        return new DesktopControlMutationRecord {
+            Action = action,
+            Success = true,
+            VerificationPerformed = true,
+            Verified = verified,
+            VerificationMode = mode,
+            VerificationSummary = verified
+                ? $"Observed the requested postcondition after '{action}'."
+                : $"DesktopManager requested '{action}', but the observed postcondition did not match.",
+            RequestedControl = requestedControl,
+            ObservedControl = observedControl,
+            ParentWindow = parentWindow,
+            ActiveWindow = activeWindow,
+            VerificationNotes = notes
+        };
+    }
+
+    internal static DesktopControlMutationRecord CreateFailureRecord(string action, WindowControlInfo requestedControl, string message, bool verificationPerformed) {
+        return new DesktopControlMutationRecord {
+            Action = action,
+            Success = false,
+            VerificationPerformed = verificationPerformed,
+            Verified = verificationPerformed ? false : null,
+            VerificationMode = verificationPerformed ? "error" : string.Empty,
+            VerificationSummary = message,
+            RequestedControl = requestedControl,
+            VerificationNotes = new[] { message }
+        };
+    }
+
+    private static WindowInfo ObserveParentWindow(DesktopAutomationService automation, IntPtr parentWindowHandle) {
+        if (parentWindowHandle == IntPtr.Zero) {
+            return null;
+        }
+
+        IReadOnlyList<WindowInfo> windows = automation.GetWindows(new WindowQueryOptions {
+            Handle = parentWindowHandle,
+            IncludeHidden = true,
+            IncludeCloaked = true,
+            IncludeOwned = true,
+            IncludeEmptyTitles = true
+        });
+        return windows.Count > 0 ? windows[0] : null;
+    }
+
+    private static WindowControlInfo ObserveControl(DesktopAutomationService automation, WindowControlInfo requestedControl, WindowInfo parentWindow) {
+        if (parentWindow == null) {
+            return null;
+        }
+
+        var query = new WindowControlQueryOptions {
+            IncludeUiAutomation = requestedControl.Source == WindowControlSource.UiAutomation || requestedControl.Handle == IntPtr.Zero,
+            UseUiAutomation = requestedControl.Source == WindowControlSource.UiAutomation || requestedControl.Handle == IntPtr.Zero,
+            EnsureForegroundWindow = false
+        };
+
+        IReadOnlyList<WindowControlTargetInfo> controls = automation.GetControls(new WindowQueryOptions {
+            Handle = parentWindow.Handle,
+            IncludeHidden = true,
+            IncludeCloaked = true,
+            IncludeOwned = true,
+            IncludeEmptyTitles = true
+        }, query, allWindows: false, allControls: true);
+
+        WindowControlInfo bestMatch = null;
+        int bestScore = 0;
+        foreach (WindowControlTargetInfo target in controls) {
+            int score = ScoreControlMatch(requestedControl, target.Control);
+            if (score > bestScore) {
+                bestScore = score;
+                bestMatch = target.Control;
+            }
+        }
+
+        return bestScore > 0 ? bestMatch : null;
+    }
+
+    private static int ScoreControlMatch(WindowControlInfo requestedControl, WindowControlInfo candidate) {
+        if (candidate == null) {
+            return 0;
+        }
+
+        if (requestedControl.Handle != IntPtr.Zero && candidate.Handle == requestedControl.Handle) {
+            return 1000;
+        }
+
+        int score = 0;
+        if (!string.IsNullOrWhiteSpace(requestedControl.AutomationId) &&
+            string.Equals(requestedControl.AutomationId, candidate.AutomationId, StringComparison.Ordinal)) {
+            score += 400;
+        }
+        if (!string.IsNullOrWhiteSpace(requestedControl.ControlType) &&
+            string.Equals(requestedControl.ControlType, candidate.ControlType, StringComparison.OrdinalIgnoreCase)) {
+            score += 200;
+        }
+        if (!string.IsNullOrWhiteSpace(requestedControl.ClassName) &&
+            string.Equals(requestedControl.ClassName, candidate.ClassName, StringComparison.Ordinal)) {
+            score += 150;
+        }
+        if (!string.IsNullOrWhiteSpace(requestedControl.Text) &&
+            string.Equals(requestedControl.Text, candidate.Text, StringComparison.Ordinal)) {
+            score += 100;
+        }
+        if (!string.IsNullOrWhiteSpace(requestedControl.Value) &&
+            string.Equals(requestedControl.Value, candidate.Value, StringComparison.Ordinal)) {
+            score += 100;
+        }
+        if (requestedControl.Left == candidate.Left &&
+            requestedControl.Top == candidate.Top &&
+            requestedControl.Width == candidate.Width &&
+            requestedControl.Height == candidate.Height &&
+            requestedControl.Width > 0 &&
+            requestedControl.Height > 0) {
+            score += 50;
+        }
+        if (requestedControl.Id != 0 && requestedControl.Id == candidate.Id) {
+            score += 25;
+        }
+
+        return score;
+    }
+
+    private static string BuildMissingControlNote(WindowControlInfo requestedControl) {
+        if (requestedControl.Handle != IntPtr.Zero) {
+            return $"Control handle [{requestedControl.Handle.ToInt64():X}] could not be re-queried after the mutation.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(requestedControl.AutomationId)) {
+            return $"Control automation id '{requestedControl.AutomationId}' could not be re-queried after the mutation.";
+        }
+
+        return "The requested control could not be re-queried after the mutation.";
+    }
+
+    private static string GetObservedControlText(WindowControlInfo control) {
+        if (control == null) {
+            return string.Empty;
+        }
+
+        if (!string.IsNullOrEmpty(control.Value)) {
+            return control.Value;
+        }
+
+        if (!string.IsNullOrEmpty(control.Text)) {
+            return control.Text;
+        }
+
+        if (control.Handle != IntPtr.Zero) {
+            return WindowTextHelper.GetWindowText(control.Handle);
+        }
+
+        return string.Empty;
+    }
+
+    private static bool? TryGetObservedCheckState(WindowControlInfo control) {
+        if (control == null || control.Handle == IntPtr.Zero) {
+            return null;
+        }
+
+        try {
+            return WindowControlService.GetCheckState(control);
+        } catch {
+            return null;
+        }
+    }
+
+    private static WindowInfo SafeGetActiveWindow(DesktopAutomationService automation) {
+        try {
+            return automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
+        } catch {
+            return null;
+        }
+    }
+}

--- a/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticArtifact.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticArtifact.cs
@@ -1,0 +1,17 @@
+namespace DesktopManager.PowerShell;
+
+internal sealed class DesktopHostedSessionDiagnosticArtifact {
+    public int FormatVersion { get; set; } = 1;
+
+    public string Reason { get; set; } = string.Empty;
+
+    public string CreatedUtc { get; set; } = string.Empty;
+
+    public string Summary { get; set; } = string.Empty;
+
+    public string PolicyReport { get; set; } = string.Empty;
+
+    public DesktopHostedSessionRetryHistoryReport RetryHistoryReport { get; set; } = DesktopHostedSessionRetryHistoryReport.None;
+
+    public DesktopHostedSessionStatus Status { get; set; } = new();
+}

--- a/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticReader.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticReader.cs
@@ -1,0 +1,260 @@
+using System.IO;
+using System.Text.Json;
+
+#nullable enable
+
+namespace DesktopManager.PowerShell;
+
+internal static class DesktopHostedSessionDiagnosticReader {
+    public static DesktopHostedSessionDiagnosticRecord Load(string artifactPath) {
+        if (string.IsNullOrWhiteSpace(artifactPath)) {
+            throw new ArgumentException("ArtifactPath cannot be null or empty.", nameof(artifactPath));
+        }
+
+        if (!File.Exists(artifactPath)) {
+            throw new FileNotFoundException("Hosted-session diagnostic artifact was not found.", artifactPath);
+        }
+
+        DesktopHostedSessionDiagnosticArtifact artifact = LoadArtifact(artifactPath);
+        string? summaryPath = FindPreferredSummaryArtifactPath(artifactPath);
+        string summaryText = !string.IsNullOrWhiteSpace(summaryPath) && File.Exists(summaryPath)
+            ? File.ReadAllText(summaryPath)
+            : BuildSummaryText(artifact);
+
+        return new DesktopHostedSessionDiagnosticRecord {
+            ArtifactPath = artifactPath,
+            SummaryPath = summaryPath ?? string.Empty,
+            SummaryText = summaryText,
+            Reason = artifact.Reason,
+            CreatedUtc = artifact.CreatedUtc,
+            RetryHistoryCategory = artifact.RetryHistoryReport.CategoryHint,
+            RetryHistorySummary = artifact.RetryHistoryReport.Summary,
+            RetryHistoryExternalCount = artifact.RetryHistoryReport.ExternalCount,
+            RetryHistoryDistinctFingerprintCount = artifact.RetryHistoryReport.DistinctFingerprintCount,
+            PolicyReport = artifact.PolicyReport,
+            WindowTitle = artifact.Status.WindowTitle,
+            StatusText = artifact.Status.StatusText
+        };
+    }
+
+    public static DesktopHostedSessionDiagnosticRecord LoadLatest(string artifactDirectory) {
+        return Load(FindLatestArtifactPath(artifactDirectory));
+    }
+
+    public static string FindLatestArtifactPath(string artifactDirectory) {
+        if (string.IsNullOrWhiteSpace(artifactDirectory)) {
+            throw new ArgumentException("ArtifactDirectory cannot be null or empty.", nameof(artifactDirectory));
+        }
+
+        if (!Directory.Exists(artifactDirectory)) {
+            throw new DirectoryNotFoundException("Hosted-session diagnostic artifact directory was not found.");
+        }
+
+        string[] artifactPaths = Directory.GetFiles(artifactDirectory, "*.json", SearchOption.TopDirectoryOnly);
+        if (artifactPaths.Length == 0) {
+            throw new FileNotFoundException("No hosted-session diagnostic artifacts were found.", artifactDirectory);
+        }
+
+        Array.Sort(artifactPaths, CompareArtifactPathsByLastWriteDescending);
+        return artifactPaths[0];
+    }
+
+    public static string GetHostedSessionArtifactDirectory(string repositoryRoot) {
+        if (string.IsNullOrWhiteSpace(repositoryRoot)) {
+            throw new ArgumentException("RepositoryRoot cannot be null or empty.", nameof(repositoryRoot));
+        }
+
+        return Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+    }
+
+    public static bool TryFindRepositoryRoot(string startDirectory, out string repositoryRoot) {
+        repositoryRoot = string.Empty;
+        if (string.IsNullOrWhiteSpace(startDirectory)) {
+            return false;
+        }
+
+        DirectoryInfo? current = new(startDirectory);
+        while (current != null) {
+            if (File.Exists(Path.Combine(current.FullName, "DesktopManager.sln")) ||
+                Directory.Exists(Path.Combine(current.FullName, "Artifacts", "HostedSessionTyping"))) {
+                repositoryRoot = current.FullName;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    public static bool TryLoadLatestFromRepositoryRoot(string repositoryRoot, out DesktopHostedSessionDiagnosticRecord record, out string error) {
+        record = new DesktopHostedSessionDiagnosticRecord();
+        error = string.Empty;
+
+        try {
+            record = LoadLatest(GetHostedSessionArtifactDirectory(repositoryRoot));
+            return true;
+        } catch (Exception exception) when (
+            exception is ArgumentException ||
+            exception is DirectoryNotFoundException ||
+            exception is FileNotFoundException ||
+            exception is IOException ||
+            exception is InvalidOperationException ||
+            exception is JsonException) {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private static DesktopHostedSessionDiagnosticArtifact LoadArtifact(string artifactPath) {
+        string json = File.ReadAllText(artifactPath);
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+
+        if (root.TryGetProperty("Status", out _)) {
+            DesktopHostedSessionDiagnosticArtifact? artifact = JsonSerializer.Deserialize<DesktopHostedSessionDiagnosticArtifact>(json);
+            if (artifact == null) {
+                throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+            }
+
+            return Normalize(artifact);
+        }
+
+        if (root.TryGetProperty("WindowTitle", out _)) {
+            DesktopHostedSessionStatus? status = JsonSerializer.Deserialize<DesktopHostedSessionStatus>(json);
+            if (status == null) {
+                throw new InvalidOperationException("Hosted-session legacy diagnostic artifact could not be deserialized.");
+            }
+
+            return CreateLegacyArtifact(status);
+        }
+
+        throw new InvalidOperationException("Hosted-session diagnostic artifact could not be deserialized.");
+    }
+
+    private static DesktopHostedSessionDiagnosticArtifact Normalize(DesktopHostedSessionDiagnosticArtifact artifact) {
+        artifact.Reason ??= string.Empty;
+        artifact.CreatedUtc ??= string.Empty;
+        artifact.Summary ??= string.Empty;
+        artifact.PolicyReport ??= string.Empty;
+        artifact.RetryHistoryReport ??= DesktopHostedSessionRetryHistoryReport.None;
+        artifact.RetryHistoryReport.CategoryHint ??= string.Empty;
+        artifact.RetryHistoryReport.Summary ??= string.Empty;
+        artifact.Status ??= new DesktopHostedSessionStatus();
+        artifact.Status.WindowTitle ??= string.Empty;
+        artifact.Status.LastObservedForegroundTitle ??= string.Empty;
+        artifact.Status.LastObservedForegroundClass ??= string.Empty;
+        artifact.Status.StatusText ??= string.Empty;
+        artifact.Status.ForegroundHistory ??= [];
+        return artifact;
+    }
+
+    private static DesktopHostedSessionDiagnosticArtifact CreateLegacyArtifact(DesktopHostedSessionStatus status) {
+        string categoryHint;
+        if (!string.IsNullOrWhiteSpace(status.LastObservedForegroundClass) &&
+            (status.LastObservedForegroundClass.Contains("Chrome_WidgetWin_1", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("Chrome_RenderWidgetHostHWND", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("MozillaWindowClass", StringComparison.OrdinalIgnoreCase) ||
+             status.LastObservedForegroundClass.Contains("ApplicationFrameWindow", StringComparison.OrdinalIgnoreCase))) {
+            categoryHint = "browser-electron";
+        } else if (!string.IsNullOrWhiteSpace(status.LastObservedForegroundTitle)) {
+            categoryHint = "unknown";
+        } else {
+            categoryHint = "none";
+        }
+
+        return Normalize(new DesktopHostedSessionDiagnosticArtifact {
+            FormatVersion = 0,
+            Reason = "Legacy hosted-session diagnostic artifact",
+            CreatedUtc = string.Empty,
+            Summary = BuildSummaryText(status.WindowTitle, status.StatusText, categoryHint, 0, 0, $"category='{categoryHint}'"),
+            PolicyReport = $"category='{categoryHint}'",
+            RetryHistoryReport = new DesktopHostedSessionRetryHistoryReport {
+                CategoryHint = categoryHint,
+                Summary = categoryHint == "none" ? "no retained external foreground interruption" : $"external foreground interruption observed ({categoryHint})",
+                ExternalCount = categoryHint == "none" ? 0 : 1,
+                DistinctFingerprintCount = categoryHint == "none" ? 0 : 1
+            },
+            Status = status
+        });
+    }
+
+    private static string BuildSummaryText(DesktopHostedSessionDiagnosticArtifact artifact) {
+        if (!string.IsNullOrWhiteSpace(artifact.Summary)) {
+            return artifact.Summary;
+        }
+
+        return BuildSummaryText(
+            artifact.Status.WindowTitle,
+            artifact.Status.StatusText,
+            artifact.RetryHistoryReport.CategoryHint,
+            artifact.RetryHistoryReport.ExternalCount,
+            artifact.RetryHistoryReport.DistinctFingerprintCount,
+            artifact.PolicyReport);
+    }
+
+    private static string BuildSummaryText(string windowTitle, string statusText, string categoryHint, int externalCount, int distinctFingerprintCount, string policyReport) {
+        return
+            "category='" + categoryHint + "', " +
+            "externalCount=" + externalCount + ", " +
+            "distinctFingerprintCount=" + distinctFingerprintCount + ", " +
+            "policy='" + policyReport + "', " +
+            "windowTitle='" + windowTitle + "', " +
+            "statusText='" + statusText + "'";
+    }
+
+    private static string? FindPreferredSummaryArtifactPath(string artifactPath) {
+        string directory = Path.GetDirectoryName(artifactPath) ?? string.Empty;
+        string stem = Path.GetFileNameWithoutExtension(artifactPath);
+        if (string.IsNullOrWhiteSpace(directory) || string.IsNullOrWhiteSpace(stem) || !Directory.Exists(directory)) {
+            return null;
+        }
+
+        string[] summaryPaths = Directory.GetFiles(directory, stem + "*.summary.txt", SearchOption.TopDirectoryOnly);
+        if (summaryPaths.Length == 0) {
+            return null;
+        }
+
+        Array.Sort(summaryPaths, CompareSummaryPaths);
+        return summaryPaths[0];
+    }
+
+    private static int CompareSummaryPaths(string left, string right) {
+        string leftFileName = Path.GetFileName(left);
+        string rightFileName = Path.GetFileName(right);
+        int leftSegmentCount = CountSegments(leftFileName);
+        int rightSegmentCount = CountSegments(rightFileName);
+        int comparison = leftSegmentCount.CompareTo(rightSegmentCount);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(leftFileName, rightFileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountSegments(string fileName) {
+        if (string.IsNullOrWhiteSpace(fileName)) {
+            return int.MaxValue;
+        }
+
+        int count = 0;
+        foreach (char character in fileName) {
+            if (character == '.') {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int CompareArtifactPathsByLastWriteDescending(string left, string right) {
+        DateTime leftWriteTime = File.Exists(left) ? File.GetLastWriteTimeUtc(left) : DateTime.MinValue;
+        DateTime rightWriteTime = File.Exists(right) ? File.GetLastWriteTimeUtc(right) : DateTime.MinValue;
+        int comparison = rightWriteTime.CompareTo(leftWriteTime);
+        if (comparison != 0) {
+            return comparison;
+        }
+
+        return string.Compare(right, left, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticRecord.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopHostedSessionDiagnosticRecord.cs
@@ -1,0 +1,64 @@
+namespace DesktopManager.PowerShell;
+
+/// <summary>Represents a hosted-session diagnostic artifact resolved for PowerShell output.</summary>
+public sealed class DesktopHostedSessionDiagnosticRecord {
+    /// <summary>
+    /// <para type="description">Path to the resolved hosted-session JSON artifact.</para>
+    /// </summary>
+    public string ArtifactPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Path to the preferred companion summary artifact when one exists.</para>
+    /// </summary>
+    public string SummaryPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Resolved summary text, preferring the companion summary file when available.</para>
+    /// </summary>
+    public string SummaryText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Artifact reason string recorded by the hosted-session harness.</para>
+    /// </summary>
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Artifact creation time in UTC when available.</para>
+    /// </summary>
+    public string CreatedUtc { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Retry-history category hint such as browser-electron, mixed, or none.</para>
+    /// </summary>
+    public string RetryHistoryCategory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Compact retry-history summary text when available.</para>
+    /// </summary>
+    public string RetryHistorySummary { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Count of retry attempts that observed an external foreground interruption.</para>
+    /// </summary>
+    public int RetryHistoryExternalCount { get; set; }
+
+    /// <summary>
+    /// <para type="description">Count of distinct external-foreground fingerprints seen during retries.</para>
+    /// </summary>
+    public int RetryHistoryDistinctFingerprintCount { get; set; }
+
+    /// <summary>
+    /// <para type="description">Structured policy report describing the observed focus-steal classification.</para>
+    /// </summary>
+    public string PolicyReport { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Window title recorded in the diagnostic status payload.</para>
+    /// </summary>
+    public string WindowTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <para type="description">Status text recorded by the hosted-session harness.</para>
+    /// </summary>
+    public string StatusText { get; set; } = string.Empty;
+}

--- a/Sources/DesktopManager.PowerShell/DesktopHostedSessionRetryHistoryReport.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopHostedSessionRetryHistoryReport.cs
@@ -1,0 +1,13 @@
+namespace DesktopManager.PowerShell;
+
+internal sealed class DesktopHostedSessionRetryHistoryReport {
+    public static DesktopHostedSessionRetryHistoryReport None { get; } = new();
+
+    public string CategoryHint { get; set; } = string.Empty;
+
+    public string Summary { get; set; } = string.Empty;
+
+    public int ExternalCount { get; set; }
+
+    public int DistinctFingerprintCount { get; set; }
+}

--- a/Sources/DesktopManager.PowerShell/DesktopHostedSessionStatus.cs
+++ b/Sources/DesktopManager.PowerShell/DesktopHostedSessionStatus.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace DesktopManager.PowerShell;
+
+internal sealed class DesktopHostedSessionStatus {
+    public string WindowTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundTitle { get; set; } = string.Empty;
+
+    public string LastObservedForegroundClass { get; set; } = string.Empty;
+
+    public string StatusText { get; set; } = string.Empty;
+
+    public List<string> ForegroundHistory { get; set; } = [];
+}

--- a/Sources/DesktopManager.Tests/CliApplicationTests.cs
+++ b/Sources/DesktopManager.Tests/CliApplicationTests.cs
@@ -68,6 +68,7 @@ public class CliApplicationTests {
     [DataRow("control-target")]
     [DataRow("layout")]
     [DataRow("snapshot")]
+    [DataRow("diagnostic")]
     [DataRow("workflow")]
     [DataRow("mcp")]
     /// <summary>
@@ -92,6 +93,7 @@ public class CliApplicationTests {
     [DataRow("control-target")]
     [DataRow("layout")]
     [DataRow("snapshot")]
+    [DataRow("diagnostic")]
     [DataRow("workflow")]
     [DataRow("mcp")]
     /// <summary>
@@ -234,6 +236,36 @@ public class CliApplicationTests {
         Assert.AreEqual(string.Empty, standardOutput);
         StringAssert.Contains(standardError, "Error: Option '--position-tolerance-px' expects an integer value.");
         StringAssert.Contains(standardError, "desktopmanager - Windows desktop automation CLI");
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the hosted-session diagnostic CLI command reads the newest artifact via repository-root resolution.
+    /// </summary>
+    public void Run_DiagnosticHostedSessionSummaryOnly_WritesSummaryToStandardOutput() {
+        string repositoryRoot = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "CliDiagnostic", Guid.NewGuid().ToString("N"));
+        string artifactDirectory = Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+        Directory.CreateDirectory(artifactDirectory);
+        File.WriteAllText(Path.Combine(repositoryRoot, "DesktopManager.sln"), string.Empty);
+
+        string artifactPath = Path.Combine(artifactDirectory, "sample.json");
+        File.WriteAllText(artifactPath, """
+{"FormatVersion":1,"Reason":"Test artifact","CreatedUtc":"2026-03-24T08:00:00Z","Summary":"summary from json","PolicyReport":"category='none'","RetryHistoryReport":{"CategoryHint":"none","Summary":"no retained external foreground interruption","ExternalCount":0,"DistinctFingerprintCount":0},"Status":{"WindowTitle":"DesktopManager Test App","StatusText":"Waiting for focus","ForegroundHistory":[]}}
+""");
+        File.WriteAllText(Path.Combine(artifactDirectory, "sample.summary.txt"), "summary from sidecar");
+
+        string originalCurrentDirectory = Environment.CurrentDirectory;
+        Environment.CurrentDirectory = repositoryRoot;
+        try {
+            (int exitCode, string standardOutput, string standardError) = RunCli("diagnostic", "hosted-session", "--summary-only");
+
+            Assert.AreEqual(0, exitCode);
+            StringAssert.Contains(standardOutput, "summary from sidecar");
+            Assert.AreEqual(string.Empty, standardError);
+        } finally {
+            Environment.CurrentDirectory = originalCurrentDirectory;
+            Directory.Delete(repositoryRoot, true);
+        }
     }
 
     private static (int ExitCode, string StandardOutput, string StandardError) RunCli(params string[] args) {

--- a/Sources/DesktopManager.Tests/DiagnosticCommandOutputTests.cs
+++ b/Sources/DesktopManager.Tests/DiagnosticCommandOutputTests.cs
@@ -1,0 +1,68 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI hosted-session diagnostic text output.
+/// </summary>
+public class DiagnosticCommandOutputTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures summary-only output writes the preferred summary text.
+    /// </summary>
+    public void WriteSummary_WritesSummaryText() {
+        var result = new global::DesktopManager.Cli.HostedSessionDiagnosticResult {
+            SummaryText = "summary from sidecar"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.DiagnosticCommands.WriteSummary(result, writer);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.AreEqual("summary from sidecar" + System.Environment.NewLine, writer.ToString());
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures full output includes artifact metadata, retry-history details, and status fields.
+    /// </summary>
+    public void WriteDiagnosticResult_WritesRichDiagnosticSummary() {
+        var result = new global::DesktopManager.Cli.HostedSessionDiagnosticResult {
+            ArtifactPath = @"C:\Artifacts\HostedSessionTyping\sample.json",
+            SummaryPath = @"C:\Artifacts\HostedSessionTyping\sample.summary.txt",
+            SummaryText = "summary from sidecar",
+            Reason = "Interactive session stayed noisy.",
+            CreatedUtc = "2026-03-24T08:00:00Z",
+            RetryHistoryCategory = "browser-electron",
+            RetryHistorySummary = "same external foreground interruption repeated",
+            RetryHistoryExternalCount = 2,
+            RetryHistoryDistinctFingerprintCount = 1,
+            PolicyReport = "category='browser-electron'",
+            WindowTitle = "DesktopManager Test App",
+            StatusText = "Waiting for focus"
+        };
+
+        using var writer = new StringWriter();
+
+        int exitCode = global::DesktopManager.Cli.DiagnosticCommands.WriteDiagnosticResult(result, writer);
+        string output = writer.ToString();
+
+        Assert.AreEqual(0, exitCode);
+        StringAssert.Contains(output, @"C:\Artifacts\HostedSessionTyping\sample.json");
+        StringAssert.Contains(output, @"- SummaryPath: C:\Artifacts\HostedSessionTyping\sample.summary.txt");
+        StringAssert.Contains(output, "- Summary: summary from sidecar");
+        StringAssert.Contains(output, "- Reason: Interactive session stayed noisy.");
+        StringAssert.Contains(output, "- CreatedUtc: 2026-03-24T08:00:00Z");
+        StringAssert.Contains(output, "- RetryHistoryCategory: browser-electron");
+        StringAssert.Contains(output, "- RetryHistorySummary: same external foreground interruption repeated");
+        StringAssert.Contains(output, "- RetryHistoryExternalCount: 2");
+        StringAssert.Contains(output, "- RetryHistoryDistinctFingerprintCount: 1");
+        StringAssert.Contains(output, "- PolicyReport: category='browser-electron'");
+        StringAssert.Contains(output, "- WindowTitle: DesktopManager Test App");
+        StringAssert.Contains(output, "- StatusText: Waiting for focus");
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/HelpTextTests.cs
+++ b/Sources/DesktopManager.Tests/HelpTextTests.cs
@@ -16,6 +16,7 @@ public class HelpTextTests {
     [DataRow("control-target", "Control-target commands:")]
     [DataRow("layout", "Layout commands:")]
     [DataRow("snapshot", "Snapshot commands:")]
+    [DataRow("diagnostic", "Diagnostic commands:")]
     [DataRow("workflow", "Workflow commands:")]
     [DataRow("mcp", "MCP commands:")]
     /// <summary>
@@ -55,6 +56,7 @@ public class HelpTextTests {
             "control-target",
             "layout",
             "snapshot",
+            "diagnostic",
             "workflow",
             "mcp"
         }) {

--- a/Sources/DesktopManager.Tests/HostedSessionDiagnosticReaderCliTests.cs
+++ b/Sources/DesktopManager.Tests/HostedSessionDiagnosticReaderCliTests.cs
@@ -1,0 +1,59 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for CLI hosted-session diagnostic reader behavior.
+/// </summary>
+public class HostedSessionDiagnosticReaderCliTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the CLI reader prefers the sidecar summary artifact and maps retry-history fields.
+    /// </summary>
+    public void Load_PrefersSummaryArtifactAndMapsFields() {
+        string directory = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "CliHostedSessionReader", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            string artifactPath = Path.Combine(directory, "sample.json");
+            File.WriteAllText(artifactPath, """
+{"FormatVersion":1,"Reason":"Test artifact","CreatedUtc":"2026-03-24T08:00:00Z","Summary":"summary from json","PolicyReport":"category='mixed'","RetryHistoryReport":{"CategoryHint":"mixed","Summary":"mixed focus contention","ExternalCount":3,"DistinctFingerprintCount":2},"Status":{"WindowTitle":"DesktopManager Test App","StatusText":"Waiting for focus","ForegroundHistory":[]}}
+""");
+            File.WriteAllText(Path.Combine(directory, "sample.summary.txt"), "summary from sidecar");
+
+            global::DesktopManager.Cli.HostedSessionDiagnosticResult result =
+                global::DesktopManager.Cli.HostedSessionDiagnosticReader.Load(artifactPath);
+
+            Assert.AreEqual(artifactPath, result.ArtifactPath);
+            Assert.AreEqual("summary from sidecar", result.SummaryText);
+            Assert.AreEqual("mixed", result.RetryHistoryCategory);
+            Assert.AreEqual(3, result.RetryHistoryExternalCount);
+            Assert.AreEqual(2, result.RetryHistoryDistinctFingerprintCount);
+            Assert.AreEqual("DesktopManager Test App", result.WindowTitle);
+        } finally {
+            Directory.Delete(directory, true);
+        }
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures repository-root discovery resolves the artifact folder from nested directories.
+    /// </summary>
+    public void TryFindRepositoryRoot_FromNestedDirectory_ReturnsRepositoryRoot() {
+        string repositoryRoot = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", "CliRepoRoot", Guid.NewGuid().ToString("N"));
+        string nestedDirectory = Path.Combine(repositoryRoot, "Sources", "DesktopManager.Cli");
+        Directory.CreateDirectory(nestedDirectory);
+        File.WriteAllText(Path.Combine(repositoryRoot, "DesktopManager.sln"), string.Empty);
+
+        try {
+            bool found = global::DesktopManager.Cli.HostedSessionDiagnosticReader.TryFindRepositoryRoot(nestedDirectory, out string resolvedRoot);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual(repositoryRoot, resolvedRoot);
+        } finally {
+            Directory.Delete(repositoryRoot, true);
+        }
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/PowerShellControlMutationTests.cs
+++ b/Sources/DesktopManager.Tests/PowerShellControlMutationTests.cs
@@ -1,0 +1,113 @@
+#if NET8_0_OR_GREATER
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for PowerShell control mutation verification records and cmdlet defaults.
+/// </summary>
+public class PowerShellControlMutationTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures PowerShell control failure records distinguish verification failures from plain mutation failures.
+    /// </summary>
+    public void CreateFailureRecord_MapsVerificationState() {
+        var requestedControl = new WindowControlInfo {
+            Handle = new IntPtr(0x1234),
+            ParentWindowHandle = new IntPtr(0x4321),
+            ClassName = "Edit",
+            Text = "Editor"
+        };
+
+        global::DesktopManager.PowerShell.DesktopControlMutationRecord verifiedFailure =
+            global::DesktopManager.PowerShell.DesktopControlMutationVerifier.CreateFailureRecord(
+                "set-text",
+                requestedControl,
+                "Verification mismatch.",
+                verificationPerformed: true);
+        global::DesktopManager.PowerShell.DesktopControlMutationRecord plainFailure =
+            global::DesktopManager.PowerShell.DesktopControlMutationVerifier.CreateFailureRecord(
+                "set-text",
+                requestedControl,
+                "Mutation call failed.",
+                verificationPerformed: false);
+
+        Assert.IsFalse(verifiedFailure.Success);
+        Assert.IsTrue(verifiedFailure.VerificationPerformed);
+        Assert.AreEqual(false, verifiedFailure.Verified);
+        Assert.AreEqual("error", verifiedFailure.VerificationMode);
+        Assert.AreEqual("Edit", verifiedFailure.RequestedControl.ClassName);
+
+        Assert.IsFalse(plainFailure.Success);
+        Assert.IsFalse(plainFailure.VerificationPerformed);
+        Assert.IsNull(plainFailure.Verified);
+        Assert.AreEqual(string.Empty, plainFailure.VerificationMode);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures PowerShell control mutation records preserve observed evidence for operator feedback.
+    /// </summary>
+    public void DesktopControlMutationRecord_StoresObservedEvidence() {
+        var requestedControl = new WindowControlInfo {
+            Handle = new IntPtr(0x1234),
+            ParentWindowHandle = new IntPtr(0x4321),
+            ClassName = "Edit",
+            Text = "Editor"
+        };
+        var observedControl = new WindowControlInfo {
+            Handle = new IntPtr(0x1234),
+            ParentWindowHandle = new IntPtr(0x4321),
+            ClassName = "Edit",
+            Text = "Editor",
+            Value = "Hello world"
+        };
+        var parentWindow = new WindowInfo {
+            Handle = new IntPtr(0x4321),
+            Title = "DesktopManager Command Surface",
+            ProcessId = 42
+        };
+
+        var record = new global::DesktopManager.PowerShell.DesktopControlMutationRecord {
+            Action = "set-text",
+            Success = true,
+            VerificationPerformed = true,
+            Verified = true,
+            VerificationMode = "text",
+            VerificationSummary = "Observed the requested postcondition after 'set-text'.",
+            RequestedControl = requestedControl,
+            ObservedControl = observedControl,
+            ParentWindow = parentWindow,
+            VerificationNotes = new[] { "Control text matched." }
+        };
+
+        Assert.AreEqual("set-text", record.Action);
+        Assert.AreEqual(true, record.Verified);
+        Assert.AreEqual("text", record.VerificationMode);
+        Assert.AreEqual("Edit", record.RequestedControl.ClassName);
+        Assert.AreEqual("Hello world", record.ObservedControl.Value);
+        Assert.AreEqual("DesktopManager Command Surface", record.ParentWindow.Title);
+        Assert.AreEqual(1, record.VerificationNotes.Count);
+    }
+
+    [DataTestMethod]
+    [DataRow("CmdletInvokeDesktopControlClick")]
+    [DataRow("CmdletSendDesktopControlKey")]
+    [DataRow("CmdletSetDesktopControlCheck")]
+    [DataRow("CmdletSetDesktopControlText")]
+    /// <summary>
+    /// Ensures control mutation cmdlets expose the shared verification and pass-through options.
+    /// </summary>
+    public void ControlMutationCmdlets_ExposeSharedVerificationParameters(string typeName) {
+        Type? cmdletType = Type.GetType($"DesktopManager.PowerShell.{typeName}, DesktopManager.PowerShell", throwOnError: true);
+        Assert.IsNotNull(cmdletType);
+
+        object? instance = Activator.CreateInstance(cmdletType);
+        System.Reflection.PropertyInfo? verifyProperty = cmdletType.GetProperty("Verify");
+        System.Reflection.PropertyInfo? passThruProperty = cmdletType.GetProperty("PassThru");
+
+        Assert.IsNotNull(instance);
+        Assert.IsNotNull(verifyProperty);
+        Assert.IsNotNull(passThruProperty);
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/PowerShellHostedSessionDiagnosticTests.cs
+++ b/Sources/DesktopManager.Tests/PowerShellHostedSessionDiagnosticTests.cs
@@ -1,0 +1,87 @@
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for the hosted-session diagnostic PowerShell reader and cmdlet surface.
+/// </summary>
+public class PowerShellHostedSessionDiagnosticTests {
+    [TestMethod]
+    /// <summary>
+    /// Ensures the PowerShell reader prefers the companion summary file when one exists.
+    /// </summary>
+    public void HostedSessionDiagnosticReader_PrefersSummaryArtifact() {
+        string repositoryRoot = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", Guid.NewGuid().ToString("N"));
+        string artifactDirectory = Path.Combine(repositoryRoot, "Artifacts", "HostedSessionTyping");
+        Directory.CreateDirectory(artifactDirectory);
+        File.WriteAllText(Path.Combine(repositoryRoot, "DesktopManager.sln"), string.Empty);
+
+        string artifactPath = Path.Combine(artifactDirectory, "20260324-101500000-sample.json");
+        string summaryPath = Path.Combine(artifactDirectory, "20260324-101500000-sample.browser-electron.summary.txt");
+
+        File.WriteAllText(artifactPath, JsonSerializer.Serialize(new {
+            FormatVersion = 1,
+            Reason = "Hosted-session sample",
+            CreatedUtc = "2026-03-24T10:15:00Z",
+            Summary = "json summary",
+            PolicyReport = "category='browser-electron'",
+            RetryHistoryReport = new {
+                CategoryHint = "browser-electron",
+                Summary = "same culprit repeated",
+                ExternalCount = 2,
+                DistinctFingerprintCount = 1
+            },
+            Status = new {
+                WindowTitle = "Remote session",
+                StatusText = "foreground contention"
+            }
+        }));
+        File.WriteAllText(summaryPath, "preferred summary");
+
+        global::DesktopManager.PowerShell.DesktopHostedSessionDiagnosticRecord record =
+            global::DesktopManager.PowerShell.DesktopHostedSessionDiagnosticReader.LoadLatest(
+                global::DesktopManager.PowerShell.DesktopHostedSessionDiagnosticReader.GetHostedSessionArtifactDirectory(repositoryRoot));
+
+        Assert.AreEqual(artifactPath, record.ArtifactPath);
+        Assert.AreEqual(summaryPath, record.SummaryPath);
+        Assert.AreEqual("preferred summary", record.SummaryText);
+        Assert.AreEqual("browser-electron", record.RetryHistoryCategory);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures repository-root discovery finds the repo marker from a nested working directory.
+    /// </summary>
+    public void HostedSessionDiagnosticReader_FindsRepositoryRootFromNestedDirectory() {
+        string repositoryRoot = Path.Combine(Path.GetTempPath(), "DesktopManager.Tests", Guid.NewGuid().ToString("N"));
+        string nestedDirectory = Path.Combine(repositoryRoot, "Sources", "DesktopManager.PowerShell");
+        Directory.CreateDirectory(nestedDirectory);
+        File.WriteAllText(Path.Combine(repositoryRoot, "DesktopManager.sln"), string.Empty);
+
+        bool found = global::DesktopManager.PowerShell.DesktopHostedSessionDiagnosticReader.TryFindRepositoryRoot(
+            nestedDirectory,
+            out string resolvedRepositoryRoot);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(repositoryRoot, resolvedRepositoryRoot);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Ensures the hosted-session diagnostic cmdlet exposes the expected operator parameters.
+    /// </summary>
+    public void HostedSessionDiagnosticCmdlet_ExposesExpectedParameters() {
+        Type? cmdletType = Type.GetType(
+            "DesktopManager.PowerShell.CmdletGetDesktopHostedSessionDiagnostic, DesktopManager.PowerShell",
+            throwOnError: true);
+
+        Assert.IsNotNull(cmdletType);
+        Assert.IsNotNull(cmdletType.GetProperty("ArtifactPath"));
+        Assert.IsNotNull(cmdletType.GetProperty("ArtifactDirectory"));
+        Assert.IsNotNull(cmdletType.GetProperty("RepositoryRoot"));
+        Assert.IsNotNull(cmdletType.GetProperty("SummaryOnly"));
+    }
+}
+#endif

--- a/Sources/DesktopManager.Tests/TestHelper.cs
+++ b/Sources/DesktopManager.Tests/TestHelper.cs
@@ -131,6 +131,22 @@ internal static class TestHelper {
     }
 
     /// <summary>
+    /// Determines if repo-owned harness window tests should be skipped.
+    /// </summary>
+    public static bool ShouldSkipOwnedWindowUiTests() {
+        if (ShouldSkipUITests()) {
+            return true;
+        }
+
+        if (Environment.GetEnvironmentVariable("RUN_OWNED_WINDOW_UI_TESTS") == "true" ||
+            Environment.GetEnvironmentVariable("DESKTOPMANAGER_RUN_OWNED_WINDOW_UI_TESTS") == "true") {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Determines if system-wide desktop state tests should be skipped.
     /// </summary>
     public static bool ShouldSkipSystemDesktopChangeTests() {
@@ -202,6 +218,17 @@ internal static class TestHelper {
     public static void RequireOwnedWindowUiTests() {
         RequireInteractive();
         RequireInteractiveDesktopSession();
+        if (ShouldSkipOwnedWindowUiTests()) {
+            Assert.Inconclusive("Owned-window UI tests skipped. Set RUN_OWNED_WINDOW_UI_TESTS=true (or DESKTOPMANAGER_RUN_OWNED_WINDOW_UI_TESTS=true) together with RUN_UI_TESTS=true to run.");
+        }
+    }
+
+    /// <summary>
+    /// Skips owned-window mutation tests unless desktop-changing execution is explicitly enabled.
+    /// </summary>
+    public static void RequireOwnedWindowMutationTests() {
+        RequireOwnedWindowUiTests();
+        RequireDesktopChanges();
     }
 
     /// <summary>

--- a/Sources/DesktopManager.Tests/TestHelper.cs
+++ b/Sources/DesktopManager.Tests/TestHelper.cs
@@ -274,6 +274,7 @@ internal static class TestHelper {
     /// Skips tests that intentionally steal foreground focus unless explicitly enabled.
     /// </summary>
     public static void RequireForegroundWindowUiTests() {
+        RequireOwnedWindowUiTests();
         RequireDesktopChanges();
         if (ShouldSkipForegroundWindowUiTests()) {
             Assert.Inconclusive("Foreground-window UI tests skipped. Set RUN_FOREGROUND_UI_TESTS=true (or DESKTOPMANAGER_RUN_FOREGROUND_UI_TESTS=true) to run.");

--- a/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
+++ b/Sources/DesktopManager.Tests/WindowActivationPositioningTests.cs
@@ -18,7 +18,7 @@ public class WindowActivationPositioningTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position Harness");
 

--- a/Sources/DesktopManager.Tests/WindowLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/WindowLayoutTests.cs
@@ -19,7 +19,7 @@ public class WindowLayoutTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         string title = $"Layout Harness {System.Guid.NewGuid():N}";
         var fullLayoutPath = System.IO.Path.GetTempFileName();

--- a/Sources/DesktopManager.Tests/WindowPositionTests.cs
+++ b/Sources/DesktopManager.Tests/WindowPositionTests.cs
@@ -18,7 +18,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Position RoundTrip Harness");
 
@@ -41,7 +41,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager ZOrder Harness");
 
@@ -81,7 +81,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Same Monitor Harness");
 
@@ -105,7 +105,7 @@ public class WindowPositionTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         var monitors = new Monitors().GetMonitors();
         if (monitors.Count < 2) {

--- a/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStateHelpersTests.cs
@@ -16,7 +16,7 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager State Harness");
 
@@ -40,7 +40,7 @@ public class WindowStateHelpersTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager OnScreen Harness");
 

--- a/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowStyleModificationTests.cs
@@ -39,7 +39,7 @@ public class WindowStyleModificationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Style Harness");
 

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -57,7 +57,7 @@ public class WindowTopMostActivationTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireForegroundWindowUiTests();
 
         var manager = new WindowManager();
         using WinFormsWindowHarness firstHarness = WinFormsWindowHarness.Create("DesktopManager Activation Harness 1");

--- a/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTransparencyTests.cs
@@ -17,7 +17,7 @@ public class WindowTransparencyTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Transparency Harness");
 

--- a/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
+++ b/Sources/DesktopManager.Tests/WindowVisibilityTests.cs
@@ -18,7 +18,7 @@ public class WindowVisibilityTests {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             Assert.Inconclusive("Test requires Windows");
         }
-        TestHelper.RequireOwnedWindowUiTests();
+        TestHelper.RequireOwnedWindowMutationTests();
 
         using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Visibility Harness");
 


### PR DESCRIPTION
## Summary
- add first-class hosted-session diagnostic readers for both PowerShell and CLI
- add opt-in control mutation verification records for PowerShell control cmdlets
- tighten UI test gates so owned-window UI, owned-window mutations, foreground steals, and system-wide mutations are explicitly separated
- document the new operator surfaces and verification flows

## Verification
- dotnet build Sources/DesktopManager.PowerShell/DesktopManager.PowerShell.csproj --nologo
- dotnet build Sources/DesktopManager.Cli/DesktopManager.Cli.csproj --nologo
- dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --nologo --filter "FullyQualifiedName~PowerShellControlMutationTests|FullyQualifiedName~PowerShellWindowMutationTests|FullyQualifiedName~PowerShellHostedSessionDiagnosticTests"
- dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --nologo --filter "FullyQualifiedName~DiagnosticCommandOutputTests|FullyQualifiedName~HostedSessionDiagnosticReaderCliTests|FullyQualifiedName~CliApplicationTests|FullyQualifiedName~HelpTextTests"

## Notes
- I intentionally did not rerun the full UI-capable suite after the user reported a live window being restored from maximized to normal during local testing.
- The safety fix in this PR tightens the gate split so generic RUN_UI_TESTS is no longer enough to open repo-owned harness windows; owned-window harness tests now also require RUN_OWNED_WINDOW_UI_TESTS=true, and owned-window mutations still require RUN_DESTRUCTIVE_UI_TESTS=true.