### PR TITLE
Add daily DesktopManager app MSI packaging

### DIFF
--- a/.agents/skills/desktopmanager-build/SKILL.md
+++ b/.agents/skills/desktopmanager-build/SKILL.md
@@ -15,9 +15,14 @@ Use this skill when the task touches how DesktopManager is built, packaged, or p
    `.\Build\Build-Project.ps1 -Plan`
 3. For PowerShell module-only work, use:
    `.\Build\Build-Module.ps1 -SkipInstall`
-4. For CLI-only publish verification, use:
+4. For CLI/app publish verification, use:
    `.\Build\Build-Project.ps1 -Build:$false -BuildModule:$false`
-5. When checking a specific runtime publish, pass:
+5. For the daily WinUI tray app without installers, use:
+   `.\Build\Build-DesktopManagerApp.ps1`
+6. For the generated DesktopManager app MSI, use:
+   `.\Build\Build-DesktopManagerApp-MSI.ps1`
+   The MSI wrapper publishes `DesktopManager.App` as `PortableCompat`.
+7. When checking a specific runtime publish, pass:
    `-Runtimes win-x64`
 
 ## Decision Rules
@@ -25,17 +30,20 @@ Use this skill when the task touches how DesktopManager is built, packaged, or p
 - Treat `Build/Build-Project.ps1` as the primary repo build and release entrypoint.
 - Prefer changing `Build/project.build.json` and `powerforge.dotnetpublish.json` over hardcoding publish behavior in ad-hoc scripts.
 - Prefer `Build/Build-Module.ps1` for PowerShell packaging behavior instead of editing checked-in artefacts by hand.
+- Prefer the app/MSI wrapper scripts for daily desktop app packaging instead of invoking generated WiX files directly.
 - Verify the resulting behaviour from the real surfaces:
-  NuGet/library, PowerShell import, CLI help, and `desktopmanager mcp serve`.
+  NuGet/library, PowerShell import, CLI help, `desktopmanager mcp serve`, `DesktopManager.App.exe`, and MSI plan/build output.
 - Keep docs aligned with the actual build flow:
   `Docs/Build.Runbook.md`, `README.MD`, and repo-local skills.
 - When packaging or publish output changes, check the expected output locations before concluding:
-  `Artefacts/ProjectBuild`, `Artefacts/Unpacked`, `Artefacts/Packed`, and `Artefacts/PowerForge/DesktopManager`.
+  `Artefacts/ProjectBuild`, `Artefacts/Unpacked`, `Artefacts/Packed`, `Artefacts/PowerForge/DesktopManager`, `Artefacts/PowerForge/DesktopManager.App`, and `Artefacts/PowerForge/Msi/DesktopManager.App`.
 
 ## Reference Files
 
 - `Build/Build-Project.ps1`
 - `Build/Build-Module.ps1`
+- `Build/Build-DesktopManagerApp.ps1`
+- `Build/Build-DesktopManagerApp-MSI.ps1`
 - `Build/project.build.json`
 - `powerforge.dotnetpublish.json`
 - `Docs/Build.Runbook.md`

