### PR TITLE
fix(app): Address hotkey PR review feedback

### DIFF
--- a/Sources/DesktopManager.App.Core/HotkeyProfileStore.cs
+++ b/Sources/DesktopManager.App.Core/HotkeyProfileStore.cs
@@ -74,7 +74,25 @@ public static class HotkeyProfileStore {
             Directory.CreateDirectory(directory);
         }
 
-        using FileStream stream = File.Create(path);
-        JsonSerializer.Serialize(stream, profile, JsonContext.HotkeyProfile);
+        string tempPath = Path.Combine(
+            directory ?? Path.GetTempPath(),
+            $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+
+        try {
+            using (FileStream stream = new(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+                JsonSerializer.Serialize(stream, profile, JsonContext.HotkeyProfile);
+                stream.Flush(flushToDisk: true);
+            }
+
+            if (File.Exists(path)) {
+                File.Replace(tempPath, path, null);
+            } else {
+                File.Move(tempPath, path);
+            }
+        } finally {
+            if (File.Exists(tempPath)) {
+                File.Delete(tempPath);
+            }
+        }
     }
 }

--- a/Sources/DesktopManager.App/MainWindow.xaml.cs
+++ b/Sources/DesktopManager.App/MainWindow.xaml.cs
@@ -15,7 +15,8 @@ public sealed partial class MainWindow : Window {
     private readonly ObservableCollection<MonitorAdvancedColorOption> _advancedColorOptions = new();
     private readonly List<MonitorOption> _monitorOptions = new();
     private readonly global::DesktopManager.Monitors _monitors = new();
-    private HotkeyProfile _profile;
+    private HotkeyProfile _profile = HotkeyProfileDefaults.CreateDefaultProfile();
+    private string? _profileLoadError;
     private bool _loadingProfile = true;
 
     /// <summary>
@@ -33,19 +34,23 @@ public sealed partial class MainWindow : Window {
         InitializeTray();
         RefreshMonitorOptions();
         RefreshAdvancedColorStatus();
-        _profile = HotkeyProfileStore.LoadOrCreate(_profilePath);
+        LoadProfileRecoverably();
         LoadProfileIntoView();
         StartRuntime();
     }
 
     private void ReloadButton_Click(object sender, RoutedEventArgs e) {
-        _profile = HotkeyProfileStore.LoadOrCreate(_profilePath);
+        LoadProfileRecoverably();
         LoadProfileIntoView();
         StartRuntime();
     }
 
     private void EnabledSwitch_Toggled(object sender, RoutedEventArgs e) {
         if (_loadingProfile) {
+            return;
+        }
+
+        if (TryBlockRecoveryProfileEdit()) {
             return;
         }
 
@@ -59,6 +64,10 @@ public sealed partial class MainWindow : Window {
             return;
         }
 
+        if (TryBlockRecoveryProfileEdit()) {
+            return;
+        }
+
         _profile.StartWithWindows = StartWithWindowsSwitch.IsOn;
         StartupRegistrationService.SetEnabled(_profile.StartWithWindows);
         SaveProfile();
@@ -67,6 +76,10 @@ public sealed partial class MainWindow : Window {
 
     private void MinimizeToTraySwitch_Toggled(object sender, RoutedEventArgs e) {
         if (_loadingProfile) {
+            return;
+        }
+
+        if (TryBlockRecoveryProfileEdit()) {
             return;
         }
 
@@ -89,6 +102,10 @@ public sealed partial class MainWindow : Window {
     }
 
     private void SaveActionButton_Click(object sender, RoutedEventArgs e) {
+        if (TryBlockRecoveryProfileEdit()) {
+            return;
+        }
+
         if (FunctionsList.SelectedItem is not HotkeyFunctionDefinition function) {
             AddLog("No function selected.");
             return;
@@ -134,12 +151,23 @@ public sealed partial class MainWindow : Window {
             _loadingProfile = false;
         }
 
-        ValidationInfo.IsOpen = !validation.IsValid;
-        ValidationInfo.Message = validation.IsValid ? string.Empty : string.Join(" ", validation.Errors);
+        List<string> validationMessages = validation.Errors.ToList();
+        if (!string.IsNullOrWhiteSpace(_profileLoadError)) {
+            validationMessages.Insert(0, _profileLoadError);
+        }
+
+        ValidationInfo.IsOpen = validationMessages.Count > 0;
+        ValidationInfo.Message = string.Join(" ", validationMessages);
     }
 
     private void StartRuntime() {
         HotkeyProfileValidationResult validation = HotkeyProfileValidator.Validate(_profile);
+        if (!string.IsNullOrWhiteSpace(_profileLoadError)) {
+            RuntimeStatusText.Text = "Runtime not started: profile could not be loaded.";
+            _runtime.Stop();
+            return;
+        }
+
         if (!validation.IsValid) {
             RuntimeStatusText.Text = "Runtime not started: profile has validation errors.";
             _runtime.Stop();
@@ -152,6 +180,30 @@ public sealed partial class MainWindow : Window {
         } catch (Exception ex) {
             RuntimeStatusText.Text = $"Runtime failed: {ex.Message}";
         }
+    }
+
+    private void LoadProfileRecoverably() {
+        try {
+            _profile = HotkeyProfileStore.LoadOrCreate(_profilePath);
+            _profileLoadError = null;
+        } catch (Exception ex) {
+            _profile = HotkeyProfileDefaults.CreateDefaultProfile();
+            _profile.Enabled = false;
+            _profile.ProfileName = "Recovery";
+            _profileLoadError = $"Could not load hotkey profile. Fix or replace '{_profilePath}', then reload. {ex.Message}";
+            AddLog(_profileLoadError);
+        }
+    }
+
+    private bool TryBlockRecoveryProfileEdit() {
+        if (string.IsNullOrWhiteSpace(_profileLoadError)) {
+            return false;
+        }
+
+        AddLog("Profile changes are disabled until the profile file reloads successfully.");
+        LoadProfileIntoView();
+        StartRuntime();
+        return true;
     }
 
     private void ShowSelectedFunction(HotkeyFunctionDefinition? function) {

--- a/Sources/DesktopManager.Tests/DisplayConfigNativeLayoutTests.cs
+++ b/Sources/DesktopManager.Tests/DisplayConfigNativeLayoutTests.cs
@@ -35,9 +35,9 @@ public class DisplayConfigNativeLayoutTests {
 
     [TestMethod]
     /// <summary>
-    /// Legacy Advanced Color packets should not report WCG-only panels as HDR.
+    /// Legacy Advanced Color packets should keep HDR state independent from wide-color enforcement.
     /// </summary>
-    public void CreateLegacyAdvancedColorInfo_WideColorNotEnforced_DoesNotReportHdr() {
+    public void CreateLegacyAdvancedColorInfo_WideColorNotEnforced_KeepsLegacyHdrState() {
         Monitor monitor = new(new MonitorService(new StubDesktopManager())) {
             Index = 1,
             DeviceId = "DISPLAY1",
@@ -54,6 +54,31 @@ public class DisplayConfigNativeLayoutTests {
         Assert.IsTrue(result.AdvancedColorSupported);
         Assert.IsTrue(result.AdvancedColorEnabled);
         Assert.IsFalse(result.WideColorEnforced);
+        Assert.IsTrue(result.HdrSupported);
+        Assert.IsTrue(result.HdrEnabled);
+    }
+
+    [TestMethod]
+    /// <summary>
+    /// Legacy Advanced Color packets should not expose WCG-only Advanced Color as HDR-toggleable.
+    /// </summary>
+    public void CreateLegacyAdvancedColorInfo_WideColorEnforced_DoesNotReportHdr() {
+        Monitor monitor = new(new MonitorService(new StubDesktopManager())) {
+            Index = 1,
+            DeviceId = "DISPLAY1",
+            DeviceName = "\\\\.\\DISPLAY1"
+        };
+        DisplayConfigGetAdvancedColorInfo packet = new() {
+            Value = 0x7,
+            ColorEncoding = DisplayConfigColorEncoding.Rgb,
+            BitsPerColorChannel = 10
+        };
+
+        MonitorAdvancedColorInfo result = MonitorService.CreateLegacyAdvancedColorInfo(monitor, packet);
+
+        Assert.IsTrue(result.AdvancedColorSupported);
+        Assert.IsTrue(result.AdvancedColorEnabled);
+        Assert.IsTrue(result.WideColorEnforced);
         Assert.IsFalse(result.HdrSupported);
         Assert.IsFalse(result.HdrEnabled);
     }

--- a/Sources/DesktopManager.Tests/HotkeyProfileStoreTests.cs
+++ b/Sources/DesktopManager.Tests/HotkeyProfileStoreTests.cs
@@ -147,6 +147,41 @@ public class HotkeyProfileStoreTests {
     }
 
     /// <summary>
+    /// A failed profile replacement should leave the last readable profile intact.
+    /// </summary>
+    [TestMethod]
+    public void Save_WhenReplaceFails_PreservesExistingProfile() {
+        string directory = CreateTemporaryDirectory();
+        string path = Path.Combine(directory, "profile.json");
+
+        try {
+            HotkeyProfile original = HotkeyProfileDefaults.CreateDefaultProfile();
+            original.ProfileName = "Original";
+            HotkeyProfileStore.Save(path, original);
+
+            using (FileStream lockedProfile = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                HotkeyProfile changed = HotkeyProfileDefaults.CreateDefaultProfile();
+                changed.ProfileName = "Changed";
+
+                Exception? saveException = null;
+                try {
+                    HotkeyProfileStore.Save(path, changed);
+                } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException) {
+                    saveException = ex;
+                }
+
+                Assert.IsNotNull(saveException);
+            }
+
+            HotkeyProfile loaded = HotkeyProfileStore.LoadOrCreate(path);
+            Assert.AreEqual("Original", loaded.ProfileName);
+            Assert.IsTrue(HotkeyProfileValidator.Validate(loaded).IsValid);
+        } finally {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Duplicate enabled hotkeys should be rejected before registration is attempted.
     /// </summary>
     [TestMethod]

--- a/Sources/DesktopManager/MonitorService.AdvancedColor.cs
+++ b/Sources/DesktopManager/MonitorService.AdvancedColor.cs
@@ -202,12 +202,17 @@ public partial class MonitorService {
         result.AdvancedColorSupported = info.AdvancedColorSupported;
         result.AdvancedColorEnabled = info.AdvancedColorEnabled;
         result.WideColorEnforced = info.WideColorEnforced;
-        result.HdrSupported = info.AdvancedColorSupported && info.WideColorEnforced;
-        result.HdrEnabled = info.AdvancedColorEnabled && info.WideColorEnforced;
+        result.HdrSupported = IsLegacyHdrAdvancedColorState(info.AdvancedColorSupported, info.WideColorEnforced);
+        result.HdrEnabled = IsLegacyHdrAdvancedColorState(info.AdvancedColorEnabled, info.WideColorEnforced);
         result.AdvancedColorLimitedByPolicy = info.AdvancedColorForceDisabled;
         result.ColorEncoding = info.ColorEncoding.ToString();
         result.BitsPerColorChannel = info.BitsPerColorChannel;
         return result;
+    }
+
+    private static bool IsLegacyHdrAdvancedColorState(bool advancedColorState, bool wideColorEnforced) {
+        // Legacy packets do not split HDR from SDR/WCG Advanced Color. Wide-color enforcement identifies the WCG-only path.
+        return advancedColorState && !wideColorEnforced;
     }
 
     private static bool TryGetSdrWhiteLevel(DisplayConfigPathInfo path, out uint sdrWhiteLevel) {


### PR DESCRIPTION
## Summary
- keep legacy HDR support/enabled state independent from the legacy wide-color-enforced flag
- make hotkey profile saves atomic with temp-file replacement
- keep the WinUI hotkey app recoverable when the user profile JSON is malformed

## Review threads addressed
- PR #174: legacy HDR state was incorrectly gated by `WideColorEnforced`
- PR #174: malformed `%AppData%\Evotec\DesktopManager\Hotkeys\profile.json` could abort app startup
- PR #174: `profile.json` saves truncated the existing file before serialization completed
- PR #173: checked, no unresolved review threads

## Validation
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj --framework net8.0-windows10.0.19041.0 --filter "FullyQualifiedName~DisplayConfigNativeLayoutTests|FullyQualifiedName~HotkeyProfileStoreTests"`
- `dotnet test Sources\DesktopManager.Tests\DesktopManager.Tests.csproj --framework net10.0-windows10.0.19041.0 --filter "FullyQualifiedName~DisplayConfigNativeLayoutTests|FullyQualifiedName~HotkeyProfileStoreTests"`
- `dotnet build Sources\DesktopManager.App\DesktopManager.App.csproj --configuration Debug`
- `git diff --check`