### PR TITLE
Improve monitor mapping and workspace refresh stability

### DIFF
--- a/Sources/DesktopManager.Tests/MonitorEnumerationMappingTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorEnumerationMappingTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+public class MonitorEnumerationMappingTests {
+    [TestMethod]
+    public void ResolveDisplayPathForMonitor_PrefersExactDeviceIdMatchOverOrdinalFallback() {
+        List<MonitorService.DisplayPathSnapshot> displayPaths = new List<MonitorService.DisplayPathSnapshot> {
+            new MonitorService.DisplayPathSnapshot {
+                AdapterDeviceName = @"\\.\DISPLAY1",
+                AdapterStateFlags = DisplayDeviceStateFlags.AttachedToDesktop,
+                MonitorDeviceId = @"\\?\DISPLAY#WRONG"
+            },
+            new MonitorService.DisplayPathSnapshot {
+                AdapterDeviceName = @"\\.\DISPLAY4",
+                AdapterStateFlags = DisplayDeviceStateFlags.AttachedToDesktop,
+                MonitorDeviceId = @"\\?\DISPLAY#TARGET"
+            }
+        };
+
+        RECT bounds = new RECT {
+            Left = 3000,
+            Top = 0,
+            Right = 6000,
+            Bottom = 2160
+        };
+
+        MonitorService.DisplayPathSnapshot? resolved = MonitorService.ResolveDisplayPathForMonitor(
+            displayPaths,
+            @"\\?\DISPLAY#TARGET",
+            bounds,
+            fallbackIndex: 0);
+
+        Assert.IsNotNull(resolved);
+        Assert.AreEqual(@"\\.\DISPLAY4", resolved.AdapterDeviceName);
+    }
+
+    [TestMethod]
+    public void ResolveDisplayPathForMonitor_FallsBackToAttachedDesktopBoundsWhenDeviceIdIsUnknown() {
+        List<MonitorService.DisplayPathSnapshot> displayPaths = new List<MonitorService.DisplayPathSnapshot> {
+            new MonitorService.DisplayPathSnapshot {
+                AdapterDeviceName = @"\\.\DISPLAY1",
+                AdapterStateFlags = DisplayDeviceStateFlags.AttachedToDesktop,
+                AdapterBounds = new RECT {
+                    Left = 0,
+                    Top = 0,
+                    Right = 1920,
+                    Bottom = 1080
+                }
+            },
+            new MonitorService.DisplayPathSnapshot {
+                AdapterDeviceName = @"\\.\DISPLAY2",
+                AdapterStateFlags = DisplayDeviceStateFlags.AttachedToDesktop,
+                AdapterBounds = new RECT {
+                    Left = 1920,
+                    Top = 0,
+                    Right = 3840,
+                    Bottom = 1080
+                }
+            }
+        };
+
+        RECT bounds = new RECT {
+            Left = 1920,
+            Top = 0,
+            Right = 3840,
+            Bottom = 1080
+        };
+
+        MonitorService.DisplayPathSnapshot? resolved = MonitorService.ResolveDisplayPathForMonitor(
+            displayPaths,
+            @"\\?\DISPLAY#MISSING",
+            bounds,
+            fallbackIndex: 0);
+
+        Assert.IsNotNull(resolved);
+        Assert.AreEqual(@"\\.\DISPLAY2", resolved.AdapterDeviceName);
+    }
+}

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -32,8 +32,15 @@ public sealed class DesktopAutomationService {
     /// <summary>
     /// Gets matching monitors.
     /// </summary>
-    public IReadOnlyList<Monitor> GetMonitors(bool? connectedOnly = null, bool? primaryOnly = null, int? index = null, string? deviceId = null, string? deviceName = null) {
-        return _monitors.GetMonitors(connectedOnly: connectedOnly, primaryOnly: primaryOnly, index: index, deviceId: deviceId, deviceName: deviceName);
+    public IReadOnlyList<Monitor> GetMonitors(bool? connectedOnly = null, bool? primaryOnly = null, int? index = null, string? deviceId = null, string? deviceName = null, bool refresh = false) {
+        return _monitors.GetMonitors(connectedOnly: connectedOnly, primaryOnly: primaryOnly, index: index, deviceId: deviceId, deviceName: deviceName, refresh: refresh);
+    }
+
+    /// <summary>
+    /// Forces monitor enumeration and refreshes the cached monitor snapshot.
+    /// </summary>
+    public void RefreshMonitors() {
+        _monitors.RefreshMonitors();
     }
 
     /// <summary>

--- a/Sources/DesktopManager/MonitorService.Core.cs
+++ b/Sources/DesktopManager/MonitorService.Core.cs
@@ -74,6 +74,7 @@ public partial class MonitorService {
     public List<Monitor> GetMonitors() {
         try {
             List<Monitor> list = new List<Monitor>();
+            List<DisplayPathSnapshot> displayPaths = EnumerateDisplayPaths();
 
             var count = Execute(() => _desktopManager.GetMonitorDevicePathCount(), nameof(IDesktopManager.GetMonitorDevicePathCount));
             for (uint i = 0; i < count; i++) {
@@ -89,15 +90,13 @@ public partial class MonitorService {
                         UpdateWallpaperCache(monitor.DeviceId, monitor.Wallpaper);
                     }
 
-                    // Populate new properties
-                    DISPLAY_DEVICE d = new DISPLAY_DEVICE();
-                    d.cb = Marshal.SizeOf(d);
-                    if (MonitorNativeMethods.EnumDisplayDevices(null, i, ref d, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
-                        monitor.DeviceName = d.DeviceName;
-                        monitor.DeviceString = d.DeviceString;
-                        monitor.StateFlags = d.StateFlags;
-                        monitor.DeviceKey = d.DeviceKey;
+                    DisplayPathSnapshot? displayPath = ResolveDisplayPathForMonitor(displayPaths, monitor.DeviceId, monitor.Rect, (int)i);
+                    if (displayPath != null) {
+                        ApplyDisplayPathMetadata(monitor, displayPath);
+                    } else {
+                        monitor.StateFlags = DisplayDeviceStateFlags.AttachedToDesktop;
                     }
+
                     monitor.LoadEdidInfo();
                 }
                 list.Add(monitor);

--- a/Sources/DesktopManager/MonitorService.Enumeration.cs
+++ b/Sources/DesktopManager/MonitorService.Enumeration.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace DesktopManager;
+
+public partial class MonitorService {
+    internal sealed class DisplayPathSnapshot {
+        public string AdapterDeviceName { get; set; } = string.Empty;
+        public string AdapterDeviceString { get; set; } = string.Empty;
+        public DisplayDeviceStateFlags AdapterStateFlags { get; set; }
+        public string AdapterDeviceKey { get; set; } = string.Empty;
+        public RECT? AdapterBounds { get; set; }
+        public string MonitorDeviceId { get; set; } = string.Empty;
+        public string MonitorDeviceString { get; set; } = string.Empty;
+        public string MonitorDeviceKey { get; set; } = string.Empty;
+    }
+
+    internal static DisplayPathSnapshot? ResolveDisplayPathForMonitor(
+        IReadOnlyList<DisplayPathSnapshot> displayPaths,
+        string deviceId,
+        RECT bounds,
+        int fallbackIndex) {
+        if (!string.IsNullOrWhiteSpace(deviceId)) {
+            foreach (DisplayPathSnapshot displayPath in displayPaths) {
+                if (MonitorDeviceIdsMatch(displayPath.MonitorDeviceId, deviceId)) {
+                    return displayPath;
+                }
+            }
+        }
+
+        foreach (DisplayPathSnapshot displayPath in displayPaths) {
+            if ((displayPath.AdapterStateFlags & DisplayDeviceStateFlags.AttachedToDesktop) == 0) {
+                continue;
+            }
+
+            if (displayPath.AdapterBounds.HasValue && AreSameBounds(displayPath.AdapterBounds.Value, bounds)) {
+                return displayPath;
+            }
+        }
+
+        if (fallbackIndex >= 0 && fallbackIndex < displayPaths.Count) {
+            return displayPaths[fallbackIndex];
+        }
+
+        return null;
+    }
+
+    private static List<DisplayPathSnapshot> EnumerateDisplayPaths() {
+        List<DisplayPathSnapshot> displayPaths = new List<DisplayPathSnapshot>();
+        Dictionary<string, RECT> adapterBounds = EnumerateAdapterBounds();
+
+        uint adapterIndex = 0;
+        while (true) {
+            DISPLAY_DEVICE adapter = new DISPLAY_DEVICE();
+            adapter.cb = Marshal.SizeOf(adapter);
+
+            if (!MonitorNativeMethods.EnumDisplayDevices(null, adapterIndex, ref adapter, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
+                break;
+            }
+
+            RECT? bounds = null;
+            if (!string.IsNullOrWhiteSpace(adapter.DeviceName) &&
+                adapterBounds.TryGetValue(adapter.DeviceName, out RECT adapterRect)) {
+                bounds = adapterRect;
+            }
+
+            uint monitorIndex = 0;
+            bool childFound = false;
+            while (true) {
+                DISPLAY_DEVICE monitor = new DISPLAY_DEVICE();
+                monitor.cb = Marshal.SizeOf(monitor);
+
+                if (!MonitorNativeMethods.EnumDisplayDevices(adapter.DeviceName, monitorIndex, ref monitor, (uint)EnumDisplayDevicesFlags.EDD_GET_DEVICE_INTERFACE_NAME)) {
+                    break;
+                }
+
+                childFound = true;
+                displayPaths.Add(new DisplayPathSnapshot {
+                    AdapterDeviceName = adapter.DeviceName ?? string.Empty,
+                    AdapterDeviceString = adapter.DeviceString ?? string.Empty,
+                    AdapterStateFlags = adapter.StateFlags,
+                    AdapterDeviceKey = adapter.DeviceKey ?? string.Empty,
+                    AdapterBounds = bounds,
+                    MonitorDeviceId = monitor.DeviceID ?? string.Empty,
+                    MonitorDeviceString = monitor.DeviceString ?? string.Empty,
+                    MonitorDeviceKey = monitor.DeviceKey ?? string.Empty
+                });
+                monitorIndex++;
+            }
+
+            if (!childFound) {
+                displayPaths.Add(new DisplayPathSnapshot {
+                    AdapterDeviceName = adapter.DeviceName ?? string.Empty,
+                    AdapterDeviceString = adapter.DeviceString ?? string.Empty,
+                    AdapterStateFlags = adapter.StateFlags,
+                    AdapterDeviceKey = adapter.DeviceKey ?? string.Empty,
+                    AdapterBounds = bounds
+                });
+            }
+
+            adapterIndex++;
+        }
+
+        return displayPaths;
+    }
+
+    private static Dictionary<string, RECT> EnumerateAdapterBounds() {
+        Dictionary<string, RECT> boundsByAdapter = new Dictionary<string, RECT>(StringComparer.OrdinalIgnoreCase);
+
+        MonitorNativeMethods.MonitorEnumProc proc = (IntPtr hMonitor, IntPtr hdc, ref RECT rect, IntPtr lparam) => {
+            MONITORINFOEX info = new MONITORINFOEX();
+            info.cbSize = Marshal.SizeOf<MONITORINFOEX>();
+            if (MonitorNativeMethods.GetMonitorInfo(hMonitor, ref info) &&
+                !string.IsNullOrWhiteSpace(info.szDevice) &&
+                !boundsByAdapter.ContainsKey(info.szDevice)) {
+                boundsByAdapter.Add(info.szDevice, info.rcMonitor);
+            }
+
+            return true;
+        };
+
+        MonitorNativeMethods.EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, proc, IntPtr.Zero);
+        return boundsByAdapter;
+    }
+
+    private static void ApplyDisplayPathMetadata(Monitor monitor, DisplayPathSnapshot displayPath) {
+        monitor.DeviceName = displayPath.AdapterDeviceName;
+        monitor.DeviceString = !string.IsNullOrWhiteSpace(displayPath.MonitorDeviceString)
+            ? displayPath.MonitorDeviceString
+            : displayPath.AdapterDeviceString;
+        monitor.StateFlags = displayPath.AdapterStateFlags;
+        monitor.DeviceKey = !string.IsNullOrWhiteSpace(displayPath.MonitorDeviceKey)
+            ? displayPath.MonitorDeviceKey
+            : displayPath.AdapterDeviceKey;
+    }
+
+    private static bool MonitorDeviceIdsMatch(string candidate, string deviceId) {
+        return !string.IsNullOrWhiteSpace(candidate) &&
+               !string.IsNullOrWhiteSpace(deviceId) &&
+               string.Equals(candidate.Trim(), deviceId.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool AreSameBounds(RECT left, RECT right) {
+        return left.Left == right.Left &&
+               left.Top == right.Top &&
+               left.Right == right.Right &&
+               left.Bottom == right.Bottom;
+    }
+}

--- a/Sources/DesktopManager/Monitors.cs
+++ b/Sources/DesktopManager/Monitors.cs
@@ -34,10 +34,13 @@ public class Monitors {
     /// <param name="index">The index of the monitor to return.</param>
     /// <param name="deviceId">The device ID of the monitor to return.</param>
     /// <param name="deviceName">The device name of the monitor to return.</param>
+    /// <param name="refresh">When true, forces a fresh monitor snapshot before filtering.</param>
     /// <returns>A list of monitors that match the specified filters.</returns>
-    public List<Monitor> GetMonitors(bool? connectedOnly = null, bool? primaryOnly = null, int? index = null, string? deviceId = null, string? deviceName = null) {
+    public List<Monitor> GetMonitors(bool? connectedOnly = null, bool? primaryOnly = null, int? index = null, string? deviceId = null, string? deviceName = null, bool refresh = false) {
         var monitorsReturn = new List<Monitor>();
-        var monitors = _cachedMonitors ??= _monitorService.GetMonitors();
+        var monitors = refresh || _cachedMonitors == null
+            ? _cachedMonitors = _monitorService.GetMonitors()
+            : _cachedMonitors;
         foreach (var monitor in monitors) {
             if (connectedOnly != null && connectedOnly.Value && !monitor.IsConnected) {
                 continue;

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -78,6 +78,7 @@ public partial class WindowManager {
             }
 
             var windows = new List<WindowInfo>();
+            List<Monitor> connectedMonitors = _monitors.GetMonitors(connectedOnly: true, refresh: true);
             for (int index = 0; index < handles.Count; index++) {
                 var handle = handles[index];
                 if (options.ActiveWindow && handle != activeWindowHandle) {
@@ -151,7 +152,7 @@ public partial class WindowManager {
                     continue;
                 }
 
-                var windowInfo = BuildWindowInfo(handle, title, windowProcessId, windowThreadId, ownerHandle, isCloaked, isVisible, index);
+                var windowInfo = BuildWindowInfo(handle, title, windowProcessId, windowThreadId, ownerHandle, isCloaked, isVisible, index, connectedMonitors);
 
                 if (options.State.HasValue && windowInfo.State != options.State.Value) {
                     continue;
@@ -211,7 +212,7 @@ public partial class WindowManager {
                 var ownerHandle = MonitorNativeMethods.GetWindow(handle, MonitorNativeMethods.GW_OWNER);
                 var title = WindowTextHelper.GetWindowText(handle);
                 bool isVisible = MonitorNativeMethods.IsWindowVisible(handle);
-                windows.Add(BuildWindowInfo(handle, title, windowProcessId, windowThreadId, ownerHandle, isCloaked, isVisible, index));
+                windows.Add(BuildWindowInfo(handle, title, windowProcessId, windowThreadId, ownerHandle, isCloaked, isVisible, index, connectedMonitors: null));
             }
 
             return windows;
@@ -354,7 +355,7 @@ public partial class WindowManager {
             return text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        private WindowInfo BuildWindowInfo(IntPtr handle, string? title, uint windowProcessId, uint windowThreadId, IntPtr ownerHandle, bool isCloaked, bool isVisible, int zOrder) {
+        private WindowInfo BuildWindowInfo(IntPtr handle, string? title, uint windowProcessId, uint windowThreadId, IntPtr ownerHandle, bool isCloaked, bool isVisible, int zOrder, IReadOnlyList<Monitor>? connectedMonitors) {
             var windowInfo = new WindowInfo {
                 Title = title ?? string.Empty,
                 Handle = handle,
@@ -389,10 +390,13 @@ public partial class WindowManager {
                 windowInfo.Right = rect.Right;
                 windowInfo.Bottom = rect.Bottom;
 
-                // Find which monitor this window is primarily on
-                var monitors = _monitors.GetMonitors();
+                IReadOnlyList<Monitor> monitors = connectedMonitors ?? _monitors.GetMonitors(connectedOnly: true, refresh: true);
                 foreach (var monitor in monitors) {
-                    var monitorRect = monitor.GetMonitorBounds();
+                    RECT monitorRect = monitor.Rect;
+                    if (monitorRect.Right <= monitorRect.Left || monitorRect.Bottom <= monitorRect.Top) {
+                        continue;
+                    }
+
                     // Check if window center point is within monitor bounds
                     int windowCenterX = (rect.Left + rect.Right) / 2;
                     int windowCenterY = (rect.Top + rect.Bottom) / 2;


### PR DESCRIPTION
## Summary
- replace fragile monitor-to-details matching with device-id and bounds-aware enumeration mapping
- add explicit monitor refresh support for longer-lived sessions and automation calls
- avoid stale workspace results when monitor and window inventory is refreshed
- cover the new monitor mapping behavior with focused tests

## Validation
- dotnet test C:\\Support\\GitHub\\DesktopManager\\Sources\\DesktopManager.Tests\\DesktopManager.Tests.csproj --filter Monitor