### PR TITLE
[codex] preserve visible window state during activation

### DIFF
--- a/Sources/DesktopManager.Tests/DesktopAutomationAssertionTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationAssertionTests.cs
@@ -1,6 +1,4 @@
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -9,6 +7,8 @@ namespace DesktopManager.Tests;
 /// Tests for shared desktop automation assertions.
 /// </summary>
 public class DesktopAutomationAssertionTests {
+    private const int FocusTimeoutMilliseconds = 5000;
+
     [TestMethod]
     /// <summary>
     /// Ensures a query by the active window handle reports that the window exists.
@@ -20,17 +20,15 @@ public class DesktopAutomationAssertionTests {
         TestHelper.RequireForegroundWindowUiTests();
 
         var automation = new DesktopAutomationService();
-        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Assertion Harness Exists");
-        new WindowManager().ActivateWindow(harness.Window);
-        Application.DoEvents();
-        Thread.Sleep(100);
+        using var session = DesktopManagerTestAppSession.Start("assertion-exists");
+        session.FocusEditorWindow(FocusTimeoutMilliseconds);
 
         WindowInfo? activeWindow = automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
         if (activeWindow == null) {
             Assert.Inconclusive("No active window could be resolved.");
         }
 
-        Assert.AreEqual(harness.Window.Handle, activeWindow.Handle, "Expected the owned harness window to be active for the assertion test.");
+        Assert.AreEqual(session.WindowHandle, activeWindow.Handle, "Expected the repo-owned DesktopManager test app window to be active for the assertion test.");
 
         bool result = automation.WindowExists(new WindowQueryOptions {
             Handle = activeWindow.Handle,
@@ -54,17 +52,15 @@ public class DesktopAutomationAssertionTests {
         TestHelper.RequireForegroundWindowUiTests();
 
         var automation = new DesktopAutomationService();
-        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager Assertion Harness Active");
-        new WindowManager().ActivateWindow(harness.Window);
-        Application.DoEvents();
-        Thread.Sleep(100);
+        using var session = DesktopManagerTestAppSession.Start("assertion-active");
+        session.FocusEditorWindow(FocusTimeoutMilliseconds);
 
         WindowInfo? activeWindow = automation.GetActiveWindow(includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
         if (activeWindow == null) {
             Assert.Inconclusive("No active window could be resolved.");
         }
 
-        Assert.AreEqual(harness.Window.Handle, activeWindow.Handle, "Expected the owned harness window to be active for the assertion test.");
+        Assert.AreEqual(session.WindowHandle, activeWindow.Handle, "Expected the repo-owned DesktopManager test app window to be active for the assertion test.");
 
         bool result = automation.ActiveWindowMatches(new WindowQueryOptions {
             Handle = activeWindow.Handle,

--- a/Sources/DesktopManager.Tests/DesktopManagerTestAppSession.cs
+++ b/Sources/DesktopManager.Tests/DesktopManagerTestAppSession.cs
@@ -144,6 +144,39 @@ internal sealed class DesktopManagerTestAppSession : IDisposable {
         throw new AssertInconclusiveException(failureMessage);
     }
 
+    public WindowInfo ResolveWindowInfo() {
+        WindowInfo? window = new DesktopAutomationService().GetWindow(
+            _windowHandle,
+            includeHidden: true,
+            includeCloaked: true,
+            includeOwned: true,
+            includeEmptyTitles: true);
+        if (window == null) {
+            throw new AssertInconclusiveException("The DesktopManager test app window could not be resolved by handle.");
+        }
+
+        return window;
+    }
+
+    public DesktopManagerTestAppStatus WaitForEditorForeground(int timeoutMilliseconds, string failureMessage) {
+        return WaitForStatus(
+            status => status.IsForegroundWindow &&
+                string.Equals(status.ActiveSurface, "editor", StringComparison.OrdinalIgnoreCase),
+            timeoutMilliseconds,
+            failureMessage);
+    }
+
+    public DesktopManagerTestAppStatus FocusEditorWindow(int timeoutMilliseconds) {
+        RequestFocusEditor();
+        try {
+            new DesktopAutomationService().FocusWindows(CreateWindowQuery());
+        } catch (InvalidOperationException) {
+            // The test app keeps retrying focus from its own UI thread.
+        }
+
+        return WaitForEditorForeground(timeoutMilliseconds, "The DesktopManager test app editor did not become the foreground target.");
+    }
+
     public string WriteStatusArtifact(string reason, string? summaryText = null, string? summaryCategoryHint = null) {
         return WriteStatusArtifact(reason, null, null, summaryText, summaryCategoryHint);
     }

--- a/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
+++ b/Sources/DesktopManager.Tests/WindowManagerFilterTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -13,6 +12,8 @@ namespace DesktopManager.Tests;
 /// Tests for WindowManager filtering features.
 /// </summary>
 public class WindowManagerFilterTests {
+    private const int FocusTimeoutMilliseconds = 5000;
+
     [TestCleanup]
     public void Cleanup() {
         TestHelper.KillAllNotepads();
@@ -186,16 +187,12 @@ public class WindowManagerFilterTests {
         }
         TestHelper.RequireForegroundWindowUiTests();
 
-        using WinFormsWindowHarness firstHarness = WinFormsWindowHarness.Create($"Foreground Harness 1 {Guid.NewGuid():N}");
-        using WinFormsWindowHarness secondHarness = WinFormsWindowHarness.Create($"Foreground Harness 2 {Guid.NewGuid():N}");
+        using var firstSession = DesktopManagerTestAppSession.Start("foreground-filter-first");
+        using var secondSession = DesktopManagerTestAppSession.Start("foreground-filter-second");
 
         var manager = new WindowManager();
-        manager.ActivateWindow(secondHarness.Window);
-        Application.DoEvents();
-        System.Threading.Thread.Sleep(100);
-        manager.ActivateWindow(firstHarness.Window);
-        Application.DoEvents();
-        System.Threading.Thread.Sleep(100);
+        secondSession.FocusEditorWindow(FocusTimeoutMilliseconds);
+        firstSession.FocusEditorWindow(FocusTimeoutMilliseconds);
 
         IntPtr foreground = MonitorNativeMethods.GetForegroundWindow();
         if (foreground == IntPtr.Zero) {
@@ -207,7 +204,7 @@ public class WindowManagerFilterTests {
             Assert.Inconclusive("The active window could not be resolved from enumeration");
         }
 
-        Assert.AreEqual(firstHarness.Window.Handle, foreground, "Expected the owned harness window to be foreground.");
+        Assert.AreEqual(firstSession.WindowHandle, foreground, "Expected the repo-owned DesktopManager test app window to be foreground.");
         Assert.AreEqual(foreground, window.Handle, "Expected GetActiveWindow to resolve the owned foreground harness window.");
     }
 

--- a/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
+++ b/Sources/DesktopManager.Tests/WindowTopMostActivationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Windows.Forms;
 
 namespace DesktopManager.Tests;
 
@@ -10,6 +9,8 @@ namespace DesktopManager.Tests;
 /// Test class for WindowTopMostActivationTests.
 /// </summary>
 public class WindowTopMostActivationTests {
+    private const int FocusTimeoutMilliseconds = 5000;
+
     [TestMethod]
     [TestCategory("UITest")]
     /// <summary>
@@ -21,29 +22,30 @@ public class WindowTopMostActivationTests {
         }
         TestHelper.RequireForegroundWindowUiTests();
 
-        using WinFormsWindowHarness harness = WinFormsWindowHarness.Create("DesktopManager TopMost Harness");
+        using var session = DesktopManagerTestAppSession.Start("topmost-toggle");
+        WindowInfo window = session.ResolveWindowInfo();
 
         var manager = new WindowManager();
 
-        long originalStyle = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        long originalStyle = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         bool wasTop = (originalStyle & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
         // Set to opposite of current state
-        manager.SetWindowTopMost(harness.Window, !wasTop);
+        manager.SetWindowTopMost(window, !wasTop);
 
         // Give the system time to process the change
         Thread.Sleep(100);
 
-        long toggled = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        long toggled = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         bool newIsTop = (toggled & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
         Assert.AreEqual(!wasTop, newIsTop, $"Expected topmost to change from {wasTop} to {!wasTop}, but got {newIsTop}");
 
         // Test changing back
-        manager.SetWindowTopMost(harness.Window, wasTop);
+        manager.SetWindowTopMost(window, wasTop);
         Thread.Sleep(100);
 
-        long restored = MonitorNativeMethods.GetWindowLongPtr(harness.Window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
+        long restored = MonitorNativeMethods.GetWindowLongPtr(window.Handle, MonitorNativeMethods.GWL_EXSTYLE).ToInt64();
         bool restoredIsTop = (restored & MonitorNativeMethods.WS_EX_TOPMOST) != 0;
 
         Assert.AreEqual(wasTop, restoredIsTop, $"Expected topmost to restore to {wasTop}, but got {restoredIsTop}");
@@ -60,27 +62,57 @@ public class WindowTopMostActivationTests {
         TestHelper.RequireForegroundWindowUiTests();
 
         var manager = new WindowManager();
-        using WinFormsWindowHarness firstHarness = WinFormsWindowHarness.Create("DesktopManager Activation Harness 1");
-        using WinFormsWindowHarness secondHarness = WinFormsWindowHarness.Create("DesktopManager Activation Harness 2");
+        using var firstSession = DesktopManagerTestAppSession.Start("activation-first");
+        using var secondSession = DesktopManagerTestAppSession.Start("activation-second");
+        WindowInfo firstWindow = firstSession.ResolveWindowInfo();
+        WindowInfo secondWindow = secondSession.ResolveWindowInfo();
 
         try {
-            manager.ActivateWindow(secondHarness.Window);
-            Application.DoEvents();
-            Thread.Sleep(100);
+            manager.ActivateWindow(secondWindow);
+            secondSession.WaitForEditorForeground(
+                FocusTimeoutMilliseconds,
+                "The second repo-owned DesktopManager test app window did not become the foreground target.");
 
-            manager.ActivateWindow(firstHarness.Window);
-            Application.DoEvents();
-            Thread.Sleep(100);
+            manager.ActivateWindow(firstWindow);
+            firstSession.WaitForEditorForeground(
+                FocusTimeoutMilliseconds,
+                "The first repo-owned DesktopManager test app window did not become the foreground target.");
 
             IntPtr newForeground = MonitorNativeMethods.GetForegroundWindow();
             if (newForeground == IntPtr.Zero) {
                 Assert.Inconclusive("GetForegroundWindow returned 0 after activation attempt.");
             }
 
-            Assert.AreEqual(firstHarness.Window.Handle, newForeground,
-                $"Expected the owned harness window to become foreground. Expected: {firstHarness.Window.Handle:X8}, Actual: {newForeground:X8}");
+            Assert.AreEqual(firstSession.WindowHandle, newForeground,
+                $"Expected the repo-owned DesktopManager test app window to become foreground. Expected: {firstSession.WindowHandle:X8}, Actual: {newForeground:X8}");
         } catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to activate window")) {
-            Assert.Inconclusive($"Window activation failed due to Windows security policies. Target window: Handle={firstHarness.Window.Handle:X8}. This is expected behavior in many Windows configurations due to User Interface Privilege Isolation (UIPI) or other focus management policies.");
+            Assert.Inconclusive($"Window activation failed due to Windows security policies. Target window: Handle={firstSession.WindowHandle:X8}. This is expected behavior in many Windows configurations due to User Interface Privilege Isolation (UIPI) or other focus management policies.");
         }
+    }
+
+    [TestMethod]
+    [TestCategory("UITest")]
+    /// <summary>
+    /// Ensures window activation preserves a maximized repo-owned harness window.
+    /// </summary>
+    public void ActivateWindow_MaximizedWindow_RemainsMaximized() {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Assert.Inconclusive("Test requires Windows");
+        }
+        TestHelper.RequireForegroundWindowUiTests();
+
+        using var session = DesktopManagerTestAppSession.Start("activation-maximized");
+        WindowManager manager = new();
+        WindowInfo window = session.ResolveWindowInfo();
+
+        manager.MaximizeWindow(window);
+        Thread.Sleep(150);
+        manager.ActivateWindow(window);
+        session.WaitForEditorForeground(
+            FocusTimeoutMilliseconds,
+            "The maximized repo-owned DesktopManager test app window did not become the foreground target.");
+
+        WindowInfo refreshedWindow = session.ResolveWindowInfo();
+        Assert.AreEqual(WindowState.Maximize, refreshedWindow.State, "Expected activation to preserve the maximized window state.");
     }
 }

--- a/Sources/DesktopManager/WindowActivationService.cs
+++ b/Sources/DesktopManager/WindowActivationService.cs
@@ -41,7 +41,7 @@ internal static class WindowActivationService {
         for (int attempt = 0; attempt < retryCount; attempt++) {
             if (MonitorNativeMethods.IsIconic(handle)) {
                 MonitorNativeMethods.ShowWindow(handle, MonitorNativeMethods.SW_RESTORE);
-            } else {
+            } else if (!MonitorNativeMethods.IsWindowVisible(handle)) {
                 MonitorNativeMethods.ShowWindow(handle, MonitorNativeMethods.SW_SHOW);
             }
 


### PR DESCRIPTION
## What changed

This change tightens the window-activation path so DesktopManager no longer changes the show state of a window that is already visible while trying to focus it.

It also moves the foreground-sensitive regression tests onto the repo-owned `DesktopManager.TestApp` harness instead of depending on whichever window happens to be active during a test run.

## Why it changed

Running the foreground-focused tests could end up touching an arbitrary active window, which made the suite feel unsafe and could leave a maximized window restored to normal size.

The root cause was that activation preparation always called `ShowWindow`, even for visible windows. That behavior is now limited to minimized or hidden windows, and the tests now target a specific DesktopManager-owned window end to end.

## Impact

- Safer foreground activation during tests and automation preparation.
- Foreground-sensitive tests now use a dedicated repo-owned harness.
- Added regression coverage that a maximized harness window stays maximized after activation.

## Validation

- `dotnet test Sources/DesktopManager.Tests/DesktopManager.Tests.csproj -f net8.0-windows --filter "DesktopAutomationAssertionTests|WindowManagerFilterTests|WindowTopMostActivationTests"`
- The targeted slice built and passed in this environment; interactive UI cases were skipped because no interactive desktop session was available.