--- a/Build/Build-DesktopManagerApp-MSI.ps1
+++ b/Build/Build-DesktopManagerApp-MSI.ps1
@@ -1,0 +1,32 @@
+param(
+    [string] $ConfigPath = "$PSScriptRoot\..\powerforge.dotnetpublish.json",
+    [ValidateSet('win-x64')]
+    [string[]] $Runtimes = @('win-x64'),
+    [ValidateSet('net10.0-windows10.0.19041.0')]
+    [string[]] $Frameworks = @('net10.0-windows10.0.19041.0'),
+    [ValidateSet('PortableCompat')]
+    [string[]] $Styles = @('PortableCompat'),
+    [switch] $Plan,
+    [switch] $Validate,
+    [switch] $SkipRestore,
+    [switch] $SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module PSPublishModule -Force -ErrorAction Stop
+
+$invokeParams = @{
+    ConfigPath = $ConfigPath
+    Target     = @('DesktopManager.App')
+    Runtimes   = $Runtimes
+    Frameworks = $Frameworks
+    Styles     = $Styles
+}
+
+if ($Plan) { $invokeParams.Plan = $true }
+if ($Validate) { $invokeParams.Validate = $true }
+if ($SkipRestore) { $invokeParams.SkipRestore = $true }
+if ($SkipBuild) { $invokeParams.SkipBuild = $true }
+
+Invoke-DotNetPublish @invokeParams

--- a/Build/Build-DesktopManagerApp.ps1
+++ b/Build/Build-DesktopManagerApp.ps1
@@ -1,0 +1,33 @@
+param(
+    [string] $ConfigPath = "$PSScriptRoot\..\powerforge.dotnetpublish.json",
+    [ValidateSet('win-x64')]
+    [string[]] $Runtimes = @('win-x64'),
+    [ValidateSet('net10.0-windows10.0.19041.0')]
+    [string[]] $Frameworks = @('net10.0-windows10.0.19041.0'),
+    [ValidateSet('PortableCompat')]
+    [string[]] $Styles = @('PortableCompat'),
+    [switch] $Plan,
+    [switch] $Validate,
+    [switch] $SkipRestore,
+    [switch] $SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module PSPublishModule -Force -ErrorAction Stop
+
+$invokeParams = @{
+    ConfigPath      = $ConfigPath
+    Target          = @('DesktopManager.App')
+    Runtimes        = $Runtimes
+    Frameworks      = $Frameworks
+    Styles          = $Styles
+    SkipInstallers  = $true
+}
+
+if ($Plan) { $invokeParams.Plan = $true }
+if ($Validate) { $invokeParams.Validate = $true }
+if ($SkipRestore) { $invokeParams.SkipRestore = $true }
+if ($SkipBuild) { $invokeParams.SkipBuild = $true }
+
+Invoke-DotNetPublish @invokeParams

--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -1,14 +1,50 @@
 param(
     [string] $ConfigPath = "$PSScriptRoot\project.build.json",
+    [string] $DotNetPublishConfigPath = "$PSScriptRoot\..\powerforge.dotnetpublish.json",
     [Nullable[bool]] $UpdateVersions,
     [Nullable[bool]] $Build,
+    [bool] $BuildModule = $true,
+    [bool] $PublishTools = $true,
     [Nullable[bool]] $PublishNuget = $false,
     [Nullable[bool]] $PublishGitHub = $false,
-    [Nullable[bool]] $Plan,
-    [string] $PlanPath
+    [switch] $Plan,
+    [string] $PlanPath,
+    [string[]] $Target = @(),
+    [string[]] $Runtimes = @(),
+    [string[]] $Frameworks = @(),
+    [ValidateSet('Portable', 'PortableCompat', 'PortableSize', 'FrameworkDependent', 'AotSpeed', 'AotSize')]
+    [string[]] $Styles = @(),
+    [switch] $SkipInstallers,
+    [switch] $Validate,
+    [switch] $SkipRestore,
+    [switch] $SkipBuild
 )
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
+
+function Invoke-DesktopManagerDotNetPublish {
+    $dotNetPublishParams = @{
+        ConfigPath = $DotNetPublishConfigPath
+    }
+
+    if ($Target.Count -gt 0) { $dotNetPublishParams.Target = $Target }
+    if ($Runtimes.Count -gt 0) { $dotNetPublishParams.Runtimes = $Runtimes }
+    if ($Frameworks.Count -gt 0) { $dotNetPublishParams.Frameworks = $Frameworks }
+    if ($Styles.Count -gt 0) { $dotNetPublishParams.Styles = $Styles }
+    if ($Plan) { $dotNetPublishParams.Plan = $true }
+    if ($Validate) { $dotNetPublishParams.Validate = $true }
+    if ($SkipInstallers) { $dotNetPublishParams.SkipInstallers = $true }
+    if ($SkipRestore) { $dotNetPublishParams.SkipRestore = $true }
+    if ($SkipBuild) { $dotNetPublishParams.SkipBuild = $true }
+
+    Invoke-DotNetPublish @dotNetPublishParams
+}
+
+$dotNetPublishInvoked = $false
+if ($Plan -and $PublishTools) {
+    Invoke-DesktopManagerDotNetPublish
+    $dotNetPublishInvoked = $true
+}
 
 $invokeParams = @{
     ConfigPath = $ConfigPath
@@ -17,7 +53,15 @@ if ($null -ne $UpdateVersions) { $invokeParams.UpdateVersions = $UpdateVersions 
 if ($null -ne $Build) { $invokeParams.Build = $Build }
 if ($null -ne $PublishNuget) { $invokeParams.PublishNuget = $PublishNuget }
 if ($null -ne $PublishGitHub) { $invokeParams.PublishGitHub = $PublishGitHub }
-if ($null -ne $Plan) { $invokeParams.Plan = $Plan }
+if ($Plan) { $invokeParams.Plan = $true }
 if ($PlanPath) { $invokeParams.PlanPath = $PlanPath }
 
 Invoke-ProjectBuild @invokeParams
+
+if ($BuildModule -and -not $Plan) {
+    & (Join-Path $PSScriptRoot 'Build-Module.ps1') -SkipInstall
+}
+
+if ($PublishTools -and -not $dotNetPublishInvoked) {
+    Invoke-DesktopManagerDotNetPublish
+}

--- a/Build/Installer/DesktopManager-License.rtf
+++ b/Build/Installer/DesktopManager-License.rtf
@@ -1,0 +1,11 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0 Segoe UI;}}
+\f0\fs20
+DesktopManager\par
+\par
+Copyright (c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.\par
+\par
+This installer is provided for DesktopManager daily desktop use. Install it only on machines where you are allowed to run Evotec desktop automation tooling.\par
+\par
+DesktopManager can inspect and automate desktop windows, controls, input, monitor state, screenshots, and related local desktop resources. Review the app settings before enabling startup or unattended workflows.\par
+}

--- a/Docs/Build.Runbook.md
+++ b/Docs/Build.Runbook.md
@@ -1,6 +1,6 @@
 # DesktopManager Build Runbook
 
-DesktopManager now uses one repo entrypoint for package, module, and CLI outputs:
+DesktopManager uses one repo entrypoint for package, module, CLI, app, and installer outputs:
 
 ```powershell
 .\Build\Build-Project.ps1
@@ -9,13 +9,17 @@ DesktopManager now uses one repo entrypoint for package, module, and CLI outputs
 ## Build Surfaces
 
 - `Build/Build-Project.ps1`
-  Orchestrates repository package build, PowerShell module build, and CLI publish.
+  Orchestrates repository package build, PowerShell module build, CLI publish, app publish, and installer publish.
+- `Build/Build-DesktopManagerApp.ps1`
+  Publishes the daily-use WinUI tray app without building installers.
+- `Build/Build-DesktopManagerApp-MSI.ps1`
+  Publishes the WinUI tray app and builds the generated MSI installer.
 - `Build/project.build.json`
   Controls `Invoke-ProjectBuild` for the `DesktopManager` NuGet package and GitHub/NuGet release settings.
 - `Build/Build-Module.ps1`
   Builds the PowerShell module artefacts using `Invoke-ModuleBuild`.
 - `powerforge.dotnetpublish.json`
-  Controls `Invoke-DotNetPublish` for the `desktopmanager.exe` publish output.
+  Controls `Invoke-DotNetPublish` for `desktopmanager.exe`, `DesktopManager.App.exe`, the app zip, and the generated MSI.
 
 ## Common Commands
 
@@ -43,10 +47,40 @@ Build module only:
 .\Build\Build-Module.ps1 -SkipInstall
 ```
 
-Build CLI output only:
+Build CLI and app outputs only:
 
 ```powershell
 .\Build\Build-Project.ps1 -Build:$false -BuildModule:$false
+```
+
+Build the daily tray app portable output only:
+
+```powershell
+.\Build\Build-DesktopManagerApp.ps1
+```
+
+Plan the app MSI without compiling:
+
+```powershell
+.\Build\Build-DesktopManagerApp-MSI.ps1 -Plan
+```
+
+Build the app MSI:
+
+```powershell
+.\Build\Build-DesktopManagerApp-MSI.ps1
+```
+
+Install it interactively:
+
+```powershell
+msiexec.exe /i .\Artefacts\PowerForge\Msi\DesktopManager.App\win-x64\net10.0-windows10.0.19041.0\PortableCompat\output\DesktopManager.msi
+```
+
+Use silent install only when automation intentionally asks for it:
+
+```powershell
+msiexec.exe /i .\Artefacts\PowerForge\Msi\DesktopManager.App\win-x64\net10.0-windows10.0.19041.0\PortableCompat\output\DesktopManager.msi /qn
 ```
 
 Publish the NuGet package using the repo config:
@@ -64,7 +98,7 @@ Publish the GitHub release asset using the repo config:
 Publish a specific CLI runtime:
 
 ```powershell
-.\Build\Build-Project.ps1 -Build:$false -BuildModule:$false -Runtimes win-x64
+.\Build\Build-Project.ps1 -Build:$false -BuildModule:$false -Target DesktopManager.Cli.net10 -Runtimes win-x64 -SkipInstallers
 ```
 
 ## Output Locations
@@ -76,12 +110,21 @@ Publish a specific CLI runtime:
   `Artefacts/Packed`
 - CLI publish output and manifests:
   `Artefacts/PowerForge/DesktopManager`
+- Daily app publish output and zip:
+  `Artefacts/PowerForge/DesktopManager.App`
+- Daily app MSI staging, generated WiX authoring, and installer output:
+  `Artefacts/PowerForge/Msi/DesktopManager.App`
 
 ## Notes
 
 - `Build-Project.ps1` is the only package and release entrypoint in this repo.
 - `Build-Project.ps1 -Plan` skips the module build execution because the module path does not expose the same standalone plan surface here.
 - The CLI publish targets package `Sources/DesktopManager.Cli/DesktopManager.Cli.csproj` as `desktopmanager.exe` for both `net8.0-windows` and `net10.0-windows`.
+- The daily app publish target packages `Sources/DesktopManager.App/DesktopManager.App.csproj` as an unpackaged, self-contained WinUI app under `DesktopManager.App`.
+- The WinUI app is not forced into NativeAOT. The nested `DesktopManager.HotkeyHost` remains NativeAOT, while the app uses a self-contained publish profile that avoids WinAppSDK single-file and NativeAOT limitations.
+- The generated MSI uses PowerForge/WiX installer UI, creates a Start Menu shortcut, and records the install path under `HKLM\Software\Evotec\DesktopManager`.
+- DesktopManager autostart stays a per-user app setting. The app writes the current user's Run key with `--minimized`, so Windows sign-in starts the tray runtime without opening the main window.
+- The MSI output, manifest, and checksums are the intended inputs for later winget release work. Microsoft Store/MSIX packaging should stay in PowerForge config when that lane is added.
 - The CLI includes the MCP server entrypoint exposed by:
 
 ```powershell

--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,7 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 
 - [Docs/DesktopManager.Cli.md](Docs/DesktopManager.Cli.md)
 - [Docs/DesktopManager.Mcp.md](Docs/DesktopManager.Mcp.md)
+- [Docs/DesktopManager.App.Design.md](Docs/DesktopManager.App.Design.md)
 - [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md)
 - [Docs/DesktopManager.AutomationBasics.md](Docs/DesktopManager.AutomationBasics.md)
 - [Docs/DesktopManager.Plugin.md](Docs/DesktopManager.Plugin.md)
@@ -73,6 +74,7 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 | PowerShell module | Scripts, operators, admin workflows, repeatable task automation | `Install-Module DesktopManager` |
 | CLI executable | Manual use, shell automation, JSON output, and MCP hosting | `desktopmanager.exe` |
 | MCP server | Agent-driven automation over stdio with an inspect-first safety model | `desktopmanager mcp serve` |
+| Windows tray app | Daily hotkeys, monitor bindings, HDR controls, tray runtime, and per-user startup | `DesktopManager.App.exe` |
 
 ## How It Fits Together
 
@@ -84,6 +86,7 @@ flowchart LR
     C["PowerShell module"] --> B
     D["desktopmanager.exe CLI"] --> B
     E["MCP server"] --> D
+    J["DesktopManager.App tray app"] --> B
     B --> F["Windows desktop APIs"]
     F --> G["Monitors / wallpapers / brightness"]
     F --> H["Windows / controls / input"]
@@ -105,6 +108,7 @@ The practical way to think about this:
 | ---- | ---------------------- |
 | Add DesktopManager features to your own code | Reference the `DesktopManager` NuGet package |
 | Run manual desktop operations from a terminal | `desktopmanager.exe` |
+| Run DesktopManager every day from the tray | `DesktopManager.App.exe` or the DesktopManager MSI |
 | Use it from PowerShell scripts | `DesktopManager` PowerShell module |
 | Connect an agent/tooling layer | `desktopmanager mcp serve` |
 | Understand the overall wiring | [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md) |
@@ -118,10 +122,12 @@ flowchart LR
     B -->|"PowerShell"| D["Cmdlets"]
     B -->|"CLI"| E["desktopmanager.exe"]
     B -->|"MCP"| F["desktopmanager mcp serve"]
+    B -->|"Tray app"| J["DesktopManager.App.exe"]
 
     D --> C
     E --> G["DesktopOperations"]
     F --> G
+    J --> C
     G --> C
     C --> H["Win32, UI Automation, monitor, screenshot, and input services"]
 ```
@@ -258,6 +264,16 @@ For using in PowerShell you can install it from PowerShell Gallery
 
 ```powershell
 Install-Module DesktopManager -Force -Verbose
+```
+
+For the daily Windows tray app, use the DesktopManager MSI release artifact when available. The installer creates a Start Menu shortcut, and the app's Startup toggle registers the current user for minimized tray startup.
+
+From source, the app and MSI are built through PowerForge:
+
+```powershell
+.\Build\Build-DesktopManagerApp.ps1
+.\Build\Build-DesktopManagerApp-MSI.ps1
+msiexec.exe /i .\Artefacts\PowerForge\Msi\DesktopManager.App\win-x64\net10.0-windows10.0.19041.0\PortableCompat\output\DesktopManager.msi
 ```
 
 ### Verified mutation examples

--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,6 @@ Additional operator-focused docs for the newer CLI and MCP surfaces:
 
 - [Docs/DesktopManager.Cli.md](Docs/DesktopManager.Cli.md)
 - [Docs/DesktopManager.Mcp.md](Docs/DesktopManager.Mcp.md)
-- [Docs/DesktopManager.App.Design.md](Docs/DesktopManager.App.Design.md)
 - [Docs/DesktopManager.Architecture.md](Docs/DesktopManager.Architecture.md)
 - [Docs/DesktopManager.AutomationBasics.md](Docs/DesktopManager.AutomationBasics.md)
 - [Docs/DesktopManager.Plugin.md](Docs/DesktopManager.Plugin.md)

--- a/Sources/DesktopManager.App/App.xaml.cs
+++ b/Sources/DesktopManager.App/App.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class App : Application {
             return;
         }
 
-        bool startMinimized = ShouldStartMinimized(args.Arguments);
+        bool startMinimized = ShouldStartMinimized(args.Arguments, Environment.GetCommandLineArgs());
         _window = new MainWindow();
         _window.Activate();
         if (startMinimized && _window is MainWindow mainWindow) {
@@ -35,15 +35,22 @@ public sealed partial class App : Application {
         }
     }
 
-    private static bool ShouldStartMinimized(string? arguments) {
-        if (string.IsNullOrWhiteSpace(arguments)) {
+    private static bool ShouldStartMinimized(string? launchArguments, string[] processArguments) {
+        if (processArguments.Any(IsMinimizedArgument)) {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(launchArguments)) {
             return false;
         }
 
-        string[] parts = arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return parts.Any(argument =>
-            string.Equals(argument, "--minimized", StringComparison.OrdinalIgnoreCase) ||
+        string[] parts = launchArguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Any(IsMinimizedArgument);
+    }
+
+    private static bool IsMinimizedArgument(string argument) {
+        return string.Equals(argument, "--minimized", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(argument, "--minimized-to-tray", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(argument, "/minimized", StringComparison.OrdinalIgnoreCase));
+            string.Equals(argument, "/minimized", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Sources/DesktopManager.App/App.xaml.cs
+++ b/Sources/DesktopManager.App/App.xaml.cs
@@ -27,7 +27,23 @@ public sealed partial class App : Application {
             return;
         }
 
+        bool startMinimized = ShouldStartMinimized(args.Arguments);
         _window = new MainWindow();
         _window.Activate();
+        if (startMinimized && _window is MainWindow mainWindow) {
+            mainWindow.HideToTrayAfterLaunch();
+        }
+    }
+
+    private static bool ShouldStartMinimized(string? arguments) {
+        if (string.IsNullOrWhiteSpace(arguments)) {
+            return false;
+        }
+
+        string[] parts = arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Any(argument =>
+            string.Equals(argument, "--minimized", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(argument, "--minimized-to-tray", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(argument, "/minimized", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Sources/DesktopManager.App/DesktopManager.App.csproj
+++ b/Sources/DesktopManager.App/DesktopManager.App.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <Target Name="PublishHotkeyHost" BeforeTargets="Build;Publish">
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\DesktopManager.HotkeyHost\DesktopManager.HotkeyHost.csproj" Targets="Publish" Properties="Configuration=$(Configuration);TargetFramework=$(DesktopManagerNet10WindowsTfm);RuntimeIdentifier=win-x64" />
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\DesktopManager.HotkeyHost\DesktopManager.HotkeyHost.csproj" Targets="Restore;Publish" Properties="Configuration=$(Configuration);TargetFramework=$(DesktopManagerNet10WindowsTfm);RuntimeIdentifier=win-x64" />
   </Target>
 
   <Target Name="CopyHotkeyHostDependencies" AfterTargets="Build">

--- a/Sources/DesktopManager.App/DesktopManager.App.csproj
+++ b/Sources/DesktopManager.App/DesktopManager.App.csproj
@@ -25,8 +25,13 @@
     <ProjectReference Include="..\DesktopManager.App.Core\DesktopManager.App.Core.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DesktopManagerHotkeyHostTargets Condition="'$(NoRestore)' == 'true' Or '$(Restore)' == 'false'">Publish</DesktopManagerHotkeyHostTargets>
+    <DesktopManagerHotkeyHostTargets Condition="'$(DesktopManagerHotkeyHostTargets)' == ''">Restore;Publish</DesktopManagerHotkeyHostTargets>
+  </PropertyGroup>
+
   <Target Name="PublishHotkeyHost" BeforeTargets="Build;Publish">
-    <MSBuild Projects="$(MSBuildProjectDirectory)\..\DesktopManager.HotkeyHost\DesktopManager.HotkeyHost.csproj" Targets="Restore;Publish" Properties="Configuration=$(Configuration);TargetFramework=$(DesktopManagerNet10WindowsTfm);RuntimeIdentifier=win-x64" />
+    <MSBuild Projects="$(MSBuildProjectDirectory)\..\DesktopManager.HotkeyHost\DesktopManager.HotkeyHost.csproj" Targets="$(DesktopManagerHotkeyHostTargets)" Properties="Configuration=$(Configuration);TargetFramework=$(DesktopManagerNet10WindowsTfm);RuntimeIdentifier=win-x64" />
   </Target>
 
   <Target Name="CopyHotkeyHostDependencies" AfterTargets="Build">

--- a/Sources/DesktopManager.App/MainWindow.Tray.cs
+++ b/Sources/DesktopManager.App/MainWindow.Tray.cs
@@ -46,6 +46,14 @@ public sealed partial class MainWindow {
         HideToTray();
     }
 
+    internal void HideToTrayAfterLaunch() {
+        if (!_profile.MinimizeToTray || !_trayIconAdded) {
+            return;
+        }
+
+        HideToTray();
+    }
+
     private void HideToTray() {
         ShowWindow(_windowHandle, SW_HIDE);
         AddLog("Window hidden to tray.");

--- a/Sources/DesktopManager.App/StartupRegistrationService.cs
+++ b/Sources/DesktopManager.App/StartupRegistrationService.cs
@@ -5,25 +5,32 @@ namespace DesktopManager.App;
 internal static class StartupRegistrationService {
     private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string ValueName = "DesktopManager";
+    private const string MinimizedArgument = "--minimized";
 
     public static bool IsEnabled() {
         using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
-        return key?.GetValue(ValueName) is string value &&
-            string.Equals(value, GetCommand(), StringComparison.OrdinalIgnoreCase);
+        if (key?.GetValue(ValueName) is not string value) {
+            return false;
+        }
+
+        return string.Equals(value, GetCommand(startMinimized: true), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, GetCommand(startMinimized: false), StringComparison.OrdinalIgnoreCase);
     }
 
     public static void SetEnabled(bool enabled) {
         using RegistryKey key = Registry.CurrentUser.CreateSubKey(RunKeyPath);
         if (enabled) {
-            key.SetValue(ValueName, GetCommand(), RegistryValueKind.String);
+            key.SetValue(ValueName, GetCommand(startMinimized: true), RegistryValueKind.String);
             return;
         }
 
         key.DeleteValue(ValueName, throwOnMissingValue: false);
     }
 
-    private static string GetCommand() {
+    private static string GetCommand(bool startMinimized) {
         string executable = Environment.ProcessPath ?? System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty;
-        return $"\"{executable}\"";
+        return startMinimized
+            ? $"\"{executable}\" {MinimizedArgument}"
+            : $"\"{executable}\"";
     }
 }

--- a/Sources/DesktopManager.App/StartupRegistrationService.cs
+++ b/Sources/DesktopManager.App/StartupRegistrationService.cs
@@ -8,13 +8,21 @@ internal static class StartupRegistrationService {
     private const string MinimizedArgument = "--minimized";
 
     public static bool IsEnabled() {
-        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
+        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
         if (key?.GetValue(ValueName) is not string value) {
             return false;
         }
 
-        return string.Equals(value, GetCommand(startMinimized: true), StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(value, GetCommand(startMinimized: false), StringComparison.OrdinalIgnoreCase);
+        if (string.Equals(value, GetCommand(startMinimized: true), StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+
+        if (string.Equals(value, GetCommand(startMinimized: false), StringComparison.OrdinalIgnoreCase)) {
+            key.SetValue(ValueName, GetCommand(startMinimized: true), RegistryValueKind.String);
+            return true;
+        }
+
+        return false;
     }
 
     public static void SetEnabled(bool enabled) {

--- a/Sources/DesktopManager/DesktopManager.csproj
+++ b/Sources/DesktopManager/DesktopManager.csproj
@@ -44,10 +44,13 @@
         <Content Include="..\..\Assets\Icons\DesktopManager.ico" />
     </ItemGroup>
 
-  <ItemGroup>
-      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0'">
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/powerforge.dotnetpublish.json
+++ b/powerforge.dotnetpublish.json
@@ -20,6 +20,34 @@
       "ExcludeSymbolsFromSingleFile": "true"
     }
   },
+  "Profiles": [
+    {
+      "Name": "daily-app",
+      "Targets": [
+        "DesktopManager.App"
+      ],
+      "Runtimes": [
+        "win-x64"
+      ],
+      "Frameworks": [
+        "net10.0-windows10.0.19041.0"
+      ],
+      "Style": "PortableCompat"
+    },
+    {
+      "Name": "desktopmanager-app-msi",
+      "Targets": [
+        "DesktopManager.App"
+      ],
+      "Runtimes": [
+        "win-x64"
+      ],
+      "Frameworks": [
+        "net10.0-windows10.0.19041.0"
+      ],
+      "Style": "PortableCompat"
+    }
+  ],
   "Targets": [
     {
       "Name": "DesktopManager.Cli.net8",
@@ -57,6 +85,148 @@
         "RenameTo": "desktopmanager.exe",
         "Zip": true,
         "ZipNameTemplate": "desktopmanager-{rid}-{framework}-{style}.zip"
+      }
+    },
+    {
+      "Name": "DesktopManager.App",
+      "Kind": "Cli",
+      "ProjectPath": "Sources/DesktopManager.App/DesktopManager.App.csproj",
+      "Publish": {
+        "Style": "PortableCompat",
+        "Framework": "net10.0-windows10.0.19041.0",
+        "OutputPath": "Artefacts/PowerForge/DesktopManager.App/{rid}/{framework}/{style}",
+        "UseStaging": true,
+        "ClearOutput": true,
+        "Slim": true,
+        "KeepSymbols": false,
+        "KeepDocs": false,
+        "PruneReferences": true,
+        "Zip": true,
+        "ZipNameTemplate": "DesktopManager.App-{rid}-{framework}-{style}.zip",
+        "ReadyToRun": false,
+        "MsBuildProperties": {
+          "SelfContained": "true",
+          "WindowsPackageType": "None",
+          "WindowsAppSDKSelfContained": "true",
+          "PublishSingleFile": "false",
+          "PublishAot": "false",
+          "IncludeNativeLibrariesForSelfExtract": "false"
+        },
+        "Sign": {
+          "Enabled": true,
+          "ToolPath": "signtool.exe",
+          "OnMissingTool": "Warn",
+          "OnSignFailure": "Warn",
+          "TimeoutSeconds": 60,
+          "TimestampUrl": "http://timestamp.digicert.com",
+          "Description": "DesktopManager"
+        }
+      }
+    }
+  ],
+  "Installers": [
+    {
+      "Id": "DesktopManager.App.MSI",
+      "PrepareFromTarget": "DesktopManager.App",
+      "Runtimes": [
+        "win-x64"
+      ],
+      "Frameworks": [
+        "net10.0-windows10.0.19041.0"
+      ],
+      "Styles": [
+        "PortableCompat"
+      ],
+      "StagingPath": "Artefacts/PowerForge/Msi/DesktopManager.App/{rid}/{framework}/{style}/Staging",
+      "ManifestPath": "Artefacts/PowerForge/Msi/DesktopManager.App/{rid}/{framework}/{style}/prepare.json",
+      "OutputPath": "Artefacts/PowerForge/Msi/DesktopManager.App/{rid}/{framework}/{style}/output",
+      "OutputName": "DesktopManager",
+      "Harvest": "Auto",
+      "HarvestPath": "Artefacts/PowerForge/Msi/DesktopManager.App/{rid}/{framework}/{style}/HarvestedPayload.wxs",
+      "HarvestDirectoryRefId": "INSTALLFOLDER",
+      "HarvestComponentGroupId": "ProductFiles",
+      "HarvestExcludePatterns": [
+        "Microsoft.UI.Xaml.Phone.dll"
+      ],
+      "MsBuildProperties": {
+        "SuppressIces": "ICE03"
+      },
+      "Authoring": {
+        "Product": {
+          "Name": "DesktopManager",
+          "Manufacturer": "Evotec",
+          "Version": "1.0.0",
+          "UpgradeCode": "{0e164c4b-6f92-42e1-b2cb-229bd40cc7b0}",
+          "Scope": "PerMachine",
+          "DowngradeErrorMessage": "A newer version of DesktopManager is already installed."
+        },
+        "CompanyFolderName": "Evotec",
+        "InstallDirectoryName": "DesktopManager",
+        "PayloadComponentGroupId": "ProductFiles",
+        "Directories": [
+          {
+            "StandardDirectoryId": "ProgramMenuFolder",
+            "Segments": [
+              {
+                "Id": "ApplicationProgramsFolder",
+                "Name": "DesktopManager"
+              }
+            ]
+          }
+        ],
+        "Dialogs": [
+          {
+            "Id": "DailyUseDlg",
+            "Title": "Daily use setup",
+            "Description": "DesktopManager installs as a tray app with a Start Menu shortcut. After first launch, enable Start with Windows in the app to start minimized to tray."
+          }
+        ],
+        "LicenseAgreement": {
+          "Path": "Build/Installer/DesktopManager-License.rtf"
+        },
+        "Components": [
+          {
+            "Type": "Shortcut",
+            "Id": "StartMenuShortcutComponent",
+            "DirectoryRefId": "ApplicationProgramsFolder",
+            "Guid": "*",
+            "ShortcutId": "StartMenuShortcut",
+            "Name": "DesktopManager",
+            "Target": "[INSTALLFOLDER]DesktopManager.App.exe",
+            "RegistryKey": "Software\\Evotec\\DesktopManager"
+          },
+          {
+            "Type": "RegistryValue",
+            "Id": "InstallPathRegistry",
+            "DirectoryRefId": "INSTALLFOLDER",
+            "Guid": "*",
+            "Root": "HKLM",
+            "Key": "Software\\Evotec\\DesktopManager",
+            "Name": "InstallPath",
+            "Value": "[INSTALLFOLDER]",
+            "ValueType": "string"
+          }
+        ]
+      },
+      "Versioning": {
+        "Enabled": true,
+        "Major": 1,
+        "Minor": 0,
+        "FloorDateUtc": "2026-01-01",
+        "Monotonic": true,
+        "ApplyToPublish": true,
+        "StatePath": "Artefacts/PowerForge/Msi/DesktopManager.App/version.state.json",
+        "PropertyName": "ProductVersion",
+        "PatchCap": 65535
+      },
+      "Sign": {
+        "Enabled": true,
+        "ToolPath": "signtool.exe",
+        "OnMissingTool": "Warn",
+        "OnSignFailure": "Warn",
+        "TimeoutSeconds": 60,
+        "TimestampUrl": "http://timestamp.digicert.com",
+        "Description": "DesktopManager"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Adds a daily-use Windows tray app packaging path for DesktopManager, including a generated MSI installer powered by PowerForge instead of repo-local installer scripting.

## What changed

- Adds thin app/MSI wrapper scripts for `DesktopManager.App` builds.
- Extends `powerforge.dotnetpublish.json` with the daily app publish target and generated MSI authoring.
- Installs DesktopManager as a Start Menu app with installer UI and a small license page.
- Keeps autostart as a per-user app setting; enabling it writes the current user's Run key with `--minimized` so sign-in starts the tray runtime without opening the window.
- Updates the app to honor `--minimized`, `--minimized-to-tray`, and `/minimized` from the process command line.
- Normalizes legacy startup Run entries to the minimized command when they are detected.
- Documents the app/MSI commands, output paths, and future winget/Microsoft Store lane.

## PowerForge dependency

The generated MSI intentionally uses the normal deep PowerForge artifact path:

`Artefacts\PowerForge\Msi\DesktopManager.App\win-x64\net10.0-windows10.0.19041.0\PortableCompat\output\DesktopManager.msi`

That path requires the shared PowerForge fix in EvotecIT/PSPublishModule#482 for generated WiX UI builds on deeply nested artifact folders. I validated this PR locally by importing the PSPublishModule DLL built from that PR, not by adding a DesktopManager-specific workaround.

## Validation

- `dotnet test .\Sources\DesktopManager.Tests\DesktopManager.Tests.csproj --configuration Release --framework net8.0-windows10.0.19041.0 --nologo` exited successfully; the target currently reports no discovered tests.
- Imported the local PSPublishModule build from EvotecIT/PSPublishModule#482 and ran `Invoke-DotNetPublish -ConfigPath .\powerforge.dotnetpublish.json -Target DesktopManager.App -Runtimes win-x64 -Frameworks net10.0-windows10.0.19041.0 -Styles PortableCompat -SkipRestore`.
- The MSI build completed successfully from the normal deep artifact path and produced DesktopManager MSI version `1.0.9508`.
- Verified the MSI Authenticode signature is valid.
- Verified MSI UI tables include `LicenseAgreementDlg`, `DailyUseDlg`, `VerifyReadyDlg`, and `ExitDialog`.
- `git diff --check`
