### PR TITLE
[codex] add focused control observation and remote session support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,282 @@
+# DesktopManager + EasyControlX + Codex Plan
+
+This plan tracks the end-to-end work needed to make Windows desktop automation feel reliable for:
+
+- local operator use
+- remote controller use through EasyControlX
+- Codex-driven verification through MCP, skills, and a dedicated plugin
+
+## Status Legend
+
+- `[x]` already exists in a meaningful way
+- `[ ]` needed or not complete enough yet
+- `[-]` intentionally deferred or optional
+
+## End Goal
+
+Create a smooth, safe, and verifiable Windows automation stack where:
+
+1. `DesktopManager` is the shared desktop automation and evidence engine.
+2. `EasyControlX` is the remote session, preview, and transport layer.
+3. A Codex plugin exposes a long-lived MCP workflow for inspect -> act -> verify loops.
+4. Codex can safely verify real Windows work using screenshots, window/control inspection, targeted input, and artifact capture.
+
+## What We Have Today
+
+### DesktopManager Core
+
+- [x] Shared C# desktop automation library
+- [x] PowerShell module
+- [x] CLI surface
+- [x] MCP server hosted by the CLI
+- [x] Window inventory and selection
+- [x] Monitor inventory and geometry
+- [x] Desktop, monitor, window, and control screenshots
+- [x] Window move, snap, minimize, restore, and focus actions
+- [x] Window-relative click, drag, and scroll actions
+- [x] Named window targets
+- [x] Named control targets
+- [x] Win32 and UI Automation control inspection
+- [x] Control click, text, and key actions
+- [x] Whole-window typing and key sending
+- [x] Layout save/apply/assert support
+- [x] Snapshot save/restore support
+- [x] Mutation evidence options on newer MCP flows
+- [x] Existing DesktopManager operator skill for Codex
+
+### DesktopManager Reliability and Safety
+
+- [x] Read-only-by-default MCP mode
+- [x] Mutation gating with explicit allow flags
+- [x] Foreground-input opt-in
+- [x] Hosted-session and interactive-session awareness in the ecosystem
+- [x] Repo-owned test app for safer UI validation
+- [x] Better-than-basic window typing paths with fallback modes
+- [x] Geometry-aware window-relative mouse actions
+
+### EasyControlX Today
+
+- [x] Shared contracts package
+- [x] Windows agent
+- [x] Windows controller app
+- [x] iOS controller app
+- [x] WebSocket control channel
+- [x] Pairing and trusted-controller model
+- [x] Window inventory through DesktopManager-backed adapters
+- [x] Window actions through DesktopManager-backed adapters
+- [x] Monitor inventory through DesktopManager-backed adapters
+- [x] Desktop, monitor, and window preview endpoints
+- [x] Interactive session bridge for service-to-user-session work
+- [x] Basic pointer movement, scroll, button, text, and key commands
+
+### Codex Usage Today
+
+- [x] DesktopManager MCP can already be used for inspect-first desktop work
+- [x] DesktopManager operator skill already teaches a safe manual workflow
+- [x] Codex can already inspect windows, controls, and screenshots through MCP
+- [x] Codex can already perform some real Windows validation when the app is structurally accessible
+
+## What Is Missing
+
+### A. Remote Session Model
+
+- [ ] Define one explicit remote desktop session model shared by DesktopManager and EasyControlX
+- [ ] Support session attach modes: desktop, monitor, window, control
+- [ ] Include session metadata: bounds, DPI, scale, cursor position, active window, timestamps
+- [ ] Support session reconnect and resume
+- [ ] Support host-visible "remote session active" state
+
+### B. Live Visual Feedback
+
+- [ ] Add frame streaming, not just one-shot preview endpoints
+- [ ] Support changed-frame or throttled-frame delivery for desktop and monitor sessions
+- [ ] Support window-scoped live preview
+- [ ] Include frame metadata needed for exact coordinate mapping
+- [ ] Decide initial codec and transport shape
+- [ ] Keep one-shot screenshot endpoints as fallback and for evidence capture
+
+### C. Reliable Remote Input
+
+- [x] Add absolute pointer movement for "click what I see" workflows
+- [ ] Keep relative pointer movement for trackpad-style control
+- [ ] Add input batching and coalescing for low-latency pointer motion
+- [ ] Add pointer smoothing or rate control so high-frequency input does not feel jittery
+- [x] Add drag semantics tied to streamed-session coordinates
+- [ ] Add richer keyboard model: chords, modifiers, repeat, press/release, navigation groups
+- [x] Route window-targeted typing through DesktopManager smart input paths instead of only raw global input
+- [ ] Route control-targeted text and key actions through DesktopManager when a control is known
+
+### D. Verification-First Automation
+
+- [ ] Every remote action should be able to return structured evidence
+- [x] Capture optional before and after screenshots for important mutations
+- [x] Return resolved window/control metadata for targeted actions
+- [x] Return elapsed time, success reason, and failure reason
+- [x] Add post-action checks for active window, cursor position, or control value when applicable
+- [x] Return best-effort observed text snapshots for window-targeted `keyboard.text` acknowledgements
+- [x] Return focused-control identity in window-targeted input acknowledgements
+- [x] Return focused-control identity in `/actions/window` evidence
+- [x] Add session artifact bundles for Codex runs
+
+### E. Coordinate System and Mapping
+
+- [x] Normalize logical vs physical pixels for remote sessions
+- [x] Map preview-space coordinates to desktop-space coordinates
+- [ ] Map preview-space coordinates to window client-area coordinates
+- [ ] Handle multi-monitor offsets and mixed DPI cleanly
+- [ ] Expose coordinate conversion helpers from shared DesktopManager code
+
+### F. DesktopManager Product Work
+
+- [ ] Add a first-class remote session service in DesktopManager
+- [ ] Expose stream-friendly capture backends
+- [ ] Expose cursor position observation
+- [x] Expose active-window and focused-control observation APIs suitable for remote verification
+- [ ] Add stronger public APIs for remote-safe pointer and keyboard operations
+- [ ] Add public contracts for evidence and remote-session artifacts
+- [ ] Expand tests for real mouse movement, remote typing, and coordinate mapping
+
+### G. EasyControlX Product Work
+
+- [x] Add separate session/control contracts for streamed remote work
+- [x] Add a frame channel alongside the command channel
+- [x] Move from one-command-one-ack behavior for pointer motion to batched or non-blocking flow
+- [x] Add attach-to-window and attach-to-monitor flows in the host
+- [x] Add a first Windows controller live window session flow with streamed preview, click, and text send
+- [x] Surface live session acknowledgement evidence in the Windows controller UI
+- [ ] Add richer controller UX for remote window selection and live preview
+- [ ] Add per-capability policy distinctions for view vs input vs control-text access
+- [ ] Add host-side session prompts and visibility for sensitive access
+- [x] Expose active remote-session status through host diagnostics and controller summaries
+- [x] Show a host-side remote-session indicator in the interactive desktop session
+- [x] Distinguish host-side viewing-only versus input-active session state
+- [x] Distinguish host-side view-only versus input-enabled session permissions
+- [x] Add controller-side editing for `session.view`, `session.input`, and `window.input`
+- [x] Add controller-side editing for host-default `session.view`, `session.input`, and `window.input` exposure
+- [x] Show host baseline versus selected-controller effective remote-session access in the controller UI
+- [x] Show live session mode as `view only`, `input allowed`, or `input active` in the controller preview flow
+- [x] Show whether live session mode is host-reported or controller-inferred in the controller preview flow
+- [x] Refresh host diagnostics opportunistically during live sessions so preview mode upgrades from inferred to host-reported
+- [x] Back off live-session status polling once host-reported session diagnostics are flowing steadily
+- [x] Show live-session mode freshness in the controller so operators can judge how recent host-reported state is
+- [x] Show live-session sync cadence in the controller so operators understand fast-sync versus steady-sync behavior
+- [x] Show a live-session host-status heartbeat so operators can spot healthy versus stale diagnostics
+- [x] Show action hints when the live-session heartbeat is waiting or stale
+- [x] Add a one-click live-status refresh action for recovery without a full controller refresh
+- [x] Add a one-click live-preview refresh action for recovery without restarting the session
+- [x] Show the last manual live-session recovery result in the controller UI
+- [x] Distinguish manual recovery results from automatic live-session sync updates in the controller UI
+- [x] Highlight live-session update failures visually with a severity badge and tinted status card
+- [x] Surface live-session update severity on the preview overlay itself
+- [x] Make live-session severity badges identify whether manual recovery or background sync is the issue
+- [x] Show a short next-step action cue on the preview overlay for live-session failure states
+- [x] Add clickable preview-overlay recovery buttons for live-session status and preview refresh
+
+### H. Codex Plugin and Skills
+
+- [ ] Create a dedicated local Codex plugin for Windows verification workflows
+- [ ] Add one MCP server definition that connects to the local or remote Windows host
+- [ ] Add a primary skill for inspect -> act -> verify desktop workflows
+- [ ] Add a skill for app smoke tests on Windows
+- [ ] Add a skill for visual verification and artifact capture
+- [ ] Add bootstrap scripts for host health checks, session startup, and artifact collection
+- [ ] Make long-lived MCP sessions the default so UI Automation caches and state stay warm
+
+### I. Test Harness and Validation
+
+- [x] Expand the repo-owned test app with remote-control scenarios
+- [x] Add scenarios for live typing into real edit fields
+- [ ] Add scenarios for Chromium-style editable surfaces
+- [x] Add scenarios for drag and drop
+- [ ] Add scenarios for canvas or coordinate-driven interaction
+- [ ] Add end-to-end tests that prove "what was seen" matches "what was clicked"
+- [x] Add end-to-end tests for service-hosted remote sessions, not only in-process calls
+
+### J. Security and Policy
+
+- [ ] Split capabilities more precisely:
+- [ ] `desktop.view`
+- [ ] `window.view`
+- [ ] `desktop.input`
+- [ ] `window.input`
+- [ ] `control.text`
+- [ ] `control.keys`
+- [ ] Add stronger per-controller access policy management
+- [ ] Add audit logging for session start, stop, attach target, and sensitive actions
+- [x] Add audit logging for remote session start, stop, and attach target
+- [ ] Add policy defaults for local-only vs LAN access
+- [ ] Add safer defaults for foreground-stealing behavior
+
+### K. Documentation and Operations
+
+- [ ] Document the end-to-end architecture for DesktopManager + EasyControlX + Codex
+- [ ] Document the intended division of responsibility between the repos
+- [ ] Document the remote session lifecycle
+- [ ] Document supported verification levels: structural, visual, interactive
+- [ ] Document safe operator guidance for live desktop sessions
+- [ ] Document how to install and use the Codex plugin locally
+
+## Suggested Delivery Phases
+
+### Phase 0: Align the Architecture
+
+- [ ] Decide the division of responsibility:
+- [ ] DesktopManager owns automation, coordinates, evidence, and capture primitives
+- [ ] EasyControlX owns transport, pairing, controller UX, and remote session lifecycle
+- [ ] Codex plugin owns MCP packaging, skills, and workflow guidance
+- [ ] Freeze the first session contract shape
+- [ ] Freeze the first capability model for remote view/input/control actions
+
+### Phase 1: Make Remote Validation Practical
+
+- [ ] Add a DesktopManager remote session abstraction
+- [x] Add absolute coordinate mapping for window and monitor sessions
+- [ ] Add richer evidence objects for actions
+- [x] Add EasyControlX attach-to-window session flow
+- [x] Add throttled live preview stream for a selected window or monitor
+- [ ] Add Codex plugin skeleton with one verification skill
+
+### Phase 2: Make It Feel Smooth
+
+- [x] Add batched pointer events
+- [ ] Add non-blocking pointer move handling
+- [x] Add drag-aware streaming sessions
+- [x] Add cursor and active-window telemetry in the session stream
+- [x] Show live input verification evidence in the Windows controller during a session
+- [x] Show live frame telemetry over the Windows controller preview
+- [ ] Improve controller UX around live interaction
+
+### Phase 3: Make It Trustworthy
+
+- [ ] Add strong end-to-end harness tests
+- [ ] Add artifact bundles and replayable evidence
+- [ ] Add detailed audit logging and controller policy controls
+- [ ] Add docs and runbooks for local and LAN usage
+
+## Definition of Done
+
+The stack is "smooth butter" for Codex when all of the following are true:
+
+- [ ] Codex can start one long-lived MCP session against a Windows host
+- [ ] Codex can inspect windows, controls, and live frames in the same session
+- [ ] Codex can choose between absolute visual clicking and targeted control interaction
+- [ ] Codex can type into a selected window or control reliably
+- [ ] Codex can verify the result with structure plus screenshots
+- [ ] Codex can collect artifacts automatically when a workflow matters
+- [ ] Codex can run safely with clear host visibility, policies, and audit logs
+- [ ] The main flows are covered by repo-owned end-to-end tests
+
+## Immediate Next Recommended Steps
+
+- [ ] Agree the repo boundary and ownership model
+- [x] Design the first remote session contract
+- [ ] Add DesktopManager coordinate-mapping helpers for remote sessions
+- [x] Add EasyControlX live window-session preview stream
+- [ ] Add a minimal Codex plugin skeleton with one MCP server and one skill
+- [ ] Build one golden-path end-to-end scenario:
+- [x] launch or attach to a test app
+- [x] stream the window
+- [x] click a known field
+- [x] type text
+- [x] verify the text
+- [x] capture before and after artifacts

