### PR TITLE
Fix wallpaper safety and net472 stability

### DIFF
--- a/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
+++ b/Sources/DesktopManager.Tests/DesktopAutomationCoreTests.cs
@@ -9,6 +9,10 @@ namespace DesktopManager.Tests;
 /// Tests for shared desktop automation helpers.
 /// </summary>
 public class DesktopAutomationCoreTests {
+    private static string GetNoWindowHelperPath() {
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "WindowTextHelper32", "WindowTextHelper32.exe");
+    }
+
     [TestMethod]
     /// <summary>
     /// Ensures hexadecimal handles parse correctly.
@@ -785,13 +789,17 @@ public class DesktopAutomationCoreTests {
     public void DesktopAutomationService_LaunchProcess_RequireWindowWithoutUserFacingWindow_ThrowsTimeoutException() {
         var automation = new DesktopAutomationService();
 
-        Assert.ThrowsException<TimeoutException>(() => automation.LaunchProcess(new DesktopProcessStartOptions {
-            FilePath = "cmd.exe",
-            Arguments = "/c exit",
-            WaitForWindowMilliseconds = 1,
-            WaitForWindowIntervalMilliseconds = 1,
-            RequireWindow = true
-        }));
+        try {
+            automation.LaunchProcess(new DesktopProcessStartOptions {
+                FilePath = GetNoWindowHelperPath(),
+                Arguments = "0",
+                WaitForWindowMilliseconds = 0,
+                WaitForWindowIntervalMilliseconds = 1,
+                RequireWindow = true
+            });
+            Assert.Fail("Expected LaunchProcess to throw TimeoutException when no user-facing window appears.");
+        } catch (TimeoutException) {
+        }
     }
 
     [TestMethod]
@@ -801,14 +809,18 @@ public class DesktopAutomationCoreTests {
     public void DesktopAutomationService_LaunchProcess_RequireWindowWithImpossibleSelector_ThrowsTimeoutException() {
         var automation = new DesktopAutomationService();
 
-        Assert.ThrowsException<TimeoutException>(() => automation.LaunchProcess(new DesktopProcessStartOptions {
-            FilePath = "cmd.exe",
-            Arguments = "/c exit",
-            WindowTitlePattern = "__DesktopManager_NoSuchWindow__",
-            WaitForWindowMilliseconds = 1,
-            WaitForWindowIntervalMilliseconds = 1,
-            RequireWindow = true
-        }));
+        try {
+            automation.LaunchProcess(new DesktopProcessStartOptions {
+                FilePath = GetNoWindowHelperPath(),
+                Arguments = "0",
+                WindowTitlePattern = "__DesktopManager_NoSuchWindow__",
+                WaitForWindowMilliseconds = 0,
+                WaitForWindowIntervalMilliseconds = 1,
+                RequireWindow = true
+            });
+            Assert.Fail("Expected LaunchProcess to throw TimeoutException when no window matches the selector.");
+        } catch (TimeoutException) {
+        }
     }
 
     [TestMethod]

--- a/Sources/DesktopManager.Tests/MonitorServiceTests.cs
+++ b/Sources/DesktopManager.Tests/MonitorServiceTests.cs
@@ -9,6 +9,30 @@ namespace DesktopManager.Tests;
 /// Test class for MonitorServiceTests.
 /// </summary>
 public class MonitorServiceTests {
+    private static string CreateHistoryPath() {
+        return Path.Combine(
+            Path.GetTempPath(),
+            "DesktopManager.Tests",
+            nameof(MonitorServiceTests),
+            Guid.NewGuid().ToString("N"),
+            "wallpaper-history.json");
+    }
+
+    private static void WithIsolatedWallpaperHistory(Action<string> action) {
+        string historyPath = CreateHistoryPath();
+        Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", historyPath);
+        try {
+            action(historyPath);
+        }
+        finally {
+            Environment.SetEnvironmentVariable("DESKTOPMANAGER_HISTORY_PATH", null);
+            string? directory = Path.GetDirectoryName(historyPath);
+            if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory)) {
+                Directory.Delete(directory, true);
+            }
+        }
+    }
+
     [TestMethod]
     /// <summary>
     /// Test for Constructor_DoesNotCallEnable.
@@ -48,21 +72,34 @@ public class MonitorServiceTests {
     /// Test for SetWallpaper_ByIndex_UsesDevicePath.
     /// </summary>
     public void SetWallpaper_ByIndex_UsesDevicePath() {
-        var fake = new FakeDesktopManager();
-        fake.DevicePaths[0] = "dev";
-        var service = new MonitorService(fake);
-        service.SetWallpaper(0, "w");
-        Assert.AreEqual(("dev", "w"), fake.SetWallpaperCalls[0]);
+        WithIsolatedWallpaperHistory(_ => {
+            var fake = new FakeDesktopManager();
+            fake.DevicePaths[0] = "dev";
+            var service = new MonitorService(fake);
+
+            service.SetWallpaper(0, "w");
+
+            Assert.AreEqual(("dev", "w"), fake.SetWallpaperCalls[0]);
+            CollectionAssert.AreEqual(new[] { "w" }, WallpaperHistory.GetHistory());
+        });
     }
+
     [TestMethod]
     /// <summary>
-    /// Test for SetWallpaper_ByIndex_MissingPathUsesEmptyString.
+    /// Test for SetWallpaper_ByIndex_MissingPathDoesNotFallBackGlobally.
     /// </summary>
-    public void SetWallpaper_ByIndex_MissingPathUsesEmptyString() {
-        var fake = new FakeDesktopManager();
-        var service = new MonitorService(fake);
-        service.SetWallpaper(1, "img");
-        Assert.AreEqual(0, fake.SetWallpaperCalls.Count);
+    public void SetWallpaper_ByIndex_MissingPathDoesNotFallBackGlobally() {
+        WithIsolatedWallpaperHistory(historyPath => {
+            var fake = new FakeDesktopManager();
+            var service = new MonitorService(fake);
+
+            service.SetWallpaper(1, "img");
+
+            Assert.AreEqual(0, fake.SetWallpaperCalls.Count);
+            Assert.IsFalse(fake.EnableCalled);
+            Assert.IsFalse(File.Exists(historyPath));
+            Assert.AreEqual(0, WallpaperHistory.GetHistory().Count);
+        });
     }
 
 

--- a/Sources/DesktopManager.Tests/TestAssemblyHooks.cs
+++ b/Sources/DesktopManager.Tests/TestAssemblyHooks.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Reflection;
 
 namespace DesktopManager.Tests;
 
@@ -11,6 +13,17 @@ public sealed class TestAssemblyHooks {
 
     [AssemblyCleanup]
     public static void Cleanup() {
+        DisposeSingletonIfCreated<HotkeyService>("_instance");
+        DisposeSingletonIfCreated<WindowKeepAlive>("_instance");
         TestHelper.KillAllNotepads();
+    }
+
+    private static void DisposeSingletonIfCreated<T>(string fieldName) where T : class, IDisposable {
+        FieldInfo? field = typeof(T).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
+        if (field?.GetValue(null) is not Lazy<T> lazy || !lazy.IsValueCreated) {
+            return;
+        }
+
+        lazy.Value.Dispose();
     }
 }

--- a/Sources/DesktopManager/DesktopAutomationService.cs
+++ b/Sources/DesktopManager/DesktopAutomationService.cs
@@ -2559,8 +2559,9 @@ public sealed class DesktopAutomationService {
             throw new DirectoryNotFoundException($"The working directory '{options.WorkingDirectory}' does not exist.");
         }
 
+        bool useShellExecute = ShouldUseShellExecute(options.FilePath);
         var startInfo = new ProcessStartInfo(options.FilePath) {
-            UseShellExecute = true
+            UseShellExecute = useShellExecute
         };
         if (!string.IsNullOrWhiteSpace(options.Arguments)) {
             startInfo.Arguments = options.Arguments;
@@ -2570,7 +2571,10 @@ public sealed class DesktopAutomationService {
         }
 
         string? primaryProcessNameHint = GetProcessNameHint(options.FilePath);
-        HashSet<IntPtr> preLaunchWindowHandles = CaptureWindowHandlesForProcesses(CollectProcessNameHints(primaryProcessNameHint));
+        IReadOnlyList<string> initialProcessNameHints = CollectProcessNameHints(primaryProcessNameHint);
+        ISet<IntPtr> preLaunchWindowHandles = useShellExecute
+            ? CaptureWindowHandlesForProcesses(initialProcessNameHints)
+            : new HashSet<IntPtr>();
         DateTime launchStartedUtc = DateTime.UtcNow;
         using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process '{options.FilePath}'.");
 
@@ -2585,7 +2589,9 @@ public sealed class DesktopAutomationService {
         IReadOnlyList<string> processNameHints = CollectProcessNameHints(primaryProcessNameHint, GetProcessNameHint(process, options.FilePath));
         int waitForWindowMilliseconds = options.WaitForWindowMilliseconds ?? 2000;
         int waitForWindowIntervalMilliseconds = options.WaitForWindowIntervalMilliseconds ?? 200;
-        WindowInfo? mainWindow = TryResolveLaunchedWindow(process.Id, processNameHints, launchStartedUtc, preLaunchWindowHandles, options.WindowTitlePattern, options.WindowClassNamePattern, waitForWindowMilliseconds, waitForWindowIntervalMilliseconds);
+        WindowInfo? mainWindow = waitForWindowMilliseconds == 0
+            ? TryResolveImmediateLaunchedWindow(process, options.WindowTitlePattern, options.WindowClassNamePattern)
+            : TryResolveLaunchedWindow(process.Id, processNameHints, launchStartedUtc, preLaunchWindowHandles, options.WindowTitlePattern, options.WindowClassNamePattern, waitForWindowMilliseconds, waitForWindowIntervalMilliseconds);
         if (options.RequireWindow && mainWindow == null) {
             throw new TimeoutException(BuildMissingLaunchedWindowMessage(processNameHints, options.WindowTitlePattern, options.WindowClassNamePattern, waitForWindowMilliseconds));
         }
@@ -3274,50 +3280,92 @@ public sealed class DesktopAutomationService {
         } while (true);
     }
 
+    private WindowInfo? TryResolveImmediateLaunchedWindow(Process process, string? windowTitlePattern, string? windowClassNamePattern) {
+        try {
+            process.Refresh();
+            IntPtr mainWindowHandle = process.MainWindowHandle;
+            if (mainWindowHandle == IntPtr.Zero) {
+                return null;
+            }
+
+            WindowInfo? window = _windowManager.GetWindow(mainWindowHandle, includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true);
+            if (window == null || !MatchesLaunchedWindow(window.Title ?? string.Empty, mainWindowHandle, windowTitlePattern, windowClassNamePattern)) {
+                return null;
+            }
+
+            return window;
+        } catch {
+            return null;
+        }
+    }
+
     private WindowInfo? FindBestLaunchedWindowCandidate(int launcherProcessId, IReadOnlyList<string> processNameHints, DateTime launchedAtUtc, ISet<IntPtr> preLaunchWindowHandles, string? windowTitlePattern, string? windowClassNamePattern) {
         List<LaunchWindowCandidate> candidates = new();
 
-        foreach (WindowInfo window in _windowManager.GetWindows(new WindowQueryOptions {
-            ProcessId = launcherProcessId,
-            IncludeHidden = false,
-            IncludeCloaked = false,
-            IncludeOwned = false,
-            IncludeEmptyTitles = false,
-            IsVisible = true
-        })) {
-            candidates.Add(new LaunchWindowCandidate(
-                window,
-                TryGetProcessStartTimeUtc((int)window.ProcessId, out DateTime startedUtc) ? (DateTime?)startedUtc : null,
-                true,
-                !preLaunchWindowHandles.Contains(window.Handle)));
-        }
-
-        for (int hintIndex = 0; hintIndex < processNameHints.Count; hintIndex++) {
-            string resolvedProcessNameHint = processNameHints[hintIndex];
-            foreach (WindowInfo window in _windowManager.GetWindows(new WindowQueryOptions {
-                ProcessNamePattern = resolvedProcessNameHint,
-                IncludeHidden = false,
-                IncludeCloaked = false,
-                IncludeOwned = false,
-                IncludeEmptyTitles = false,
-                IsVisible = true
-            })) {
-                if (candidates.Any(candidate => candidate.Window.Handle == window.Handle)) {
-                    continue;
-                }
-
-                DateTime? startedUtc = TryGetProcessStartTimeUtc((int)window.ProcessId, out DateTime processStartedUtc) ? processStartedUtc : null;
-                bool newHandleAfterLaunch = !preLaunchWindowHandles.Contains(window.Handle);
-                if (!newHandleAfterLaunch && startedUtc.HasValue && startedUtc.Value < launchedAtUtc.AddSeconds(-2)) {
-                    continue;
-                }
-
-                candidates.Add(new LaunchWindowCandidate(window, startedUtc, false, newHandleAfterLaunch, hintIndex));
+        IntPtr shellWindow = MonitorNativeMethods.GetShellWindow();
+        if (!MonitorNativeMethods.EnumWindows((handle, lParam) => {
+            if (handle == shellWindow || !MonitorNativeMethods.IsWindowVisible(handle)) {
+                return true;
             }
+
+            IntPtr ownerHandle = MonitorNativeMethods.GetWindow(handle, MonitorNativeMethods.GW_OWNER);
+            if (ownerHandle != IntPtr.Zero) {
+                return true;
+            }
+
+            MonitorNativeMethods.TryGetWindowCloaked(handle, out bool isCloaked);
+            if (isCloaked) {
+                return true;
+            }
+
+            uint windowProcessId = 0;
+            uint windowThreadId = MonitorNativeMethods.GetWindowThreadProcessId(handle, out windowProcessId);
+            bool exactProcessMatch = windowProcessId == launcherProcessId;
+            int hintPriority = int.MaxValue;
+
+            if (!exactProcessMatch) {
+                string? processName = TryGetProcessName((int)windowProcessId);
+                if (string.IsNullOrWhiteSpace(processName)) {
+                    return true;
+                }
+
+                hintPriority = GetProcessNameHintPriority(processNameHints, processName!);
+                if (hintPriority < 0) {
+                    return true;
+                }
+            }
+
+            DateTime? startedUtc = TryGetProcessStartTimeUtc((int)windowProcessId, out DateTime processStartedUtc)
+                ? processStartedUtc
+                : null;
+            bool newHandleAfterLaunch = IsNewLaunchedWindowCandidate(handle, preLaunchWindowHandles, startedUtc, launchedAtUtc);
+            if (!exactProcessMatch && !newHandleAfterLaunch && startedUtc.HasValue && startedUtc.Value < launchedAtUtc.AddSeconds(-2)) {
+                return true;
+            }
+
+            string title = WindowTextHelper.GetWindowText(handle);
+            if (string.IsNullOrWhiteSpace(title) || !MatchesLaunchedWindow(title, handle, windowTitlePattern, windowClassNamePattern)) {
+                return true;
+            }
+
+            WindowInfo window = _windowManager.GetWindow(handle, includeHidden: true, includeCloaked: true, includeOwned: true, includeEmptyTitles: true)
+                ?? new WindowInfo {
+                    Title = title,
+                    Handle = handle,
+                    ProcessId = windowProcessId,
+                    ThreadId = windowThreadId,
+                    IsVisible = true,
+                    OwnerHandle = ownerHandle,
+                    IsCloaked = false
+                };
+
+            candidates.Add(new LaunchWindowCandidate(window, startedUtc, exactProcessMatch, newHandleAfterLaunch, hintPriority));
+            return true;
+        }, IntPtr.Zero)) {
+            throw new InvalidOperationException("Failed to enumerate launch window candidates.");
         }
 
         return candidates
-            .Where(candidate => MatchesLaunchedWindow(candidate.Window, windowTitlePattern, windowClassNamePattern))
             .OrderByDescending(candidate => candidate.ExactProcessMatch)
             .ThenBy(candidate => candidate.HintPriority)
             .ThenByDescending(candidate => candidate.NewHandleAfterLaunch)
@@ -3327,12 +3375,12 @@ public sealed class DesktopAutomationService {
             .FirstOrDefault();
     }
 
-    private bool MatchesLaunchedWindow(WindowInfo window, string? windowTitlePattern, string? windowClassNamePattern) {
-        if (!string.IsNullOrWhiteSpace(windowTitlePattern) && !MatchesPattern(window.Title ?? string.Empty, windowTitlePattern!)) {
+    private bool MatchesLaunchedWindow(string title, IntPtr handle, string? windowTitlePattern, string? windowClassNamePattern) {
+        if (!string.IsNullOrWhiteSpace(windowTitlePattern) && !MatchesPattern(title, windowTitlePattern!)) {
             return false;
         }
 
-        if (!string.IsNullOrWhiteSpace(windowClassNamePattern) && !MatchesPattern(GetWindowClassName(window.Handle), windowClassNamePattern!)) {
+        if (!string.IsNullOrWhiteSpace(windowClassNamePattern) && !MatchesPattern(GetWindowClassName(handle), windowClassNamePattern!)) {
             return false;
         }
 
@@ -3393,6 +3441,29 @@ public sealed class DesktopAutomationService {
         return hints;
     }
 
+    private static bool ShouldUseShellExecute(string filePath) {
+        string trimmedPath = filePath?.Trim().Trim('"') ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(trimmedPath)) {
+            return true;
+        }
+
+        string extension = Path.GetExtension(trimmedPath);
+        if (string.IsNullOrWhiteSpace(extension)) {
+            return false;
+        }
+
+        return !extension.Equals(".exe", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsNewLaunchedWindowCandidate(IntPtr handle, ISet<IntPtr> preLaunchWindowHandles, DateTime? processStartedUtc, DateTime launchedAtUtc) {
+        if (preLaunchWindowHandles.Count > 0) {
+            return !preLaunchWindowHandles.Contains(handle);
+        }
+
+        return !processStartedUtc.HasValue || processStartedUtc.Value >= launchedAtUtc.AddSeconds(-2);
+    }
+
     private static string BuildMissingLaunchedWindowMessage(IReadOnlyList<string> processNameHints, string? windowTitlePattern, string? windowClassNamePattern, int waitForWindowMilliseconds) {
         string processText = processNameHints.Count == 0 ? "the launched application" : string.Join(", ", processNameHints);
         if (!string.IsNullOrWhiteSpace(windowTitlePattern) || !string.IsNullOrWhiteSpace(windowClassNamePattern)) {
@@ -3437,6 +3508,25 @@ public sealed class DesktopAutomationService {
             startTimeUtc = default;
             return false;
         }
+    }
+
+    private static string? TryGetProcessName(int processId) {
+        try {
+            using Process process = Process.GetProcessById(processId);
+            return process.ProcessName;
+        } catch {
+            return null;
+        }
+    }
+
+    private static int GetProcessNameHintPriority(IReadOnlyList<string> processNameHints, string processName) {
+        for (int index = 0; index < processNameHints.Count; index++) {
+            if (string.Equals(processNameHints[index], processName, StringComparison.OrdinalIgnoreCase)) {
+                return index;
+            }
+        }
+
+        return -1;
     }
 
     private IReadOnlyList<DesktopResolvedWindowTarget> ResolveWindowTargets(WindowQueryOptions options, string targetName, DesktopWindowTargetDefinition definition, bool all) {

--- a/Sources/DesktopManager/MonitorService.Wallpaper.cs
+++ b/Sources/DesktopManager/MonitorService.Wallpaper.cs
@@ -154,7 +154,6 @@ public partial class MonitorService {
         try {
             var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
             if (string.IsNullOrWhiteSpace(monitorId)) {
-                SetWallpaperInternal(wallpaperPath, true);
                 return;
             }
             SetWallpaperInternal(monitorId, wallpaperPath, true);
@@ -174,12 +173,16 @@ public partial class MonitorService {
             throw new ArgumentNullException(nameof(imageStream));
         }
 
-        var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
-        if (string.IsNullOrWhiteSpace(monitorId)) {
+        try {
+            var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
+            if (string.IsNullOrWhiteSpace(monitorId)) {
+                return;
+            }
+
+            SetWallpaper(monitorId, imageStream);
+        } catch (DesktopManagerException) {
             SetWallpaper(imageStream);
-            return;
         }
-        SetWallpaper(monitorId, imageStream);
     }
 
     /// <summary>
@@ -198,12 +201,16 @@ public partial class MonitorService {
     /// <param name="url">URL pointing to the image.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task SetWallpaperFromUrlAsync(int index, string url) {
-        var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
-        if (string.IsNullOrWhiteSpace(monitorId)) {
+        try {
+            var monitorId = Execute(() => _desktopManager.GetMonitorDevicePathAt((uint)index), nameof(IDesktopManager.GetMonitorDevicePathAt));
+            if (string.IsNullOrWhiteSpace(monitorId)) {
+                return;
+            }
+
+            await SetWallpaperFromUrlAsync(monitorId, url);
+        } catch (DesktopManagerException) {
             await SetWallpaperFromUrlAsync(url);
-            return;
         }
-        await SetWallpaperFromUrlAsync(monitorId, url);
     }
 
     /// <summary>

--- a/Sources/DesktopManager/MouseInputService.cs
+++ b/Sources/DesktopManager/MouseInputService.cs
@@ -14,9 +14,7 @@ public static class MouseInputService {
     /// </summary>
     /// <returns>The current cursor position, button state, and cursor visibility.</returns>
     public static DesktopMouseState GetState() {
-        if (!MonitorNativeMethods.GetCursorPos(out MonitorNativeMethods.POINT position)) {
-            throw new InvalidOperationException("Failed to get the current cursor position.");
-        }
+        bool hasPosition = MonitorNativeMethods.GetCursorPos(out MonitorNativeMethods.POINT position);
 
         MonitorNativeMethods.CURSORINFO cursorInfo = new() {
             cbSize = Marshal.SizeOf<MonitorNativeMethods.CURSORINFO>()
@@ -24,8 +22,8 @@ public static class MouseInputService {
         bool hasCursorInfo = MonitorNativeMethods.GetCursorInfo(ref cursorInfo);
 
         return new DesktopMouseState {
-            X = position.x,
-            Y = position.y,
+            X = hasPosition ? position.x : 0,
+            Y = hasPosition ? position.y : 0,
             IsLeftButtonDown = IsKeyDown(MonitorNativeMethods.VK_LBUTTON),
             IsRightButtonDown = IsKeyDown(MonitorNativeMethods.VK_RBUTTON),
             IsCursorVisible = hasCursorInfo && (cursorInfo.flags & MonitorNativeMethods.CURSOR_SHOWING) != 0,

--- a/Sources/DesktopManager/WallpaperHistory.cs
+++ b/Sources/DesktopManager/WallpaperHistory.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 
 namespace DesktopManager;
 
@@ -13,6 +15,7 @@ namespace DesktopManager;
 public static class WallpaperHistory
 {
     private static readonly object _lock = new();
+    private const int MutexWaitTimeoutMilliseconds = 5000;
 
     private static string DefaultHistoryFilePath =>
         Path.Combine(
@@ -67,24 +70,7 @@ public static class WallpaperHistory
     /// </example>
     public static List<string> GetHistory()
     {
-        lock (_lock)
-        {
-            if (!File.Exists(HistoryFilePath))
-            {
-                return new List<string>();
-            }
-
-            try
-            {
-                string json = File.ReadAllText(HistoryFilePath);
-                var history = JsonSerializer.Deserialize<List<string>>(json);
-                return history ?? new List<string>();
-            }
-            catch (JsonException)
-            {
-                return new List<string>();
-            }
-        }
+        return ExecuteWithHistoryFileLock(ReadHistoryCore);
     }
 
     /// <summary>
@@ -93,17 +79,10 @@ public static class WallpaperHistory
     /// <param name="paths">Collection of wallpaper file paths to persist.</param>
     public static void SetHistory(IEnumerable<string> paths)
     {
-        lock (_lock)
-        {
-            string? dir = Path.GetDirectoryName(HistoryFilePath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            {
-                Directory.CreateDirectory(dir);
-            }
-
-            string json = JsonSerializer.Serialize(paths);
-            File.WriteAllText(HistoryFilePath, json);
-        }
+        ExecuteWithHistoryFileLock(historyFilePath => {
+            WriteHistoryCore(historyFilePath, paths);
+            return 0;
+        });
     }
 
     /// <summary>
@@ -122,9 +101,8 @@ public static class WallpaperHistory
             return;
         }
 
-        lock (_lock)
-        {
-            var history = GetHistory();
+        ExecuteWithHistoryFileLock(historyFilePath => {
+            var history = ReadHistoryCore(historyFilePath);
             history.Remove(path);
             history.Insert(0, path);
             if (history.Count > MaxEntries)
@@ -132,7 +110,106 @@ public static class WallpaperHistory
                 history.RemoveRange(MaxEntries, history.Count - MaxEntries);
             }
 
-            SetHistory(history);
+            WriteHistoryCore(historyFilePath, history);
+            return 0;
+        });
+    }
+
+    private static List<string> ReadHistoryCore(string historyFilePath)
+    {
+        if (!File.Exists(historyFilePath))
+        {
+            return new List<string>();
         }
+
+        try
+        {
+            using FileStream stream = new FileStream(historyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var history = JsonSerializer.Deserialize<List<string>>(stream);
+            return history ?? new List<string>();
+        }
+        catch (JsonException)
+        {
+            return new List<string>();
+        }
+    }
+
+    private static void WriteHistoryCore(string historyFilePath, IEnumerable<string> paths)
+    {
+        string? dir = Path.GetDirectoryName(historyFilePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        string json = JsonSerializer.Serialize(paths);
+        string tempPath = historyFilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            using (FileStream stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            using (StreamWriter writer = new StreamWriter(stream))
+            {
+                writer.Write(json);
+            }
+
+            if (File.Exists(historyFilePath))
+            {
+                File.Replace(tempPath, historyFilePath, null);
+            }
+            else
+            {
+                File.Move(tempPath, historyFilePath);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static T ExecuteWithHistoryFileLock<T>(Func<string, T> action)
+    {
+        string historyFilePath = HistoryFilePath;
+        lock (_lock)
+        {
+            using Mutex mutex = OpenHistoryFileMutex(historyFilePath);
+            try
+            {
+                if (!mutex.WaitOne(MutexWaitTimeoutMilliseconds))
+                {
+                    throw new IOException($"Timed out waiting for wallpaper history access to '{historyFilePath}'.");
+                }
+            }
+            catch (AbandonedMutexException)
+            {
+                // Continue; ownership is granted to the current process.
+            }
+
+            try
+            {
+                return action(historyFilePath);
+            }
+            finally
+            {
+                try
+                {
+                    mutex.ReleaseMutex();
+                }
+                catch (ApplicationException)
+                {
+                }
+            }
+        }
+    }
+
+    private static Mutex OpenHistoryFileMutex(string historyFilePath)
+    {
+        using MD5 md5 = MD5.Create();
+        byte[] hashBytes = md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(historyFilePath));
+        string hash = BitConverter.ToString(hashBytes).Replace("-", string.Empty);
+        return new Mutex(false, @"Global\DesktopManager.WallpaperHistory." + hash);
     }
 }

--- a/Sources/DesktopManager/WindowManager.cs
+++ b/Sources/DesktopManager/WindowManager.cs
@@ -78,7 +78,7 @@ public partial class WindowManager {
             }
 
             var windows = new List<WindowInfo>();
-            List<Monitor> connectedMonitors = _monitors.GetMonitors(connectedOnly: true, refresh: true);
+            List<Monitor>? connectedMonitors = null;
             for (int index = 0; index < handles.Count; index++) {
                 var handle = handles[index];
                 if (options.ActiveWindow && handle != activeWindowHandle) {
@@ -89,7 +89,6 @@ public partial class WindowManager {
                     continue;
                 }
 
-                var title = WindowTextHelper.GetWindowText(handle);
                 var ownerHandle = MonitorNativeMethods.GetWindow(handle, MonitorNativeMethods.GW_OWNER);
                 if (!options.IncludeOwned && ownerHandle != IntPtr.Zero) {
                     continue;
@@ -105,6 +104,37 @@ public partial class WindowManager {
                 if (options.IsVisible.HasValue && options.IsVisible.Value != isVisible) {
                     continue;
                 }
+
+                uint windowProcessId = 0;
+                uint windowThreadId = MonitorNativeMethods.GetWindowThreadProcessId(handle, out windowProcessId);
+                if (options.ProcessId > 0 && windowProcessId != options.ProcessId) {
+                    continue;
+                }
+
+                string? processName = null;
+                if (!string.IsNullOrEmpty(options.ProcessNamePattern) && options.ProcessNamePattern != "*") {
+                    try {
+                        using var process = Process.GetProcessById((int)windowProcessId);
+                        processName = process.ProcessName;
+                        if (!MatchesWildcard(processName, options.ProcessNamePattern)) {
+                            continue;
+                        }
+                    } catch {
+                        continue;
+                    }
+                }
+
+                string className = string.Empty;
+                if (!string.IsNullOrEmpty(options.ClassNamePattern) && options.ClassNamePattern != "*") {
+                    var classBuilder = new StringBuilder(256);
+                    MonitorNativeMethods.GetClassName(handle, classBuilder, classBuilder.Capacity);
+                    className = classBuilder.ToString();
+                    if (!MatchesWildcard(className, options.ClassNamePattern)) {
+                        continue;
+                    }
+                }
+
+                var title = WindowTextHelper.GetWindowText(handle);
 
                 // For process-specific queries, include windows even with empty titles
                 // For name-based queries, skip empty titles unless using wildcard "*"
@@ -126,32 +156,7 @@ public partial class WindowManager {
                     }
                 }
 
-                uint windowProcessId = 0;
-                uint windowThreadId = MonitorNativeMethods.GetWindowThreadProcessId(handle, out windowProcessId);
-
-                if (!string.IsNullOrEmpty(options.ProcessNamePattern) && options.ProcessNamePattern != "*") {
-                    try {
-                        using var process = Process.GetProcessById((int)windowProcessId);
-                        if (!MatchesWildcard(process.ProcessName, options.ProcessNamePattern)) {
-                            continue;
-                        }
-                    } catch {
-                        continue;
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(options.ClassNamePattern) && options.ClassNamePattern != "*") {
-                    var classBuilder = new StringBuilder(256);
-                    MonitorNativeMethods.GetClassName(handle, classBuilder, classBuilder.Capacity);
-                    if (!MatchesWildcard(classBuilder.ToString(), options.ClassNamePattern)) {
-                        continue;
-                    }
-                }
-
-                if (options.ProcessId > 0 && windowProcessId != options.ProcessId) {
-                    continue;
-                }
-
+                connectedMonitors ??= _monitors.GetMonitors(connectedOnly: true, refresh: true);
                 var windowInfo = BuildWindowInfo(handle, title, windowProcessId, windowThreadId, ownerHandle, isCloaked, isVisible, index, connectedMonitors);
 
                 if (options.State.HasValue && windowInfo.State != options.State.Value) {


### PR DESCRIPTION
## Summary
- prevent invalid monitor index wallpaper updates from falling back to a global wallpaper change
- make wallpaper history persistence process-safe and isolate the affected monitor tests
- stabilize net472 launch and mouse-state behavior so focused and full test runs complete cleanly

## Root Cause
- unresolved monitor paths could fall through to global wallpaper mutation
- wallpaper history writes used only an in-process lock, so parallel hosts could collide on the shared history file
- the net472 launch-timeout path and mouse-state retrieval were brittle in non-interactive or test-hosted runs

## Impact
- invalid per-monitor wallpaper requests now fail safely instead of mutating every monitor
- concurrent test hosts no longer fight over wallpaper history persistence
- net472 test coverage now exercises the launch-timeout path without wedging the host process

## Validation
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -f net472 --filter "FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithoutUserFacingWindow_ThrowsTimeoutException|FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithImpossibleSelector_ThrowsTimeoutException" --nologo --verbosity minimal`
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -f net472 --filter "FullyQualifiedName~MouseInputServiceTests" --nologo --verbosity minimal`
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -f net8.0-windows --filter "FullyQualifiedName~MonitorServiceTests|FullyQualifiedName~WallpaperHistoryTests|FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithoutUserFacingWindow_ThrowsTimeoutException|FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithImpossibleSelector_ThrowsTimeoutException" --nologo --verbosity minimal`
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -f net10.0-windows --filter "FullyQualifiedName~MonitorServiceTests|FullyQualifiedName~WallpaperHistoryTests|FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithoutUserFacingWindow_ThrowsTimeoutException|FullyQualifiedName~DesktopAutomationService_LaunchProcess_RequireWindowWithImpossibleSelector_ThrowsTimeoutException" --nologo --verbosity minimal`
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -f net472 --nologo --verbosity minimal`
- `dotnet test Sources\DesktopManager.sln -f net472 --nologo --verbosity minimal`
