### PR TITLE
Simplify project build and stabilize wallpaper history tests

### DIFF
--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -1,88 +1,23 @@
 param(
-    [string] $ProjectBuildConfigPath = "$PSScriptRoot\project.build.json",
-    [string] $DotNetPublishConfigPath = "$PSScriptRoot\..\powerforge.dotnetpublish.json",
+    [string] $ConfigPath = "$PSScriptRoot\project.build.json",
     [Nullable[bool]] $UpdateVersions,
     [Nullable[bool]] $Build,
-    [switch] $PublishNuget,
-    [switch] $PublishGitHub,
-    [switch] $Plan,
-    [string] $PlanPath,
-    [bool] $BuildModule = $true,
-    [bool] $PublishTools = $true,
-    [string[]] $Target,
-    [string[]] $Runtimes,
-    [string[]] $Frameworks,
-    [ValidateSet('Portable', 'PortableCompat', 'PortableSize', 'AotSpeed', 'AotSize')][string[]] $Styles,
-    [switch] $SkipRestore,
-    [switch] $SkipBuild
+    [Nullable[bool]] $PublishNuget = $false,
+    [Nullable[bool]] $PublishGitHub = $false,
+    [Nullable[bool]] $Plan,
+    [string] $PlanPath
 )
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
 
-if (-not (Test-Path -LiteralPath $ProjectBuildConfigPath)) {
-    throw "Project build config file not found: $ProjectBuildConfigPath"
+$invokeParams = @{
+    ConfigPath = $ConfigPath
 }
-if (-not (Test-Path -LiteralPath $DotNetPublishConfigPath)) {
-    throw "DotNet publish config file not found: $DotNetPublishConfigPath"
-}
+if ($null -ne $UpdateVersions) { $invokeParams.UpdateVersions = $UpdateVersions }
+if ($null -ne $Build) { $invokeParams.Build = $Build }
+if ($null -ne $PublishNuget) { $invokeParams.PublishNuget = $PublishNuget }
+if ($null -ne $PublishGitHub) { $invokeParams.PublishGitHub = $PublishGitHub }
+if ($null -ne $Plan) { $invokeParams.Plan = $Plan }
+if ($PlanPath) { $invokeParams.PlanPath = $PlanPath }
 
-$invokeProjectBuild = @{
-    ConfigPath = $ProjectBuildConfigPath
-}
-if ($null -ne $UpdateVersions) {
-    $invokeProjectBuild.UpdateVersions = $UpdateVersions
-}
-if ($null -ne $Build) {
-    $invokeProjectBuild.Build = $Build
-}
-if ($PublishNuget) {
-    $invokeProjectBuild.PublishNuget = $true
-}
-if ($PublishGitHub) {
-    $invokeProjectBuild.PublishGitHub = $true
-}
-if ($Plan) {
-    $invokeProjectBuild.Plan = $true
-}
-if ($PlanPath) {
-    $invokeProjectBuild.PlanPath = $PlanPath
-}
-
-Invoke-ProjectBuild @invokeProjectBuild
-
-if ($Plan -and $BuildModule) {
-    Write-Warning 'Plan mode skips Build-Module.ps1 execution because the module pipeline does not expose a standalone plan surface here.'
-}
-
-if ($BuildModule -and -not $Plan) {
-    & "$PSScriptRoot\Build-Module.ps1" -SkipInstall
-}
-
-if ($PublishTools) {
-    $invokeDotNetPublish = @{
-        ConfigPath = $DotNetPublishConfigPath
-    }
-    if ($Plan) {
-        $invokeDotNetPublish.Plan = $true
-    }
-    if ($Target) {
-        $invokeDotNetPublish.Target = $Target
-    }
-    if ($Runtimes) {
-        $invokeDotNetPublish.Runtimes = $Runtimes
-    }
-    if ($Frameworks) {
-        $invokeDotNetPublish.Frameworks = $Frameworks
-    }
-    if ($Styles) {
-        $invokeDotNetPublish.Styles = $Styles
-    }
-    if ($SkipRestore) {
-        $invokeDotNetPublish.SkipRestore = $true
-    }
-    if ($SkipBuild) {
-        $invokeDotNetPublish.SkipBuild = $true
-    }
-
-    Invoke-DotNetPublish @invokeDotNetPublish
-}
+Invoke-ProjectBuild @invokeParams

--- a/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
+++ b/Sources/DesktopManager.Tests/WallpaperHistoryTests.cs
@@ -11,13 +11,22 @@ namespace DesktopManager.Tests;
 /// </summary>
 public class WallpaperHistoryTests
 {
+    private static string CreateHistoryPath()
+    {
+        return Path.Combine(
+            Path.GetTempPath(),
+            "DesktopManager.Tests",
+            Guid.NewGuid().ToString("N"),
+            "wallpaper-history.json");
+    }
+
     [TestMethod]
     /// <summary>
     /// Test for AddEntry_WritesFile.
     /// </summary>
     public void AddEntry_WritesFile()
     {
-        var temp = Path.GetTempFileName();
+        var temp = CreateHistoryPath();
         Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", temp);
         try
         {
@@ -30,9 +39,10 @@ public class WallpaperHistoryTests
         finally
         {
             Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", null);
-            if (File.Exists(temp))
+            var directory = Path.GetDirectoryName(temp);
+            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
             {
-                File.Delete(temp);
+                Directory.Delete(directory, recursive: true);
             }
         }
     }
@@ -43,7 +53,7 @@ public class WallpaperHistoryTests
     /// </summary>
     public void AddEntry_EnforcesMaximum()
     {
-        var temp = Path.GetTempFileName();
+        var temp = CreateHistoryPath();
         Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", temp);
         try
         {
@@ -57,9 +67,10 @@ public class WallpaperHistoryTests
         finally
         {
             Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", null);
-            if (File.Exists(temp))
+            var directory = Path.GetDirectoryName(temp);
+            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
             {
-                File.Delete(temp);
+                Directory.Delete(directory, recursive: true);
             }
         }
     }

--- a/Sources/DesktopManager/WallpaperHistory.cs
+++ b/Sources/DesktopManager/WallpaperHistory.cs
@@ -14,8 +14,6 @@ public static class WallpaperHistory
 {
     private static readonly object _lock = new();
 
-    private static string? _historyFilePath;
-
     private static string DefaultHistoryFilePath =>
         Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
@@ -23,7 +21,7 @@ public static class WallpaperHistory
             "wallpaper-history.json");
 
     private static string HistoryFilePath =>
-        _historyFilePath ??= GetHistoryFilePath();
+        GetHistoryFilePath();
 
     private static string GetHistoryFilePath()
     {
@@ -75,6 +73,7 @@ public static class WallpaperHistory
             {
                 return new List<string>();
             }
+
             try
             {
                 string json = File.ReadAllText(HistoryFilePath);
@@ -101,6 +100,7 @@ public static class WallpaperHistory
             {
                 Directory.CreateDirectory(dir);
             }
+
             string json = JsonSerializer.Serialize(paths);
             File.WriteAllText(HistoryFilePath, json);
         }
@@ -121,6 +121,7 @@ public static class WallpaperHistory
         {
             return;
         }
+
         lock (_lock)
         {
             var history = GetHistory();
@@ -130,6 +131,7 @@ public static class WallpaperHistory
             {
                 history.RemoveRange(MaxEntries, history.Count - MaxEntries);
             }
+
             SetHistory(history);
         }
     }


### PR DESCRIPTION
## Summary
- simplify `Build/Build-Project.ps1` so it behaves like the OfficeIMO build wrapper and no longer mixes module and tool publishing concerns
- make `WallpaperHistory` re-evaluate `DESKTOPMANAGER_HISTORY_PATH` on each access instead of caching the first resolved path
- stabilize `WallpaperHistory` tests by using isolated temp directories and cleaning them up recursively

## Why
PowerBGInfo is moving toward a more standalone packaging story, so DesktopManager build behavior should stay predictable and narrowly scoped. The history-path change also makes the test suite reliable when the environment variable changes during a run.

## Validation
- `git diff --check`
- `dotnet build Sources\\DesktopManager.sln`
- `dotnet test Sources\\DesktopManager.Tests\\DesktopManager.Tests.csproj --no-build --filter WallpaperHistoryTests`
- `pwsh -NoLogo -NoProfile -File Build\\Build-Project.ps1 -Plan:$true -Build:$false -UpdateVersions:$false`