--- a/Sources/DesktopManager.TestApp/MainForm.cs
+++ b/Sources/DesktopManager.TestApp/MainForm.cs
@@ -15,6 +15,7 @@ namespace DesktopManager.TestApp;
 
 internal sealed class MainForm : Form {
     private const int ForegroundHistoryLimit = 12;
+    private const string DragPayloadText = "desktopmanager-drag-payload";
 
     [DllImport("user32.dll")]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
@@ -39,6 +40,10 @@ internal sealed class MainForm : Form {
     private readonly ElementHost _commandBarHost;
     private readonly WpfTextBox _commandBarTextBox;
     private readonly WinFormsLabel _statusLabel;
+    private readonly Panel _dragSourcePanel;
+    private readonly WinFormsLabel _dragSourceLabel;
+    private readonly Panel _dropTargetPanel;
+    private readonly WinFormsLabel _dropTargetLabel;
     private SecondaryFocusForm? _secondaryForm;
     private System.Windows.Forms.Timer? _statusTimer;
     private DateTime _foregroundHoldUntilUtc;
@@ -50,6 +55,10 @@ internal sealed class MainForm : Form {
     private string _lastObservedForegroundClass = string.Empty;
     private string _lastObservedForegroundChangedUtc = string.Empty;
     private string _lastCommand = string.Empty;
+    private Point _dragSourceMouseDownLocation = Point.Empty;
+    private string _droppedText = string.Empty;
+    private string _dragDropStatus = "Drag source ready.";
+    private int _dragDropCount;
     private readonly List<string> _foregroundHistory = [];
 
     public MainForm(TestAppOptions options) {
@@ -137,6 +146,66 @@ internal sealed class MainForm : Form {
         };
         closeButton.Click += (_, _) => Close();
 
+        _dragSourceLabel = new WinFormsLabel {
+            Name = "DragSourceLabel",
+            AccessibleName = "DragSource",
+            AutoSize = false,
+            Text = "Drag Source\r\nHold and drag me",
+            TextAlign = ContentAlignment.MiddleCenter,
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.FromArgb(229, 240, 255),
+            Dock = DockStyle.Fill,
+            Enabled = false
+        };
+
+        _dragSourcePanel = new Panel {
+            Name = "DragSourcePanel",
+            AccessibleName = "DragSource",
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.FromArgb(229, 240, 255),
+            Margin = new Padding(0, 0, 12, 0),
+            Width = 220,
+            Height = 88
+        };
+        _dragSourcePanel.Controls.Add(_dragSourceLabel);
+        _dragSourcePanel.MouseDown += DragSourceLabel_MouseDown;
+        _dragSourcePanel.MouseMove += DragSourceLabel_MouseMove;
+        _dragSourcePanel.MouseUp += DragSourceLabel_MouseUp;
+
+        _dropTargetLabel = new WinFormsLabel {
+            AutoSize = false,
+            Dock = DockStyle.Fill,
+            Text = "Drop Target\r\nAwaiting payload",
+            TextAlign = ContentAlignment.MiddleCenter,
+            BackColor = Color.FromArgb(239, 245, 231),
+            Enabled = false
+        };
+
+        _dropTargetPanel = new Panel {
+            Name = "DropTargetPanel",
+            AccessibleName = "DropTarget",
+            AllowDrop = true,
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.FromArgb(239, 245, 231),
+            Margin = new Padding(0),
+            Width = 220,
+            Height = 88
+        };
+        _dropTargetPanel.Controls.Add(_dropTargetLabel);
+        _dropTargetPanel.DragEnter += DropTargetPanel_DragEnter;
+        _dropTargetPanel.DragLeave += DropTargetPanel_DragLeave;
+        _dropTargetPanel.DragDrop += DropTargetPanel_DragDrop;
+
+        var dragDropPanel = new FlowLayoutPanel {
+            Dock = DockStyle.Top,
+            AutoSize = true,
+            FlowDirection = FlowDirection.LeftToRight,
+            WrapContents = false,
+            Margin = new Padding(0, 0, 0, 12)
+        };
+        dragDropPanel.Controls.Add(_dragSourcePanel);
+        dragDropPanel.Controls.Add(_dropTargetPanel);
+
         var buttonPanel = new FlowLayoutPanel {
             Dock = DockStyle.Bottom,
             FlowDirection = FlowDirection.RightToLeft,
@@ -149,9 +218,10 @@ internal sealed class MainForm : Form {
         var contentPanel = new TableLayoutPanel {
             Dock = DockStyle.Fill,
             ColumnCount = 1,
-            RowCount = 3,
+            RowCount = 5,
             Padding = new Padding(16)
         };
+        contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
         contentPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
@@ -159,7 +229,8 @@ internal sealed class MainForm : Form {
         contentPanel.Controls.Add(titleLabel, 0, 0);
         contentPanel.Controls.Add(hintLabel, 0, 1);
         contentPanel.Controls.Add(_statusLabel, 0, 2);
-        contentPanel.Controls.Add(_editorTextBox, 0, 3);
+        contentPanel.Controls.Add(dragDropPanel, 0, 3);
+        contentPanel.Controls.Add(_editorTextBox, 0, 4);
 
         Controls.Add(_commandBarHost);
         Controls.Add(contentPanel);
@@ -337,7 +408,13 @@ internal sealed class MainForm : Form {
                 EditorText = _editorTextBox.Text,
                 SecondaryText = _secondaryForm != null && !_secondaryForm.IsDisposed ? _secondaryForm.CurrentText : string.Empty,
                 CommandBarText = _commandBarTextBox.Text,
-                StatusText = _statusLabel.Text
+                StatusText = _statusLabel.Text,
+                DragPayload = DragPayloadText,
+                DroppedText = _droppedText,
+                DragDropCount = _dragDropCount,
+                DragDropStatus = _dragDropStatus,
+                DragSourceBounds = GetScreenBounds(_dragSourcePanel),
+                DropTargetBounds = GetScreenBounds(_dropTargetPanel)
             };
 
             string json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions {
@@ -473,5 +550,95 @@ internal sealed class MainForm : Form {
         if (_foregroundHistory.Count > ForegroundHistoryLimit) {
             _foregroundHistory.RemoveAt(0);
         }
+    }
+
+    private void DragSourceLabel_MouseDown(object? sender, MouseEventArgs e) {
+        if (e.Button != MouseButtons.Left) {
+            return;
+        }
+
+        _dragSourceMouseDownLocation = e.Location;
+        _dragSourcePanel.Capture = true;
+        _dragDropStatus = "Drag armed from source.";
+        WriteStatusSnapshot();
+    }
+
+    private void DragSourceLabel_MouseMove(object? sender, MouseEventArgs e) {
+        if ((e.Button & MouseButtons.Left) != MouseButtons.Left) {
+            return;
+        }
+
+        Size dragSize = SystemInformation.DragSize;
+        Rectangle dragBounds = new(
+            _dragSourceMouseDownLocation.X - dragSize.Width / 2,
+            _dragSourceMouseDownLocation.Y - dragSize.Height / 2,
+            dragSize.Width,
+            dragSize.Height);
+        if (dragBounds.Contains(e.Location)) {
+            return;
+        }
+
+        _dragDropStatus = "Dragging payload.";
+        WriteStatusSnapshot();
+        _dragSourcePanel.Capture = false;
+        DragDropEffects effect = _dragSourcePanel.DoDragDrop(DragPayloadText, DragDropEffects.Copy);
+        _dragDropStatus = effect == DragDropEffects.None ? "Drag canceled." : "Drag completed.";
+        WriteStatusSnapshot();
+    }
+
+    private void DragSourceLabel_MouseUp(object? sender, MouseEventArgs e) {
+        _dragSourcePanel.Capture = false;
+    }
+
+    private void DropTargetPanel_DragEnter(object? sender, DragEventArgs e) {
+        if (e.Data?.GetDataPresent(DataFormats.UnicodeText) == true || e.Data?.GetDataPresent(DataFormats.Text) == true) {
+            e.Effect = DragDropEffects.Copy;
+            _dragDropStatus = "Drop target armed.";
+            _dropTargetPanel.BackColor = Color.FromArgb(214, 235, 204);
+            _dropTargetLabel.BackColor = _dropTargetPanel.BackColor;
+            WriteStatusSnapshot();
+            return;
+        }
+
+        e.Effect = DragDropEffects.None;
+    }
+
+    private void DropTargetPanel_DragLeave(object? sender, EventArgs e) {
+        _dropTargetPanel.BackColor = Color.FromArgb(239, 245, 231);
+        _dropTargetLabel.BackColor = _dropTargetPanel.BackColor;
+        _dragDropStatus = "Drag left drop target.";
+        WriteStatusSnapshot();
+    }
+
+    private void DropTargetPanel_DragDrop(object? sender, DragEventArgs e) {
+        string droppedText = e.Data?.GetData(DataFormats.UnicodeText)?.ToString()
+            ?? e.Data?.GetData(DataFormats.Text)?.ToString()
+            ?? string.Empty;
+        _droppedText = droppedText;
+        _dragDropCount++;
+        _dragDropStatus = string.IsNullOrWhiteSpace(droppedText) ? "Drop completed with empty payload." : "Drop completed.";
+        _dropTargetPanel.BackColor = Color.FromArgb(198, 227, 184);
+        _dropTargetLabel.BackColor = _dropTargetPanel.BackColor;
+        _dropTargetLabel.Text = string.IsNullOrWhiteSpace(droppedText)
+            ? "Drop Target\r\nReceived empty payload"
+            : "Drop Target\r\nReceived: " + droppedText;
+        _statusLabel.Text = string.IsNullOrWhiteSpace(droppedText)
+            ? "Drop completed with empty payload."
+            : "Dropped payload: " + droppedText;
+        WriteStatusSnapshot();
+    }
+
+    private static TestAppControlBounds GetScreenBounds(Control control) {
+        if (!control.IsHandleCreated) {
+            return new TestAppControlBounds();
+        }
+
+        Rectangle screenBounds = control.RectangleToScreen(control.ClientRectangle);
+        return new TestAppControlBounds {
+            Left = screenBounds.Left,
+            Top = screenBounds.Top,
+            Width = screenBounds.Width,
+            Height = screenBounds.Height
+        };
     }
 }

--- a/Sources/DesktopManager.TestApp/TestAppControlBounds.cs
+++ b/Sources/DesktopManager.TestApp/TestAppControlBounds.cs
@@ -1,0 +1,11 @@
+namespace DesktopManager.TestApp;
+
+internal sealed class TestAppControlBounds {
+    public int Left { get; set; }
+
+    public int Top { get; set; }
+
+    public int Width { get; set; }
+
+    public int Height { get; set; }
+}

--- a/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
+++ b/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
@@ -46,4 +46,16 @@ internal sealed class TestAppStatusSnapshot {
     public string CommandBarText { get; set; } = string.Empty;
 
     public string StatusText { get; set; } = string.Empty;
+
+    public string DragPayload { get; set; } = string.Empty;
+
+    public string DroppedText { get; set; } = string.Empty;
+
+    public int DragDropCount { get; set; }
+
+    public string DragDropStatus { get; set; } = string.Empty;
+
+    public TestAppControlBounds DragSourceBounds { get; set; } = new();
+
+    public TestAppControlBounds DropTargetBounds { get; set; } = new();
 }

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -99,6 +99,47 @@ public sealed class DesktopAutomationService {
     }
 
     /// <summary>
+    /// Observes the currently focused control for the first matching window when it can be resolved.
+    /// </summary>
+    public DesktopFocusedControlObservation? GetFocusedControlObservation(WindowQueryOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        WindowInfo window = ResolveWindows(options, all: false)[0];
+        IntPtr focusedHandle = GetFocusedControlHandle(window.Handle);
+        if (focusedHandle == IntPtr.Zero) {
+            return null;
+        }
+
+        WindowControlInfo? control = _windowManager.GetControls(
+            window,
+            new WindowControlQueryOptions {
+                Handle = focusedHandle,
+                UseUiAutomation = true,
+                IncludeUiAutomation = true
+            }).FirstOrDefault();
+
+        string liveText = WindowTextHelper.GetWindowText(focusedHandle);
+        string controlText = !string.IsNullOrWhiteSpace(liveText)
+            ? liveText
+            : control?.Text ?? string.Empty;
+
+        return new DesktopFocusedControlObservation {
+            WindowHandle = window.Handle,
+            WindowTitle = window.Title,
+            FocusedHandle = focusedHandle,
+            ClassName = control?.ClassName ?? string.Empty,
+            AutomationId = control?.AutomationId ?? string.Empty,
+            ControlType = control?.ControlType ?? string.Empty,
+            Text = controlText,
+            Value = control?.Value ?? string.Empty,
+            IsKeyboardFocusable = control?.IsKeyboardFocusable,
+            IsEnabled = control?.IsEnabled
+        };
+    }
+
+    /// <summary>
     /// Moves and optionally resizes matching windows.
     /// </summary>
     public IReadOnlyList<WindowInfo> MoveWindows(WindowQueryOptions options, int? monitorIndex, int? x, int? y, int? width, int? height, bool activate, bool all = false) {
@@ -127,6 +168,21 @@ public sealed class DesktopAutomationService {
         }
 
         return RefreshWindows(windows);
+    }
+
+    private static IntPtr GetFocusedControlHandle(IntPtr windowHandle) {
+        uint threadId = MonitorNativeMethods.GetWindowThreadProcessId(windowHandle, out _);
+        if (threadId == 0) {
+            return IntPtr.Zero;
+        }
+
+        MonitorNativeMethods.GUITHREADINFO threadInfo = new() {
+            cbSize = System.Runtime.InteropServices.Marshal.SizeOf<MonitorNativeMethods.GUITHREADINFO>()
+        };
+
+        return MonitorNativeMethods.GetGUIThreadInfo(threadId, ref threadInfo)
+            ? threadInfo.hwndFocus
+            : IntPtr.Zero;
     }
 
     /// <summary>

--- a/Sources/DesktopManager/DesktopFocusedControlObservation.cs
+++ b/Sources/DesktopManager/DesktopFocusedControlObservation.cs
@@ -1,0 +1,57 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Describes the currently focused child control for a target window when it can be resolved.
+/// </summary>
+public sealed class DesktopFocusedControlObservation
+{
+    /// <summary>
+    /// Gets or sets the parent window handle.
+    /// </summary>
+    public IntPtr WindowHandle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parent window title.
+    /// </summary>
+    public string WindowTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the focused child handle.
+    /// </summary>
+    public IntPtr FocusedHandle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the focused control class name.
+    /// </summary>
+    public string ClassName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the focused control automation identifier.
+    /// </summary>
+    public string AutomationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the focused control type.
+    /// </summary>
+    public string ControlType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the focused control text when available.
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the focused control value when available.
+    /// </summary>
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the focused control can receive keyboard focus.
+    /// </summary>
+    public bool? IsKeyboardFocusable { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the focused control is enabled.
+    /// </summary>
+    public bool? IsEnabled { get; set; }
+}

--- a/Sources/DesktopManager/DesktopRemoteSessionModels.cs
+++ b/Sources/DesktopManager/DesktopRemoteSessionModels.cs
@@ -1,0 +1,150 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Identifies the kind of remote desktop target a session is attached to.
+/// </summary>
+public enum DesktopRemoteSessionTargetKind
+{
+    /// <summary>
+    /// The session is attached to the combined desktop.
+    /// </summary>
+    Desktop,
+
+    /// <summary>
+    /// The session is attached to a single monitor.
+    /// </summary>
+    Monitor,
+
+    /// <summary>
+    /// The session is attached to a single window.
+    /// </summary>
+    Window,
+
+    /// <summary>
+    /// The session is attached to a specific control.
+    /// </summary>
+    Control
+}
+
+/// <summary>
+/// Describes the source viewport used by a remote desktop session.
+/// </summary>
+public sealed class DesktopRemoteSessionViewport
+{
+    /// <summary>
+    /// Gets or sets the left coordinate in desktop space.
+    /// </summary>
+    public int Left { get; set; }
+
+    /// <summary>
+    /// Gets or sets the top coordinate in desktop space.
+    /// </summary>
+    public int Top { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width in desktop pixels.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height in desktop pixels.
+    /// </summary>
+    public int Height { get; set; }
+
+    /// <summary>
+    /// Gets or sets the horizontal DPI of the source viewport.
+    /// </summary>
+    public int DpiX { get; set; } = 96;
+
+    /// <summary>
+    /// Gets or sets the vertical DPI of the source viewport.
+    /// </summary>
+    public int DpiY { get; set; } = 96;
+
+    /// <summary>
+    /// Gets or sets the X-axis scale factor applied to the source viewport.
+    /// </summary>
+    public double ScaleX { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the Y-axis scale factor applied to the source viewport.
+    /// </summary>
+    public double ScaleY { get; set; } = 1;
+}
+
+/// <summary>
+/// Describes the resolved target for a remote desktop session.
+/// </summary>
+public sealed class DesktopRemoteSessionTarget
+{
+    /// <summary>
+    /// Gets or sets the target kind.
+    /// </summary>
+    public DesktopRemoteSessionTargetKind TargetKind { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional monitor identifier.
+    /// </summary>
+    public string? MonitorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional window identifier.
+    /// </summary>
+    public string? WindowId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional control identifier.
+    /// </summary>
+    public string? ControlId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional human-readable target name.
+    /// </summary>
+    public string? DisplayName { get; set; }
+}
+
+/// <summary>
+/// Represents a remote desktop session that can be used for view, input, and verification work.
+/// </summary>
+public sealed class DesktopRemoteSessionInfo
+{
+    /// <summary>
+    /// Gets or sets the unique session identifier.
+    /// </summary>
+    public string SessionId { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// Gets or sets the resolved session target.
+    /// </summary>
+    public DesktopRemoteSessionTarget Target { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the source viewport used by the session.
+    /// </summary>
+    public DesktopRemoteSessionViewport SourceViewport { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the encoded frame width.
+    /// </summary>
+    public int FrameWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the encoded frame height.
+    /// </summary>
+    public int FrameHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether cursor telemetry is included with session frames.
+    /// </summary>
+    public bool CursorIncluded { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the active window identifier when it is known.
+    /// </summary>
+    public string? ActiveWindowId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the session creation time.
+    /// </summary>
+    public DateTimeOffset CreatedUtc { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Sources/DesktopManager/MonitorNativeMethods.Window.cs
+++ b/Sources/DesktopManager/MonitorNativeMethods.Window.cs
@@ -249,11 +249,74 @@ public static partial class MonitorNativeMethods
     public static extern IntPtr GetForegroundWindow();
 
     /// <summary>
+    /// Retrieves information about the active window and focused control for a GUI thread.
+    /// </summary>
+    /// <param name="idThread">The GUI thread identifier.</param>
+    /// <param name="threadInfo">Receives the GUI thread information.</param>
+    /// <returns>True when information is available; otherwise false.</returns>
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetGUIThreadInfo(uint idThread, ref GUITHREADINFO threadInfo);
+
+    /// <summary>
     /// Retrieves the identifier of the calling thread.
     /// </summary>
     /// <returns>The current thread identifier.</returns>
     [DllImport("kernel32.dll")]
     public static extern uint GetCurrentThreadId();
+
+    /// <summary>
+    /// Describes the active window and caret state for a GUI thread.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GUITHREADINFO
+    {
+        /// <summary>Structure size.</summary>
+        public int cbSize;
+
+        /// <summary>Thread state flags.</summary>
+        public uint flags;
+
+        /// <summary>Active window handle.</summary>
+        public IntPtr hwndActive;
+
+        /// <summary>Focused window handle.</summary>
+        public IntPtr hwndFocus;
+
+        /// <summary>Capture window handle.</summary>
+        public IntPtr hwndCapture;
+
+        /// <summary>Menu owner handle.</summary>
+        public IntPtr hwndMenuOwner;
+
+        /// <summary>Move/size window handle.</summary>
+        public IntPtr hwndMoveSize;
+
+        /// <summary>Caret window handle.</summary>
+        public IntPtr hwndCaret;
+
+        /// <summary>Caret rectangle.</summary>
+        public GUIRECT rcCaret;
+    }
+
+    /// <summary>
+    /// Describes a native rectangle.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GUIRECT
+    {
+        /// <summary>Left edge.</summary>
+        public int Left;
+
+        /// <summary>Top edge.</summary>
+        public int Top;
+
+        /// <summary>Right edge.</summary>
+        public int Right;
+
+        /// <summary>Bottom edge.</summary>
+        public int Bottom;
+    }
 
     /// <summary>
     /// Attaches or detaches the input processing mechanism of one thread to that of another thread.


### PR DESCRIPTION
## Summary
- add remote session model support and focused-control observation APIs used by paired remote-session work
- extend DesktopManager.TestApp status/control metadata for richer remote-session verification scenarios
- document the end-to-end remote session roadmap in PLAN.md

## Validation
- dotnet build .\Sources\DesktopManager\DesktopManager.csproj
- dotnet build .\Sources\DesktopManager.TestApp\DesktopManager.TestApp.csproj

## Notes
- paired with the EasyControlX PR for live session transport, controller UX, verification, and recovery tooling
- manual desktop smoke testing has not been run yet