### PR TITLE
test(powershell): remove unreleased slideshow alias assertions

### DIFF
--- a/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Tests.ps1
@@ -18,8 +18,6 @@ Describe 'Packaged AssemblyLoadContext isolation' {
 `$module = Import-Module DesktopManager -Force -WarningVariable warnings -PassThru
 `$command = `$module.ExportedCmdlets['Get-DesktopBackgroundColor']
 `$stepCommand = `$module.ExportedCmdlets['Step-DesktopSlideshow']
-`$advanceCmdlet = `$module.ExportedCmdlets['Advance-DesktopSlideshow']
-`$advanceAlias = `$module.ExportedAliases['Advance-DesktopSlideshow']
 `$commandAssembly = `$command.ImplementingType.Assembly
 `$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
 `$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
@@ -47,8 +45,6 @@ Describe 'Packaged AssemblyLoadContext isolation' {
     CommandALC = `$commandAlc.Name
     CommandALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
     StepCommandName = `$stepCommand.Name
-    HasAdvanceCmdlet = `$null -ne `$advanceCmdlet
-    HasAdvanceAlias = `$null -ne `$advanceAlias
     LoadedAssemblies = @(`$loadedAssemblies)
 } | ConvertTo-Json -Depth 6 -Compress
 "@
@@ -67,8 +63,6 @@ Describe 'Packaged AssemblyLoadContext isolation' {
         $result.CommandALC | Should -Be 'DesktopManager'
         $result.CommandALCIsDefault | Should -BeFalse
         $result.StepCommandName | Should -Be 'Step-DesktopSlideshow'
-        $result.HasAdvanceCmdlet | Should -BeFalse
-        $result.HasAdvanceAlias | Should -BeFalse
 
         $loadedAssemblies = @($result.LoadedAssemblies)
         $powerShellAssembly = $loadedAssemblies | Where-Object Assembly -eq 'DesktopManager.PowerShell' | Select-Object -First 1

--- a/Tests/Basic.Tests.ps1
+++ b/Tests/Basic.Tests.ps1
@@ -45,11 +45,8 @@ Describe 'DesktopManager basic tests' {
         Get-Command Set-DesktopSlideshowOptions | Should -Not -BeNullOrEmpty
     }
 
-    It 'Exports Step-DesktopSlideshow without the unreleased Advance alias' {
-        (Get-Command Step-DesktopSlideshow).CommandType | Should -Be 'Cmdlet'
-        $module = Get-Module DesktopManager
-        $module.ExportedCmdlets.ContainsKey('Advance-DesktopSlideshow') | Should -BeFalse
-        $module.ExportedAliases.ContainsKey('Advance-DesktopSlideshow') | Should -BeFalse
+    It 'Exports Step-DesktopSlideshow' {
+        Get-Command Step-DesktopSlideshow | Should -Not -BeNullOrEmpty
     }
 
     It 'Exports Start-DesktopWindowKeepAlive' {


### PR DESCRIPTION
## Summary
- remove the stale Basic test that asserted the absence of the unreleased `Advance-DesktopSlideshow` name
- remove the same negative `Advance-*` checks from the packaged ALC test
- keep the ALC test focused on packaged module isolation and the approved `Step-DesktopSlideshow` command

## Validation
- `Invoke-Pester -Path .\Tests\Basic.Tests.ps1 -Output Detailed` (28 passed)
- `Invoke-Pester -Path .\Tests\AssemblyLoadContext.Tests.ps1 -Output Detailed` (skipped because packaged Core artifact is required in this clean worktree)
- `git diff --check`