### PR TITLE
fix(powershell): isolate module load and approve slideshow verb

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -35,7 +35,7 @@ Invoke-ModuleBuild @invokeModuleBuild -Settings {
         PowerShellVersion      = '5.1'
         CompatiblePSEditions   = @('Desktop', 'Core')
         GUID                   = '56f85fa6-c622-4204-8e97-3d99e3e06e75'
-        ModuleVersion          = '3.6.1'
+        ModuleVersion          = '4.X.0'
         Author                 = 'Przemyslaw Klys'
         CompanyName            = 'Evotec'
         Copyright              = "(c) 2011 - $((Get-Date).Year) Przemyslaw Klys @ Evotec. All rights reserved."

--- a/DesktopManager.psd1
+++ b/DesktopManager.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @('Get-DesktopMonitors', 'Get-LockScreenWallpaper', 'Set-LockScreenWallpaper')
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Advance-DesktopSlideshow', 'Get-DesktopBackgroundColor', 'Get-DesktopBrightness', 'Get-DesktopControlCheck', 'Get-DesktopMonitor', 'Get-DesktopSlideshow', 'Get-DesktopWallpaper', 'Get-DesktopWallpaperHistory', 'Get-DesktopWindow', 'Get-DesktopWindowControl', 'Get-DesktopWindowKeepAlive', 'Get-DesktopWindowProcessInfo', 'Get-LogonWallpaper', 'Invoke-DesktopControlClick', 'Invoke-DesktopKeyPress', 'Invoke-DesktopMouseClick', 'Invoke-DesktopMouseDrag', 'Invoke-DesktopMouseMove', 'Invoke-DesktopMouseScroll', 'Invoke-DesktopScreenshot', 'Invoke-DesktopWindowScreenshot', 'Register-DesktopHotkey', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Restore-DesktopWindowLayout', 'Save-DesktopWindowLayout', 'Send-DesktopControlKey', 'Set-DefaultAudioDevice', 'Set-DesktopBackgroundColor', 'Set-DesktopBrightness', 'Set-DesktopControlCheck', 'Set-DesktopDpiScaling', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopSlideshowOptions', 'Set-DesktopWallpaper', 'Set-DesktopWallpaperHistory', 'Set-DesktopWindow', 'Set-DesktopWindowSnap', 'Set-DesktopWindowStyle', 'Set-DesktopWindowText', 'Set-DesktopWindowTransparency', 'Set-DesktopWindowVisibility', 'Set-LogonWallpaper', 'Set-TaskbarPosition', 'Start-DesktopSlideshow', 'Start-DesktopWindowKeepAlive', 'Stop-DesktopSlideshow', 'Stop-DesktopWindowKeepAlive', 'Unregister-DesktopHotkey', 'Wait-DesktopWindow')
+    CmdletsToExport        = @('Get-DesktopBackgroundColor', 'Get-DesktopBrightness', 'Get-DesktopControlCheck', 'Get-DesktopMonitor', 'Get-DesktopSlideshow', 'Get-DesktopWallpaper', 'Get-DesktopWallpaperHistory', 'Get-DesktopWindow', 'Get-DesktopWindowControl', 'Get-DesktopWindowKeepAlive', 'Get-DesktopWindowProcessInfo', 'Get-LogonWallpaper', 'Invoke-DesktopControlClick', 'Invoke-DesktopKeyPress', 'Invoke-DesktopMouseClick', 'Invoke-DesktopMouseDrag', 'Invoke-DesktopMouseMove', 'Invoke-DesktopMouseScroll', 'Invoke-DesktopScreenshot', 'Invoke-DesktopWindowScreenshot', 'Register-DesktopHotkey', 'Register-DesktopMonitorEvent', 'Register-DesktopOrientationEvent', 'Register-DesktopResolutionEvent', 'Restore-DesktopWindowLayout', 'Save-DesktopWindowLayout', 'Send-DesktopControlKey', 'Set-DefaultAudioDevice', 'Set-DesktopBackgroundColor', 'Set-DesktopBrightness', 'Set-DesktopControlCheck', 'Set-DesktopDpiScaling', 'Set-DesktopPosition', 'Set-DesktopResolution', 'Set-DesktopSlideshowOptions', 'Set-DesktopWallpaper', 'Set-DesktopWallpaperHistory', 'Set-DesktopWindow', 'Set-DesktopWindowSnap', 'Set-DesktopWindowStyle', 'Set-DesktopWindowText', 'Set-DesktopWindowTransparency', 'Set-DesktopWindowVisibility', 'Set-LogonWallpaper', 'Set-TaskbarPosition', 'Start-DesktopSlideshow', 'Start-DesktopWindowKeepAlive', 'Step-DesktopSlideshow', 'Stop-DesktopSlideshow', 'Stop-DesktopWindowKeepAlive', 'Unregister-DesktopHotkey', 'Wait-DesktopWindow')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = '56f85fa6-c622-4204-8e97-3d99e3e06e75'
-    ModuleVersion          = '3.6.1'
+    ModuleVersion          = '4.0.0'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/DesktopManager.psm1
+++ b/DesktopManager.psm1
@@ -12,12 +12,22 @@ $DevelopmentEnv = $env:DESKTOPMANAGER_DEVELOPMENT
 if ($DevelopmentEnv) {
     $Development = $DevelopmentEnv.ToString().ToLowerInvariant() -in @('1', 'true', 'yes', 'on')
 }
-$DevelopmentPath = "$PSScriptRoot\Sources\DesktopManager.PowerShell\bin\Debug"
+$DevelopmentPath = "$PSScriptRoot\Sources\DesktopManager.PowerShell\bin"
+$DevelopmentConfiguration = 'Release'
+if ($DevelopmentEnv -and (Test-Path "$DevelopmentPath\Debug")) {
+    $DevelopmentConfiguration = 'Debug'
+} elseif (-not (Test-Path "$DevelopmentPath\$DevelopmentConfiguration") -and (Test-Path "$DevelopmentPath\Debug")) {
+    $DevelopmentConfiguration = 'Debug'
+}
+$DevelopmentBuildPath = "$DevelopmentPath\$DevelopmentConfiguration"
+if (-not $DevelopmentEnv -and (Test-Path $DevelopmentBuildPath)) {
+    $Development = $true
+}
 $DevelopmentFolderCore = "net8.0-windows10.0.19041.0"
 $DevelopmentFolderDefault = "net472"
-$DevelopmentCoreFolder = Get-ChildItem -Path $DevelopmentPath -Directory -Filter 'net8.0-windows*' -ErrorAction SilentlyContinue | Select-Object -First 1
+$DevelopmentCoreFolder = Get-ChildItem -Path $DevelopmentBuildPath -Directory -Filter 'net8.0-windows*' -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $DevelopmentCoreFolder) {
-    $DevelopmentCoreFolder = Get-ChildItem -Path $DevelopmentPath -Directory -Filter 'net8.*' -ErrorAction SilentlyContinue | Select-Object -First 1
+    $DevelopmentCoreFolder = Get-ChildItem -Path $DevelopmentBuildPath -Directory -Filter 'net8.*' -ErrorAction SilentlyContinue | Select-Object -First 1
 }
 if ($DevelopmentCoreFolder) {
     $DevelopmentFolderCore = $DevelopmentCoreFolder.Name
@@ -67,9 +77,9 @@ if ($Standard -and $Core -and $Default) {
 $Assembly = @(
     if ($Development) {
         if ($PSEdition -eq 'Core') {
-            Get-ChildItem -Path $DevelopmentPath\$DevelopmentFolderCore\*.dll -ErrorAction SilentlyContinue -Recurse
+            Get-ChildItem -Path $DevelopmentBuildPath\$DevelopmentFolderCore\*.dll -ErrorAction SilentlyContinue -Recurse
         } else {
-            Get-ChildItem -Path $DevelopmentPath\$DevelopmentFolderDefault\*.dll -ErrorAction SilentlyContinue -Recurse
+            Get-ChildItem -Path $DevelopmentBuildPath\$DevelopmentFolderDefault\*.dll -ErrorAction SilentlyContinue -Recurse
         }
     } else {
         if ($Framework -and $PSEdition -eq 'Core') {
@@ -86,12 +96,16 @@ if ($Development) {
     $BinaryDev = @(
         foreach ($BinaryModule in $BinaryModules) {
             if ($PSEdition -eq 'Core') {
-                $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderCore\$BinaryModule"
+                $Variable = Resolve-Path "$DevelopmentBuildPath\$DevelopmentFolderCore\$BinaryModule"
             } else {
-                $Variable = Resolve-Path "$DevelopmentPath\$DevelopmentFolderDefault\$BinaryModule"
+                $Variable = Resolve-Path "$DevelopmentBuildPath\$DevelopmentFolderDefault\$BinaryModule"
             }
             $Variable
-            Write-Warning "Development mode: Using binaries from $Variable"
+            if ($DevelopmentEnv) {
+                Write-Warning "Development mode: Using binaries from $Variable"
+            } else {
+                Write-Verbose "Development mode: Using binaries from $Variable"
+            }
         }
     )
 }

--- a/README.MD
+++ b/README.MD
@@ -142,7 +142,7 @@ The important part is that CLI, MCP, and PowerShell are meant to stay aligned by
 | Set-DesktopSlideshowOptions | Update slideshow shuffle behavior and tick interval |
 | Start-DesktopSlideshow | Begin wallpaper slideshow across monitors |
 | Stop-DesktopSlideshow | Stop currently running slideshow |
-| Advance-DesktopSlideshow | Move slideshow forward or backward |
+| Step-DesktopSlideshow | Move slideshow forward or backward |
 | Get-DesktopBackgroundColor | Read current desktop background color |
 | Set-DesktopBackgroundColor | Change desktop background color |
 | Get-DesktopBrightness | Read monitor brightness level |
@@ -205,7 +205,7 @@ The table below shows the most relevant API methods behind each PowerShell cmdle
 | Set-DesktopSlideshowOptions | `Monitors.SetWallpaperSlideshowOptions` |
 | Start-DesktopSlideshow | `Monitors.StartWallpaperSlideshow` |
 | Stop-DesktopSlideshow | `Monitors.StopWallpaperSlideshow` |
-| Advance-DesktopSlideshow | `Monitors.AdvanceWallpaperSlide` |
+| Step-DesktopSlideshow | `Monitors.AdvanceWallpaperSlide` |
 | Get-DesktopBackgroundColor | `Monitors.GetBackgroundColor` |
 | Set-DesktopBackgroundColor | `Monitors.SetBackgroundColor` |
 | Get-DesktopBrightness | `Monitors.GetMonitorBrightness` |
@@ -452,7 +452,7 @@ Get-DesktopBackgroundColor
 Start-DesktopSlideshow -ImagePath 'C:\Wallpapers\img1.jpg','C:\Wallpapers\img2.jpg' -Shuffle -SlideshowTick 300000
 Get-DesktopSlideshow
 Set-DesktopSlideshowOptions -NoShuffle -SlideshowTick 600000
-Advance-DesktopSlideshow -Direction Forward
+Step-DesktopSlideshow -Direction Forward
 Stop-DesktopSlideshow
 ```
 

--- a/Sources/DesktopManager.PowerShell/CmdletStepDesktopSlideshow.cs
+++ b/Sources/DesktopManager.PowerShell/CmdletStepDesktopSlideshow.cs
@@ -2,11 +2,11 @@ using System.Management.Automation;
 
 namespace DesktopManager.PowerShell;
 
-/// <summary>Advances the desktop wallpaper slideshow.</summary>
-/// <para type="synopsis">Advances the desktop wallpaper slideshow.</para>
+/// <summary>Steps the desktop wallpaper slideshow.</summary>
+/// <para type="synopsis">Steps the desktop wallpaper slideshow.</para>
 /// <para type="description">Moves the wallpaper slideshow forward or backward on all monitors.</para>
-[Cmdlet("Advance", "DesktopSlideshow", SupportsShouldProcess = false)]
-public sealed class CmdletAdvanceDesktopSlideshow : PSCmdlet {
+[Cmdlet(VerbsCommon.Step, "DesktopSlideshow", SupportsShouldProcess = false)]
+public sealed class CmdletStepDesktopSlideshow : PSCmdlet {
     /// <summary>
     /// <para type="description">Direction to advance the slideshow.</para>
     /// </summary>
@@ -14,8 +14,8 @@ public sealed class CmdletAdvanceDesktopSlideshow : PSCmdlet {
     public DesktopSlideshowDirection Direction { get; set; }
 
     /// <example>
-    ///   <summary>Advance to the next slide</summary>
-    ///   <code>Advance-DesktopSlideshow -Direction Forward</code>
+    ///   <summary>Step to the next slide</summary>
+    ///   <code>Step-DesktopSlideshow -Direction Forward</code>
     /// </example>
 
     /// <summary>Begin processing.</summary>

--- a/Sources/DesktopManager.PowerShell/OnImportAndRemove.cs
+++ b/Sources/DesktopManager.PowerShell/OnImportAndRemove.cs
@@ -3,6 +3,9 @@ using System.IO;
 using System.Management.Automation;
 using System.Reflection;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 
 /// <summary>
 /// OnModuleImportAndRemove is a class that implements the IModuleAssemblyInitializer and IModuleAssemblyCleanup interfaces.
@@ -16,6 +19,13 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            if (IsLoadedInDefaultContext()) {
+                AssemblyLoadContext.Default.Resolving += ResolveAlc;
+            }
+        }
+#endif
     }
 
     /// <summary>
@@ -26,6 +36,13 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            if (IsLoadedInDefaultContext()) {
+                AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+            }
+        }
+#endif
     }
 
     /// <summary>
@@ -36,10 +53,13 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     /// <returns>The loaded assembly or <c>null</c> if not found.</returns>
     private static Assembly MyResolveEventHandler(object sender, ResolveEventArgs args) {
         var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-        var directoriesToSearch = new List<string> { libDirectory };
+        var directoriesToSearch = new List<string>();
 
-        if (Directory.Exists(libDirectory)) {
-            directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+        if (!string.IsNullOrEmpty(libDirectory)) {
+            directoriesToSearch.Add(libDirectory);
+            if (Directory.Exists(libDirectory)) {
+                directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+            }
         }
 
         var requestedAssemblyName = new AssemblyName(args.Name).Name + ".dll";
@@ -59,6 +79,60 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         return null;
     }
 
+#if NET5_0_OR_GREATER
+    private sealed class LoadContext : AssemblyLoadContext {
+        private readonly string _assemblyDir;
+
+        public LoadContext(string assemblyDir)
+            : base(name: "DesktopManager", isCollectible: false) {
+            _assemblyDir = assemblyDir;
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName) {
+            string asmPath = Path.Combine(_assemblyDir, $"{assemblyName.Name}.dll");
+            if (File.Exists(asmPath)) {
+                return LoadFromAssemblyPath(asmPath);
+            }
+
+            return null;
+        }
+    }
+
+    private static readonly string _assemblyDir = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location) ?? string.Empty;
+
+    private static readonly LoadContext _alc = new LoadContext(_assemblyDir);
+
+    private static bool IsLoadedInDefaultContext() {
+        return AssemblyLoadContext.GetLoadContext(typeof(OnModuleImportAndRemove).Assembly) == AssemblyLoadContext.Default;
+    }
+
+    private static Assembly ResolveAlc(AssemblyLoadContext defaultAlc, AssemblyName assemblyToResolve) {
+        string asmPath = Path.Combine(_assemblyDir, $"{assemblyToResolve.Name}.dll");
+        if (IsSatisfyingAssembly(assemblyToResolve, asmPath)) {
+            return _alc.LoadFromAssemblyName(assemblyToResolve);
+        }
+
+        return null;
+    }
+
+    private static bool IsSatisfyingAssembly(AssemblyName requiredAssemblyName, string assemblyPath) {
+        if (requiredAssemblyName.Name == "DesktopManager.PowerShell" || !File.Exists(assemblyPath)) {
+            return false;
+        }
+
+        AssemblyName asmToLoadName = AssemblyName.GetAssemblyName(assemblyPath);
+        if (!string.Equals(asmToLoadName.Name, requiredAssemblyName.Name, StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        if (requiredAssemblyName.Version != null && asmToLoadName.Version != null) {
+            return asmToLoadName.Version >= requiredAssemblyName.Version;
+        }
+
+        return true;
+    }
+#endif
+
     /// <summary>
     /// Determines whether the current runtime is .NET Framework.
     /// </summary>
@@ -67,23 +141,4 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Determines whether the current runtime is .NET Core.
-    /// </summary>
-    /// <returns><c>true</c> if running on .NET Core; otherwise <c>false</c>.</returns>
-    private bool IsNetCore() {
-        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Determines whether the current runtime is .NET 5 or higher.
-    /// </summary>
-    /// <returns><c>true</c> if running on .NET 5 or newer; otherwise <c>false</c>.</returns>
-    private bool IsNet5OrHigher() {
-        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 7", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase) ||
-               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 9", StringComparison.OrdinalIgnoreCase);
-    }
 }

--- a/Sources/DesktopManager.Tests/PowerShellCoreCmdletSurfaceTests.cs
+++ b/Sources/DesktopManager.Tests/PowerShellCoreCmdletSurfaceTests.cs
@@ -21,7 +21,7 @@ public class PowerShellCoreCmdletSurfaceTests {
     [DataRow("CmdletSetDesktopWallpaper", "Index", "DeviceId", "DeviceName", "ConnectedOnly", "PrimaryOnly", "All", "AllUsers", "ExcludeDefaultUserProfile", "WallpaperPosition", "WallpaperPath", "Url", "ImageData")]
     [DataRow("CmdletGetLogonWallpaper")]
     [DataRow("CmdletSetLogonWallpaper", "ImagePath")]
-    [DataRow("CmdletAdvanceDesktopSlideshow", "Direction")]
+    [DataRow("CmdletStepDesktopSlideshow", "Direction")]
     [DataRow("CmdletGetDesktopSlideshow")]
     [DataRow("CmdletSetDesktopSlideshowOptions", "Shuffle", "NoShuffle", "SlideshowTick")]
     [DataRow("CmdletStartDesktopSlideshow", "ImagePath", "Shuffle", "SlideshowTick")]

--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -1,0 +1,84 @@
+Describe 'Packaged AssemblyLoadContext isolation' {
+    It 'loads DesktopManager from the packaged module ALC without unapproved verb warnings' {
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'DesktopManager'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\DesktopManager.ModuleLoadContext.dll'
+        if ($PSVersionTable.PSEdition -ne 'Core' -or -not (Test-Path -LiteralPath $packagedLoader)) {
+            Set-ItResult -Skipped -Because 'packaged Core artifact is required'
+            return
+        }
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$moduleRoot = '$moduleRootLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + [IO.Path]::Combine(`$PSHOME, 'Modules')
+
+`$warnings = @()
+`$module = Import-Module DesktopManager -Force -WarningVariable warnings -PassThru
+`$command = `$module.ExportedCmdlets['Get-DesktopBackgroundColor']
+`$stepCommand = `$module.ExportedCmdlets['Step-DesktopSlideshow']
+`$advanceCmdlet = `$module.ExportedCmdlets['Advance-DesktopSlideshow']
+`$advanceAlias = `$module.ExportedAliases['Advance-DesktopSlideshow']
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    ForEach-Object {
+        `$alc = `$_
+        foreach (`$assembly in `$alc.Assemblies) {
+            if (`$assembly.GetName().Name -in @('DesktopManager.PowerShell', 'DesktopManager', 'DesktopManager.ModuleLoadContext')) {
+                [pscustomobject]@{
+                    Assembly = `$assembly.GetName().Name
+                    Version = `$assembly.GetName().Version.ToString()
+                    ALC = `$alc.Name
+                    IsDefault = [object]::ReferenceEquals(`$alc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+                    Location = `$assembly.Location
+                }
+            }
+        }
+    }
+
+[pscustomobject]@{
+    WarningCount = @(`$warnings).Count
+    Warnings = @(`$warnings | ForEach-Object ToString)
+    CommandSource = `$command.Source
+    CommandModuleName = `$command.ModuleName
+    CommandAssembly = `$commandAssembly.Location
+    CommandALC = `$commandAlc.Name
+    CommandALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    StepCommandName = `$stepCommand.Name
+    HasAdvanceCmdlet = `$null -ne `$advanceCmdlet
+    HasAdvanceAlias = `$null -ne `$advanceAlias
+    LoadedAssemblies = @(`$loadedAssemblies)
+} | ConvertTo-Json -Depth 6 -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.WarningCount | Should -Be 0 -Because ($result.Warnings -join [Environment]::NewLine)
+        $result.CommandSource | Should -Be 'DesktopManager'
+        $result.CommandModuleName | Should -Be 'DesktopManager'
+        $result.CommandAssembly | Should -BeLike '*\Artefacts\Unpacked\Modules\DesktopManager\Lib\Core\DesktopManager.PowerShell.dll'
+        $result.CommandALC | Should -Be 'DesktopManager'
+        $result.CommandALCIsDefault | Should -BeFalse
+        $result.StepCommandName | Should -Be 'Step-DesktopSlideshow'
+        $result.HasAdvanceCmdlet | Should -BeFalse
+        $result.HasAdvanceAlias | Should -BeFalse
+
+        $loadedAssemblies = @($result.LoadedAssemblies)
+        $powerShellAssembly = $loadedAssemblies | Where-Object Assembly -eq 'DesktopManager.PowerShell' | Select-Object -First 1
+        $coreAssembly = $loadedAssemblies | Where-Object Assembly -eq 'DesktopManager' | Select-Object -First 1
+        $loaderAssembly = $loadedAssemblies | Where-Object Assembly -eq 'DesktopManager.ModuleLoadContext' | Select-Object -First 1
+
+        $powerShellAssembly.ALC | Should -Be 'DesktopManager'
+        $powerShellAssembly.IsDefault | Should -BeFalse
+        $coreAssembly.ALC | Should -Be 'DesktopManager'
+        $coreAssembly.IsDefault | Should -BeFalse
+        $loaderAssembly.IsDefault | Should -BeTrue
+    }
+}

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -45,6 +45,13 @@ Describe 'DesktopManager basic tests' {
         Get-Command Set-DesktopSlideshowOptions | Should -Not -BeNullOrEmpty
     }
 
+    It 'Exports Step-DesktopSlideshow without the unreleased Advance alias' {
+        (Get-Command Step-DesktopSlideshow).CommandType | Should -Be 'Cmdlet'
+        $module = Get-Module DesktopManager
+        $module.ExportedCmdlets.ContainsKey('Advance-DesktopSlideshow') | Should -BeFalse
+        $module.ExportedAliases.ContainsKey('Advance-DesktopSlideshow') | Should -BeFalse
+    }
+
     It 'Exports Start-DesktopWindowKeepAlive' {
         Get-Command Start-DesktopWindowKeepAlive | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
## Summary
- add module-scoped ALC dependency resolution for DesktopManager PowerShell imports
- change the unreleased slideshow cmdlet surface to the approved `Step-DesktopSlideshow` command without a compatibility alias
- prefer fresh source build output for root-module development imports and add packaged ALC regression coverage

## Validation
- `dotnet build .\Sources\DesktopManager.PowerShell\DesktopManager.PowerShell.csproj -c Release -f net8.0-windows10.0.19041.0`
- `dotnet test .\Sources\DesktopManager.Tests\DesktopManager.Tests.csproj -c Release -f net8.0-windows10.0.19041.0 --filter PowerShellCoreCmdletSurfaceTests`
- `.\Build\Build-Module.ps1 -SkipInstall -NoInteractive`
- `Invoke-Pester -Path .\Tests\Basic.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path .\Tests\AssemblyLoadContext.Tests.ps1 -Output Detailed`
- clean packaged import probe confirmed no `Advance-DesktopSlideshow` cmdlet or alias export
