### PR TITLE
feat(remote-session): ✨ add shared coordinate mapper foundations

### DIFF
--- a/Sources/DesktopManager.TestApp/MainForm.cs
+++ b/Sources/DesktopManager.TestApp/MainForm.cs
@@ -413,6 +413,7 @@ internal sealed class MainForm : Form {
                 DroppedText = _droppedText,
                 DragDropCount = _dragDropCount,
                 DragDropStatus = _dragDropStatus,
+                EditorBounds = GetScreenBounds(_editorTextBox),
                 DragSourceBounds = GetScreenBounds(_dragSourcePanel),
                 DropTargetBounds = GetScreenBounds(_dropTargetPanel)
             };

--- a/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
+++ b/Sources/DesktopManager.TestApp/TestAppStatusSnapshot.cs
@@ -55,6 +55,8 @@ internal sealed class TestAppStatusSnapshot {
 
     public string DragDropStatus { get; set; } = string.Empty;
 
+    public TestAppControlBounds EditorBounds { get; set; } = new();
+
     public TestAppControlBounds DragSourceBounds { get; set; } = new();
 
     public TestAppControlBounds DropTargetBounds { get; set; } = new();

--- a/Sources/DesktopManager.Tests/DesktopRemoteSessionCoordinateMapperTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopRemoteSessionCoordinateMapperTests.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace DesktopManager.Tests;
+
+[TestClass]
+/// <summary>
+/// Tests for <see cref="DesktopRemoteSessionCoordinateMapper"/>.
+/// </summary>
+public class DesktopRemoteSessionCoordinateMapperTests
+{
+    [TestMethod]
+    /// <summary>
+    /// Frame coordinates should map into the configured source viewport.
+    /// </summary>
+    public void MapFrameToSourceViewport_MapsIntoViewport() {
+        DesktopRemoteSessionInfo session = CreateSession(
+            left: 100,
+            top: 200,
+            viewportWidth: 1280,
+            viewportHeight: 720,
+            frameWidth: 640,
+            frameHeight: 360);
+
+        (int x, int y) = DesktopRemoteSessionCoordinateMapper.MapFrameToSourceViewport(session, 320, 180);
+
+        Assert.AreEqual(741, x);
+        Assert.AreEqual(561, y);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Out-of-range frame coordinates should clamp into the source viewport bounds.
+    /// </summary>
+    public void MapFrameToSourceViewport_ClampsOutsideTheFrame() {
+        DesktopRemoteSessionInfo session = CreateSession(
+            left: -50,
+            top: 25,
+            viewportWidth: 1920,
+            viewportHeight: 1080,
+            frameWidth: 960,
+            frameHeight: 540);
+
+        (int x, int y) = DesktopRemoteSessionCoordinateMapper.MapFrameToSourceViewport(session, 4000, -200);
+
+        Assert.AreEqual(1869, x);
+        Assert.AreEqual(25, y);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Source viewport coordinates should map back into frame space.
+    /// </summary>
+    public void MapSourceViewportToFrame_MapsBackIntoFrame() {
+        DesktopRemoteSessionInfo session = CreateSession(
+            left: 100,
+            top: 200,
+            viewportWidth: 1280,
+            viewportHeight: 720,
+            frameWidth: 640,
+            frameHeight: 360);
+
+        (int x, int y) = DesktopRemoteSessionCoordinateMapper.MapSourceViewportToFrame(session, 741, 561);
+
+        Assert.AreEqual(320, x);
+        Assert.AreEqual(180, y);
+    }
+
+    private static DesktopRemoteSessionInfo CreateSession(
+        int left,
+        int top,
+        int viewportWidth,
+        int viewportHeight,
+        int frameWidth,
+        int frameHeight) {
+        return new DesktopRemoteSessionInfo {
+            SessionId = "session-1",
+            Target = new DesktopRemoteSessionTarget {
+                TargetKind = DesktopRemoteSessionTargetKind.Window,
+                WindowId = "0x123",
+                DisplayName = "Target"
+            },
+            SourceViewport = new DesktopRemoteSessionViewport {
+                Left = left,
+                Top = top,
+                Width = viewportWidth,
+                Height = viewportHeight,
+                DpiX = 96,
+                DpiY = 96,
+                ScaleX = 1,
+                ScaleY = 1
+            },
+            FrameWidth = frameWidth,
+            FrameHeight = frameHeight,
+            CursorIncluded = true,
+            ActiveWindowId = "0x123",
+            CreatedUtc = new DateTimeOffset(2026, 03, 29, 14, 00, 00, TimeSpan.Zero)
+        };
+    }
+}

--- a/Sources/DesktopManager.Tests/HotkeyServiceTests.cs
+++ b/Sources/DesktopManager.Tests/HotkeyServiceTests.cs
@@ -13,6 +13,8 @@ namespace DesktopManager.Tests;
 #endif
 /// <summary>Tests for <see cref="HotkeyService"/>.</summary>
 public class HotkeyServiceTests {
+    private const string HotkeyTestMutexName = @"Local\DesktopManager.HotkeyServiceTests.HotkeyCallback_FiresOnMessage";
+
     [TestMethod]
     /// <summary>Callback fires when hotkey message is posted.</summary>
     public void HotkeyCallback_FiresOnMessage() {
@@ -24,6 +26,18 @@ public class HotkeyServiceTests {
             Assert.Inconclusive("Test requires Windows");
         }
 
+        using Mutex mutex = new(false, HotkeyTestMutexName);
+        bool hasHandle;
+        try {
+            hasHandle = mutex.WaitOne(TimeSpan.FromSeconds(10));
+        } catch (AbandonedMutexException) {
+            hasHandle = true;
+        }
+
+        if (!hasHandle) {
+            Assert.Inconclusive("Timed out waiting for the shared hotkey test mutex.");
+        }
+
         var service = HotkeyService.Instance;
         bool called = false;
         int id = service.RegisterHotkey(HotkeyModifiers.Control, VirtualKey.VK_F24, () => called = true);
@@ -33,6 +47,7 @@ public class HotkeyServiceTests {
             Assert.IsTrue(called);
         } finally {
             service.UnregisterHotkey(id);
+            mutex.ReleaseMutex();
         }
     }
 }

--- a/Sources/DesktopManager/DesktopRemoteSessionCoordinateMapper.cs
+++ b/Sources/DesktopManager/DesktopRemoteSessionCoordinateMapper.cs
@@ -1,0 +1,86 @@
+namespace DesktopManager;
+
+/// <summary>
+/// Maps coordinates between encoded remote-session frames and the source viewport in desktop space.
+/// </summary>
+public static class DesktopRemoteSessionCoordinateMapper
+{
+    /// <summary>
+    /// Maps a coordinate from encoded frame space into the source viewport in desktop space.
+    /// </summary>
+    /// <param name="session">Remote session metadata describing the source viewport and frame size.</param>
+    /// <param name="frameX">X coordinate within the encoded frame.</param>
+    /// <param name="frameY">Y coordinate within the encoded frame.</param>
+    /// <returns>The mapped coordinate in source viewport space.</returns>
+    public static (int X, int Y) MapFrameToSourceViewport(DesktopRemoteSessionInfo session, int frameX, int frameY)
+    {
+        if (session == null)
+        {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        int boundedFrameWidth = Math.Max(1, session.FrameWidth);
+        int boundedFrameHeight = Math.Max(1, session.FrameHeight);
+        int clampedX = Clamp(frameX, 0, boundedFrameWidth - 1);
+        int clampedY = Clamp(frameY, 0, boundedFrameHeight - 1);
+
+        int viewportWidth = Math.Max(1, session.SourceViewport.Width);
+        int viewportHeight = Math.Max(1, session.SourceViewport.Height);
+
+        int mappedX = session.SourceViewport.Left + ScaleCoordinate(clampedX, boundedFrameWidth, viewportWidth);
+        int mappedY = session.SourceViewport.Top + ScaleCoordinate(clampedY, boundedFrameHeight, viewportHeight);
+        return (mappedX, mappedY);
+    }
+
+    /// <summary>
+    /// Maps a coordinate from source viewport space in desktop coordinates into encoded frame space.
+    /// </summary>
+    /// <param name="session">Remote session metadata describing the source viewport and frame size.</param>
+    /// <param name="sourceX">X coordinate within the source viewport in desktop space.</param>
+    /// <param name="sourceY">Y coordinate within the source viewport in desktop space.</param>
+    /// <returns>The mapped coordinate in encoded frame space.</returns>
+    public static (int X, int Y) MapSourceViewportToFrame(DesktopRemoteSessionInfo session, int sourceX, int sourceY)
+    {
+        if (session == null)
+        {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        int viewportWidth = Math.Max(1, session.SourceViewport.Width);
+        int viewportHeight = Math.Max(1, session.SourceViewport.Height);
+        int localX = Clamp(sourceX - session.SourceViewport.Left, 0, viewportWidth - 1);
+        int localY = Clamp(sourceY - session.SourceViewport.Top, 0, viewportHeight - 1);
+
+        int frameWidth = Math.Max(1, session.FrameWidth);
+        int frameHeight = Math.Max(1, session.FrameHeight);
+        return (
+            ScaleCoordinate(localX, viewportWidth, frameWidth),
+            ScaleCoordinate(localY, viewportHeight, frameHeight));
+    }
+
+    private static int ScaleCoordinate(int value, int sourceSize, int targetSize)
+    {
+        if (sourceSize <= 1 || targetSize <= 1)
+        {
+            return 0;
+        }
+
+        double ratio = (double)value / (sourceSize - 1);
+        return (int)Math.Round((targetSize - 1) * ratio, MidpointRounding.AwayFromZero);
+    }
+
+    private static int Clamp(int value, int minimum, int maximum)
+    {
+        if (value < minimum)
+        {
+            return minimum;
+        }
+
+        if (value > maximum)
+        {
+            return maximum;
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Summary:
- add a shared DesktopRemoteSessionCoordinateMapper with targeted tests
- expose test-app editor bounds for remote-session golden paths
- harden HotkeyServiceTests against parallel hotkey registration collisions

Validation:
- DesktopManager.Tests full run completed cleanly on net8.0-windows and net10.0-windows in local validation
- focused HotkeyServiceTests and DesktopRemoteSessionCoordinateMapperTests passed on net472, net8.0-windows, and net10.0-windows